### PR TITLE
Fix set_console_border_color doc-test

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -305,7 +305,7 @@ pub fn clear_screen_with_api(api: &dyn WindowsApi) {
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use csshw_lib::utils::set_console_border_color;
 /// use windows::Win32::Foundation::COLORREF;
 ///


### PR DESCRIPTION
Depending on the operating system (windows 10 vs newer) actual windows API calls would be emitted which can result in test failures. To avoid this we tell Rust to only compile the example but not run it.