### PR TITLE
Fix clippy warnings for rustc 1.86.0

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,7 @@
 //! Client implementation
 
 #![deny(clippy::implicit_return)]
-#![allow(clippy::needless_return)]
+#![allow(clippy::needless_return, clippy::doc_overindented_list_items)]
 #![warn(missing_docs)]
 
 use log::{error, info, warn};

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,7 +1,7 @@
 //! Daemon imlementation
 
 #![deny(clippy::implicit_return)]
-#![allow(clippy::needless_return)]
+#![allow(clippy::needless_return, clippy::doc_overindented_list_items)]
 #![warn(missing_docs)]
 
 use std::cmp::max;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Cluster SSH tool for Windows inspired by csshX
 
 #![deny(clippy::implicit_return)]
-#![allow(clippy::needless_return)]
+#![allow(clippy::needless_return, clippy::doc_overindented_list_items)]
 #![warn(missing_docs)]
 #![doc(html_no_source)]
 
@@ -137,13 +137,12 @@ impl Drop for WindowsSettingsDefaultTerminalApplicationGuard {
 ///
 /// The registry key where the default terminal application system settings are stored.
 fn get_reg_key() -> Option<RegKey> {
-    return match Hive::CurrentUser.open(
-        DEFAULT_TERMINAL_APP_REGISTRY_PATH,
-        Security::Read | Security::Write,
-    ) {
-        Ok(val) => Some(val),
-        Err(_) => None,
-    };
+    return Hive::CurrentUser
+        .open(
+            DEFAULT_TERMINAL_APP_REGISTRY_PATH,
+            Security::Read | Security::Write,
+        )
+        .ok();
 }
 
 /// Write `DelegationConsole` and `DelegationTerminal` registry values to the given [RegKey].

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@
 //! ```
 
 #![deny(clippy::implicit_return)]
-#![allow(clippy::needless_return)]
+#![allow(clippy::needless_return, clippy::doc_overindented_list_items)]
 #![warn(missing_docs)]
 #![doc(html_no_source)]
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,7 +1,7 @@
 //! Serialization/Deserialization implemention for windows INPUT_RECORD_0.
 
 #![deny(clippy::implicit_return)]
-#![allow(clippy::needless_return)]
+#![allow(clippy::needless_return, clippy::doc_overindented_list_items)]
 #![warn(missing_docs)]
 
 #[allow(missing_docs)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,7 @@
 //! Utilities shared by daemon and client.
 
 #![deny(clippy::implicit_return)]
-#![allow(clippy::needless_return)]
+#![allow(clippy::needless_return, clippy::doc_overindented_list_items)]
 
 use log::error;
 use std::{mem, ptr, thread, time};


### PR DESCRIPTION
The GitHub CI windows runners are regularly getting updated by GitHub and receive, among other things, new versions of the rust toolchain. With the latest version (1.86.0) new clippy warnings appear. This change fixes some of them and allows others.