### PR TITLE
Upgrade tokio to 1.44.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_derive = "1.0.217"
 simplelog = "0.12.2"
 ssh2-config = "0.3.0"
 time = "0.3.37"
-tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "net", "sync", "macros", "time", "signal", "process"] }
+tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread", "net", "sync", "macros", "time", "signal", "process"] }
 
 [dependencies.confy]
 version = "0.6.1"


### PR DESCRIPTION
This mitigates GHSA-rr8g-9fpq-6wmg

https://github.com/whme/csshw/security/dependabot/3