### PR TITLE
Switch to executable directory on startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "csshw"
 version = "0.3.1"
 edition = "2021"
 license-file = "LICENSE.txt"
+default-run = "csshw"
 
 [[bin]]
 name = "csshw"

--- a/csshw-client.exe
+++ b/csshw-client.exe
@@ -1,1 +1,0 @@
-target/debug/csshw-client.exe

--- a/csshw-daemon.exe
+++ b/csshw-daemon.exe
@@ -1,1 +1,0 @@
-target/debug/csshw-daemon.exe

--- a/csshw.exe
+++ b/csshw.exe
@@ -1,1 +1,0 @@
-target/debug/csshw.exe

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,22 @@ struct Args {
 }
 
 fn main() {
+    match std::env::current_exe() {
+        Ok(path) => match path.parent() {
+            None => {
+                eprintln!("Failed to get executable path parent working directory");
+            }
+            Some(exe_dir) => {
+                std::env::set_current_dir(exe_dir)
+                    .expect("Failed to change current working directory");
+                println!("Set current working directory to {}", exe_dir.display());
+            }
+        },
+        Err(_) => {
+            eprintln!("Failed to get executable directory");
+        }
+    }
+
     let args = Args::parse();
     let mut daemon_args: Vec<&str> = Vec::new();
     if let Some(username) = args.username.as_ref() {


### PR DESCRIPTION
This makes it possible to use `cargo run -- <args>`