### PR TITLE
Add -p/--port CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,16 @@ Arguments:
 
           E.g.: `csshw.exe -u user3 user1@host1 userA@hostA host3`
 
-          Hosts can include a port number.
+          Hosts can include a port number which will take precedence over the port given via the `-p` option.
 
           E.g.: `csshw.exe -u root host1 host2:22 host3:2022`
 
 Options:
   -u, --username <USERNAME>
           Optional username used to connect to the hosts
+
+  -p, --port <PORT>
+          Optional port used for all SSH connections
 
   -d, --debug
           Enable extensive logging

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,11 @@ pub struct Args {
     /// username given via the `-u` option and over any ssh config value.
     ///
     /// E.g.: `csshw.exe -u user3 user1@host1 userA@hostA host3`
+    ///
+    /// Hosts can include a port number which will take precedence over the
+    /// port given via the `-p` option.
+    ///
+    /// E.g.: `csshw.exe -u root host1 host2:22 host3:2022`
     #[clap(required = false, global = true)]
     hosts: Vec<String>,
     /// Enable extensive logging

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,9 @@ pub struct Args {
     /// Optional username used to connect to the hosts
     #[clap(long, short = 'u')]
     username: Option<String>,
+    /// Optional port used for all SSH connections
+    #[clap(long, short = 'p')]
+    port: Option<u16>,
     /// Hosts and/or cluster tag(s) to connect to
     ///
     /// Hosts or cluster tags might use brace expansion,
@@ -82,6 +85,7 @@ pub trait Entrypoint {
         &mut self,
         host: String,
         username: Option<String>,
+        port: Option<u16>,
         config: &ClientConfig,
     ) -> impl std::future::Future<Output = ()> + Send;
     /// Entrypoint for the daemon subcommand
@@ -89,6 +93,7 @@ pub trait Entrypoint {
         &mut self,
         hosts: Vec<String>,
         username: Option<String>,
+        port: Option<u16>,
         config: &DaemonConfig,
         clusters: &[Cluster],
         debug: bool,
@@ -98,39 +103,54 @@ pub trait Entrypoint {
 }
 
 impl Entrypoint for MainEntrypoint {
-    async fn client_main(&mut self, host: String, username: Option<String>, config: &ClientConfig) {
-        client_main(host, username, config).await;
+    async fn client_main(
+        &mut self,
+        host: String,
+        username: Option<String>,
+        port: Option<u16>,
+        config: &ClientConfig,
+    ) {
+        client_main(host, username, port, config).await;
     }
 
     async fn daemon_main(
         &mut self,
         hosts: Vec<String>,
         username: Option<String>,
+        port: Option<u16>,
         config: &DaemonConfig,
         clusters: &[Cluster],
         debug: bool,
     ) {
-        daemon_main(hosts, username, config, clusters, debug).await;
+        daemon_main(hosts, username, port, config, clusters, debug).await;
     }
 
     fn main(&mut self, config_path: &str, config: &Config, args: Args) {
         confy::store_path(config_path, config).unwrap();
 
-        let mut daemon_args: Vec<&str> = Vec::new();
+        let mut daemon_args: Vec<String> = Vec::new();
         if args.debug {
-            daemon_args.push("-d");
+            daemon_args.push("-d".to_string());
         }
-        if let Some(username) = args.username.as_ref() {
-            daemon_args.push("-u");
+        if let Some(username) = args.username {
+            daemon_args.push("-u".to_string());
             daemon_args.push(username);
         }
-        daemon_args.push("daemon");
+        if let Some(port) = args.port {
+            daemon_args.push("-p".to_string());
+            daemon_args.push(port.to_string());
+        }
+        daemon_args.push("daemon".to_string());
         // Order is important here. If the hosts are passed before the daemon subcommand
         // it will not be recognizes as such and just be passed along as one of the hosts.
-        daemon_args.extend(resolve_cluster_tags(
-            args.hosts.iter().map(|host| return &**host).collect(),
-            &config.clusters,
-        ));
+        daemon_args.extend(
+            resolve_cluster_tags(
+                args.hosts.iter().map(|host| return &**host).collect(),
+                &config.clusters,
+            )
+            .into_iter()
+            .map(|host| return host.to_string()),
+        );
         let _guard = WindowsSettingsDefaultTerminalApplicationGuard::new();
         // We must wait for the window to actually launch before dropping the _guard as we might otherwise
         // reset the configuration before the window was launched
@@ -178,7 +198,12 @@ pub async fn main<T: Entrypoint>(args: Args, mut entrypoint: T) {
                 init_logger(&format!("csshw_client_{host}"));
             }
             entrypoint
-                .client_main(host.to_owned(), args.username.to_owned(), &config.client)
+                .client_main(
+                    host.to_owned(),
+                    args.username.to_owned(),
+                    args.port,
+                    &config.client,
+                )
                 .await;
         }
         Some(Commands::Daemon {}) => {
@@ -189,6 +214,7 @@ pub async fn main<T: Entrypoint>(args: Args, mut entrypoint: T) {
                 .daemon_main(
                     args.hosts.to_owned(),
                     args.username.clone(),
+                    args.port,
                     &config.daemon,
                     &config.clusters,
                     args.debug,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,8 +448,8 @@ impl<R: Registry> Drop for WindowsSettingsDefaultTerminalApplicationGuard<R> {
 /// # Returns
 ///
 /// [PROCESS_INFORMATION] of the spawned process.
-pub fn spawn_console_process(application: &str, args: Vec<&str>) -> PROCESS_INFORMATION {
-    return spawn_console_process_with_api(&DefaultWindowsApi, application, &args)
+pub fn spawn_console_process(application: &str, args: Vec<String>) -> PROCESS_INFORMATION {
+    return spawn_console_process_with_api(&DefaultWindowsApi, application, args)
         .expect("Failed to create process");
 }
 
@@ -467,10 +467,9 @@ pub fn spawn_console_process(application: &str, args: Vec<&str>) -> PROCESS_INFO
 pub fn spawn_console_process_with_api<W: WindowsApi>(
     api: &W,
     application: &str,
-    args: &[&str],
+    args: Vec<String>,
 ) -> Option<PROCESS_INFORMATION> {
-    let string_args: Vec<String> = args.iter().map(|s| return s.to_string()).collect();
-    return api.create_process_with_args(application, string_args);
+    return api.create_process_with_args(application, args);
 }
 
 /// Initialize the logger.

--- a/src/tests/test_cli.rs
+++ b/src/tests/test_cli.rs
@@ -14,6 +14,7 @@ mod cli_args_test {
         let args = Args::parse_from(vec!["executable_name", "host1", "host2", "cluster1"]);
         assert_eq!(args.command, None);
         assert_eq!(args.username, None);
+        assert_eq!(args.port, None);
         assert_eq!(args.hosts, vec!["host1", "host2", "cluster1"]);
         assert!(!args.debug);
         // With username
@@ -27,6 +28,7 @@ mod cli_args_test {
         ]);
         assert_eq!(args.command, None);
         assert_eq!(args.username, Some("username".to_string()));
+        assert_eq!(args.port, None);
         assert_eq!(args.hosts, vec!["host1", "host2", "cluster1"]);
         assert!(!args.debug);
         // With username and debug
@@ -41,6 +43,38 @@ mod cli_args_test {
         ]);
         assert_eq!(args.command, None);
         assert_eq!(args.username, Some("username".to_string()));
+        assert_eq!(args.port, None);
+        assert_eq!(args.hosts, vec!["host1", "host2", "cluster1"]);
+        assert!(args.debug);
+        // With port
+        let args = Args::parse_from(vec![
+            "executable_name",
+            "-p",
+            "2222",
+            "host1",
+            "host2",
+            "cluster1",
+        ]);
+        assert_eq!(args.command, None);
+        assert_eq!(args.username, None);
+        assert_eq!(args.port, Some(2222));
+        assert_eq!(args.hosts, vec!["host1", "host2", "cluster1"]);
+        assert!(!args.debug);
+        // With username, port and debug
+        let args = Args::parse_from(vec![
+            "executable_name",
+            "-u",
+            "username",
+            "-p",
+            "8080",
+            "-d",
+            "host1",
+            "host2",
+            "cluster1",
+        ]);
+        assert_eq!(args.command, None);
+        assert_eq!(args.username, Some("username".to_string()));
+        assert_eq!(args.port, Some(8080));
         assert_eq!(args.hosts, vec!["host1", "host2", "cluster1"]);
         assert!(args.debug);
     }
@@ -111,6 +145,7 @@ mod cli_main_test {
         let args = Args {
             command: None,
             username: None,
+            port: None,
             hosts: vec!["host1".to_string(), "host2".to_string()],
             debug: false,
         };
@@ -130,15 +165,17 @@ mod cli_main_test {
         let mut mock = MockEntrypoint::new();
         mock.expect_daemon_main()
             .once()
-            .returning(|hosts, username, _, _, debug| {
+            .returning(|hosts, username, port, _, _, debug| {
                 assert_eq!(hosts, vec!["host1".to_string(), "host2".to_string()]);
                 assert_eq!(username, Some("username".to_string()));
+                assert_eq!(port, None);
                 assert!(!debug);
                 return Box::pin(async {});
             });
         let args = Args {
             command: Some(Commands::Daemon {}),
             username: Some("username".to_string()),
+            port: None,
             hosts: vec!["host1".to_string(), "host2".to_string()],
             debug: false,
         };
@@ -150,9 +187,10 @@ mod cli_main_test {
         let mut mock = MockEntrypoint::new();
         mock.expect_client_main()
             .once()
-            .returning(|host, username, _| {
+            .returning(|host, username, port, _| {
                 assert_eq!(host, "host1");
                 assert_eq!(username, Some("username".to_string()));
+                assert_eq!(port, None);
                 return Box::pin(async {});
             });
         let args = Args {
@@ -160,6 +198,7 @@ mod cli_main_test {
                 host: "host1".to_string(),
             }),
             username: Some("username".to_string()),
+            port: None,
             hosts: vec!["host1".to_string()],
             debug: false,
         };

--- a/src/tests/test_lib.rs
+++ b/src/tests/test_lib.rs
@@ -428,7 +428,11 @@ mod spawn_process_test {
                 });
             });
 
-        let result = spawn_console_process_with_api(&mock_api, "cmd.exe", &["/c", "echo", "test"]);
+        let result = spawn_console_process_with_api(
+            &mock_api,
+            "cmd.exe",
+            vec!["/c".to_string(), "echo".to_string(), "test".to_string()],
+        );
 
         assert!(result.is_some());
         let process_info = result.unwrap();
@@ -448,7 +452,8 @@ mod spawn_process_test {
             .times(1)
             .returning(|_, _| return None);
 
-        let result = spawn_console_process_with_api(&mock_api, "nonexistent.exe", &["arg1"]);
+        let result =
+            spawn_console_process_with_api(&mock_api, "nonexistent.exe", vec!["arg1".to_string()]);
 
         assert!(result.is_none());
     }
@@ -472,7 +477,7 @@ mod spawn_process_test {
                 });
             });
 
-        let result = spawn_console_process_with_api(&mock_api, "notepad.exe", &[]);
+        let result = spawn_console_process_with_api(&mock_api, "notepad.exe", vec![]);
 
         assert!(result.is_some());
         let process_info = result.unwrap();
@@ -486,11 +491,14 @@ mod spawn_process_test {
     fn test_spawn_console_process_complex_args() {
         let mut mock_api = MockWindowsApi::new();
 
-        let args = vec!["-o", "StrictHostKeyChecking=no", "user@host.com"];
-        let string_args: Vec<String> = args.iter().map(|s| return s.to_string()).collect();
+        let args = vec![
+            "-o".to_string(),
+            "StrictHostKeyChecking=no".to_string(),
+            "user@host.com".to_string(),
+        ];
         mock_api
             .expect_create_process_with_args()
-            .with(eq("ssh.exe"), eq(string_args))
+            .with(eq("ssh.exe"), eq(args.clone()))
             .times(1)
             .returning(|_, _| {
                 return Some(PROCESS_INFORMATION {
@@ -501,7 +509,7 @@ mod spawn_process_test {
                 });
             });
 
-        let result = spawn_console_process_with_api(&mock_api, "ssh.exe", &args);
+        let result = spawn_console_process_with_api(&mock_api, "ssh.exe", args);
 
         assert!(result.is_some());
         let process_info = result.unwrap();


### PR DESCRIPTION
With this change the SSH port to be used by the clients can be specified
for all hosts by using the `-p/--port `CLI option.
Inline ports (e.g. `host:123`) still take precedence over the CLI
option.

SSH config values take precedence over everything.

Code generated by Cline using anthropic--claude-4-sonnet