### PR TITLE
Automatically change default terminal application setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -221,6 +221,7 @@ dependencies = [
  "log",
  "log-panics",
  "os_info",
+ "registry",
  "rmp",
  "serde",
  "serde_derive",
@@ -228,7 +229,7 @@ dependencies = [
  "ssh2-config",
  "time",
  "tokio",
- "windows",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -805,6 +806,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "515143bd3c240fd5a47002a552fd7eba71acf8cd3cf7472e5ec392cda2ed3d90"
+dependencies = [
+ "bitflags 1.3.2",
+ "log",
+ "thiserror",
+ "utfx",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1147,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "utfx"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133bf74f01486773317ddfcde8e2e20d2933cc3b68ab797e5d718bef996a81de"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,7 +1350,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
  "windows-core 0.56.0",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1339,7 +1369,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1348,10 +1378,23 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-targets 0.52.5",
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.1",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1359,6 +1402,17 @@ name = "windows-implement"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1377,12 +1431,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1400,7 +1484,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1420,18 +1504,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1442,9 +1526,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1454,9 +1538,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1466,15 +1550,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1484,9 +1568,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1496,9 +1580,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1508,9 +1592,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1520,9 +1604,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ itertools = "0.12.1"
 log = "0.4.21"
 log-panics = "2.1.0"
 os_info = { version="3.7.0", default-features = false }
+registry = "1.3.0"
 rmp = "0.8.11"
 serde = "1.0.163"
 serde_derive = "1.0.163"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _Cluster SSH tool for Windows inspired by [csshX](https://github.com/brockgr/css
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-## Pre-requisites
+## Pre-requisite
 - Any SSH client (Windows 10 and Windows 11 already include a built-in SSH server and client - [docs](https://learn.microsoft.com/en-us/windows/terminal/tutorials/ssh))
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ _Cluster SSH tool for Windows inspired by [csshX](https://github.com/brockgr/css
 
 ## Pre-requisites
 - Any SSH client (Windows 10 and Windows 11 already include a built-in SSH server and client - [docs](https://learn.microsoft.com/en-us/windows/terminal/tutorials/ssh))
-- ``Default terminal application`` is set to ``Windows Console Host`` in the windows Terminal Startup Settings (only if Windows Terminal app is installed, which is the case for Windows 11)
 
 ## Overview
 csshW will launch 1 daemon and N client windows (with N being the number of hosts to SSH onto).<br>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,9 @@ pub mod daemon;
 pub mod serde;
 pub mod utils;
 
-// https://github.com/microsoft/terminal/blob/main/src/propslib/DelegationConfig.hpp#L105
+// https://github.com/microsoft/terminal/blob/v1.22.3232.0/src/propslib/DelegationConfig.hpp#L105
 const CLSID_CONHOST: &str = "{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}";
-// https://github.com/microsoft/terminal/blob/main/src/propslib/DelegationConfig.cpp#L29
+// https://github.com/microsoft/terminal/blob/v1.22.3232.0/src/propslib/DelegationConfig.cpp#L29
 const DEFAULT_TERMINAL_APP_REGISTRY_PATH: &str = r"Console\%%Startup";
 const DELEGATION_CONSOLE: &str = "DelegationConsole";
 const DELEGATION_TERMINAL: &str = "DelegationTerminal";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@ pub mod daemon;
 pub mod serde;
 pub mod utils;
 
+// https://github.com/microsoft/terminal/blob/main/src/propslib/DelegationConfig.hpp#L105
 const CLSID_CONHOST: &str = "{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}";
+// https://github.com/microsoft/terminal/blob/main/src/propslib/DelegationConfig.cpp#L29
 const DEFAULT_TERMINAL_APP_REGISTRY_PATH: &str = r"Console\%%Startup";
 const DELEGATION_CONSOLE: &str = "DelegationConsole";
 const DELEGATION_TERMINAL: &str = "DelegationTerminal";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ use std::{mem, ptr};
 
 use std::os::windows::ffi::OsStrExt;
 
+use log::warn;
+use registry::{value, Data, Hive, RegKey, Security};
 use simplelog::{format_description, ConfigBuilder, LevelFilter, WriteLogger};
 use windows::core::{HSTRING, PCWSTR, PWSTR};
 use windows::Win32::Foundation::BOOL;
@@ -17,6 +19,113 @@ pub mod client;
 pub mod daemon;
 pub mod serde;
 pub mod utils;
+
+const CLSID_CONHOST: &str = "{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}";
+const DEFAULT_TERMINAL_APP_REGISTRY_PATH: &str = r"Console\%%Startup";
+const DELEGATION_CONSOLE: &str = "DelegationConsole";
+const DELEGATION_TERMINAL: &str = "DelegationTerminal";
+
+#[derive(Default)]
+struct DefaultTerminalApplicationGuard {
+    old_windows_terminal_console: Option<String>,
+    old_windows_terminal_terminal: Option<String>,
+}
+
+fn get_reg_key() -> RegKey {
+    return Hive::CurrentUser
+        .open(
+            DEFAULT_TERMINAL_APP_REGISTRY_PATH,
+            Security::Read | Security::Write,
+        )
+        .unwrap_or_else(|_| {
+            panic!("Failed to open registry path {DEFAULT_TERMINAL_APP_REGISTRY_PATH}")
+        });
+}
+
+fn write_registry_values(
+    regkey: &RegKey,
+    delegation_console_value: String,
+    delegation_terminal_value: String,
+) {
+    let _: Result<(), value::Error> = regkey
+        .set_value::<String>(
+            DELEGATION_CONSOLE.to_owned(),
+            &Data::String(delegation_console_value.clone().try_into().unwrap()),
+        )
+        .or_else(|_| {
+            warn!(
+                "Failed to change the default console application for registry key {} to {:?}",
+                DELEGATION_CONSOLE, delegation_console_value
+            );
+            return Ok(());
+        });
+    let _: Result<(), value::Error> = regkey
+        .set_value::<String>(
+            DELEGATION_TERMINAL.to_owned(),
+            &Data::String(delegation_terminal_value.clone().try_into().unwrap()),
+        )
+        .or_else(|_| {
+            warn!(
+                "Failed to change the default console application for registry key {} to {:?}",
+                DELEGATION_TERMINAL, delegation_terminal_value
+            );
+            return Ok(());
+        });
+}
+
+impl DefaultTerminalApplicationGuard {
+    //
+    pub fn new() -> Self {
+        let regkey = get_reg_key();
+        let old_windows_terminal_console = match regkey
+            .value(DELEGATION_CONSOLE)
+            .unwrap_or_else(|_| panic!("Failed to read value {DELEGATION_CONSOLE} from registry"))
+        {
+            Data::String(value) => value.to_string_lossy(),
+            _ => {
+                panic!("Expected string data");
+            }
+        };
+        let old_windows_terminal_terminal = match regkey
+            .value(DELEGATION_TERMINAL)
+            .unwrap_or_else(|_| panic!("Failed to read value {DELEGATION_TERMINAL} from registry"))
+        {
+            Data::String(value) => value.to_string_lossy(),
+            _ => {
+                panic!("Expected string data");
+            }
+        };
+        // No need to change the default terminal application if it is already set to conhost
+        if old_windows_terminal_console == old_windows_terminal_terminal
+            && old_windows_terminal_console == CLSID_CONHOST
+        {
+            return DefaultTerminalApplicationGuard::default();
+        }
+
+        write_registry_values(&regkey, CLSID_CONHOST.to_owned(), CLSID_CONHOST.to_owned());
+
+        return DefaultTerminalApplicationGuard {
+            old_windows_terminal_console: Some(old_windows_terminal_console),
+            old_windows_terminal_terminal: Some(old_windows_terminal_terminal),
+        };
+    }
+}
+
+// FIXME: the drop happens to fast and we reset the config before the windows got launched.
+impl Drop for DefaultTerminalApplicationGuard {
+    fn drop(&mut self) {
+        if let (Some(old_windows_terminal_console), Some(old_windows_terminal_terminal)) = (
+            &self.old_windows_terminal_console,
+            &self.old_windows_terminal_terminal,
+        ) {
+            write_registry_values(
+                &get_reg_key(),
+                old_windows_terminal_console.to_owned(),
+                old_windows_terminal_terminal.to_owned(),
+            );
+        }
+    }
+}
 
 pub fn spawn_console_process(application: &str, args: Vec<&str>) -> PROCESS_INFORMATION {
     let mut cmd: Vec<u16> = Vec::new();
@@ -40,20 +149,23 @@ pub fn spawn_console_process(application: &str, args: Vec<&str>) -> PROCESS_INFO
     // as x and y coordinates must be u32 and we might have negative values
     let mut process_information = PROCESS_INFORMATION::default();
     let command_line = PWSTR(cmd.as_mut_ptr());
-    unsafe {
-        CreateProcessW(
-            &HSTRING::from(application),
-            command_line,
-            Some(ptr::null_mut()),
-            Some(ptr::null_mut()),
-            BOOL::from(false),
-            CREATE_NEW_CONSOLE,
-            Some(ptr::null_mut()),
-            PCWSTR::null(),
-            ptr::addr_of_mut!(startupinfo),
-            ptr::addr_of_mut!(process_information),
-        )
-        .expect("Failed to create process");
+    {
+        let _guard = DefaultTerminalApplicationGuard::new();
+        unsafe {
+            CreateProcessW(
+                &HSTRING::from(application),
+                command_line,
+                Some(ptr::null_mut()),
+                Some(ptr::null_mut()),
+                BOOL::from(false),
+                CREATE_NEW_CONSOLE,
+                Some(ptr::null_mut()),
+                PCWSTR::null(),
+                ptr::addr_of_mut!(startupinfo),
+                ptr::addr_of_mut!(process_information),
+            )
+            .expect("Failed to create process");
+        }
     }
     return process_information;
 }


### PR DESCRIPTION
Instead of requiring the user to manually change the default terminal application in the windows system settings or via the Windows Terminal settings to Windows Console Host, we do this ourselves before launching any console windows and revert the setting immediately afterwards.
This rids us of the pre-requisite:
> - ``Default terminal application`` is set to ``Windows Console Host`` in the windows Terminal Startup Settings (only if Windows Terminal app is installed, which is the case for Windows 11)