### PR TITLE
Fix get_console_window_handle

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use crate::client::main as client_main;
 use crate::daemon::{main as daemon_main, resolve_cluster_tags};
 use crate::utils::config::{ClientConfig, Cluster, Config, ConfigOpt, DaemonConfig};
 use crate::{
-    get_concole_window_handle, init_logger, spawn_console_process,
+    get_console_window_handle, init_logger, spawn_console_process,
     WindowsSettingsDefaultTerminalApplicationGuard,
 };
 use clap::{ArgAction, Parser, Subcommand};
@@ -134,7 +134,7 @@ impl Entrypoint for MainEntrypoint {
         let _guard = WindowsSettingsDefaultTerminalApplicationGuard::new();
         // We must wait for the window to actually launch before dropping the _guard as we might otherwise
         // reset the configuration before the window was launched
-        let _ = get_concole_window_handle(
+        let _ = get_console_window_handle(
             spawn_console_process(&format!("{PKG_NAME}.exe"), daemon_args).dwProcessId,
         );
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use std::{thread, time};
 
-use crate::get_concole_window_handle;
+use crate::get_console_window_handle;
 use crate::utils::config::{Cluster, DaemonConfig};
 use crate::utils::debug::StringRepr;
 use crate::utils::{clear_screen, set_console_color};
@@ -736,7 +736,7 @@ fn launch_client_console(
     }
     client_args.push("client");
     client_args.extend(vec!["--", actual_host]);
-    let client_window_handle = get_concole_window_handle(
+    let client_window_handle = get_console_window_handle(
         spawn_console_process(&format!("{PKG_NAME}.exe"), client_args).dwProcessId,
     );
     arrange_client_window(


### PR DESCRIPTION
The recent refactoring when adding tests introduced a bug where it could happen that we would not wait long enough for the client window to launch resulting in the daemon window dying prematurely.