### PR TITLE
Only run CI for pull requests that touch relevant files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths:
+      - .cargo/**
+      - .github/workflows/ci.yml
+      - src/**
+      - build.rs
+      - Cargo.toml
+      - clippy.toml
+      - Makefile.toml
+      - rustfmt.toml
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
If no relevant files were touched we don't need to run the CI.