### PR TITLE
Perform brace expansion on hostnames argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "bracoxide"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f52991c481aa9d7518254cfb6ce5726d24ff8c5d383d6422cd3793729b0962a"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +264,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 name = "csshw"
 version = "0.16.0"
 dependencies = [
+ "bracoxide",
  "chrono",
  "clap",
  "cli-clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bracoxide = "0.1.5"
 chrono = "0.4.39"
 clap = { version = "4.5.26", features = ["derive"] }
 cli-clipboard = "0.4.0"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     },
     WindowsSettingsDefaultTerminalApplicationGuard,
 };
+use bracoxide::explode;
 use log::{debug, error, warn};
 use tokio::sync::broadcast::error::TryRecvError;
 use tokio::{
@@ -1099,7 +1100,7 @@ pub async fn main(
     debug: bool,
 ) {
     let daemon: Daemon = Daemon {
-        hosts,
+        hosts: explode(&hosts.join(" ")).unwrap_or(hosts),
         username,
         config,
         clusters,


### PR DESCRIPTION
Note: the windows powershell for one does interpret `{` as special character which will cause a simple call such as `csshw host{1..3}` to fail.
To avoid this any hostname including brace expansion syntax must be quoted: `csshw "host{1..3}" hostA hostB`.

This implements #46.