### PR TITLE
Add interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Arguments:
 
           E.g.: `csshw.exe -p 33 host1:11 host2:22 host3`
 
+          If no hosts are provided and the application is launched in a new console window (e.g. by double clicking the executable in the File Explorer), it will launch in interactive mode.
+
 Options:
   -u, --username <USERNAME>
           Optional username used to connect to the hosts

--- a/src/tests/test_cli.rs
+++ b/src/tests/test_cli.rs
@@ -205,3 +205,177 @@ mod cli_main_test {
         main(args, mock).await;
     }
 }
+
+/// Test module for the new interactive mode helper functions
+mod interactive_mode_test {
+    use crate::cli::{
+        execute_parsed_command, handle_special_commands, Args, Commands, MockArgsCommand,
+        MockEntrypoint,
+    };
+    use crate::utils::config::Config;
+    use mockall::predicate::*;
+
+    /// Test handle_special_commands function
+    #[test]
+    fn test_handle_special_commands() {
+        // Test --help command
+        assert!(handle_special_commands("--help"));
+
+        // Test -h command
+        assert!(handle_special_commands("-h"));
+
+        // Test non-special commands
+        assert!(!handle_special_commands("host1 host2"));
+        assert!(!handle_special_commands("-u username host1"));
+        assert!(!handle_special_commands("daemon host1"));
+        assert!(!handle_special_commands("client host1"));
+        assert!(!handle_special_commands(""));
+        assert!(!handle_special_commands("--version"));
+        assert!(!handle_special_commands("-v"));
+    }
+
+    /// Test execute_parsed_command with Client command
+    #[tokio::test]
+    async fn test_execute_parsed_command_client() {
+        let mut mock_entrypoint = MockEntrypoint::new();
+        let config = Config::default();
+        let config_path = "test-config.toml";
+
+        // Set up expectations
+        mock_entrypoint
+            .expect_client_main()
+            .with(
+                eq("testhost".to_string()),
+                eq(Some("testuser".to_string())),
+                eq(Some(2222)),
+                always(),
+            )
+            .times(1)
+            .returning(|_, _, _, _| return Box::pin(async {}));
+
+        let args = Args {
+            command: Some(Commands::Client {
+                host: "testhost".to_string(),
+            }),
+            username: Some("testuser".to_string()),
+            port: Some(2222),
+            hosts: vec![],
+            debug: false,
+        };
+
+        let mock_args_command = MockArgsCommand::new();
+        execute_parsed_command(
+            args,
+            &mut mock_entrypoint,
+            &mock_args_command,
+            &config,
+            config_path,
+        )
+        .await;
+    }
+
+    /// Test execute_parsed_command with Daemon command
+    #[tokio::test]
+    async fn test_execute_parsed_command_daemon() {
+        let mut mock_entrypoint = MockEntrypoint::new();
+        let config = Config::default();
+        let config_path = "test-config.toml";
+
+        // Set up expectations
+        mock_entrypoint
+            .expect_daemon_main()
+            .with(
+                eq(vec!["host1".to_string(), "host2".to_string()]),
+                eq(Some("testuser".to_string())),
+                eq(Some(8080)),
+                always(),
+                always(),
+                eq(true),
+            )
+            .times(1)
+            .returning(|_, _, _, _, _, _| return Box::pin(async {}));
+
+        let args = Args {
+            command: Some(Commands::Daemon {}),
+            username: Some("testuser".to_string()),
+            port: Some(8080),
+            hosts: vec!["host1".to_string(), "host2".to_string()],
+            debug: true,
+        };
+
+        let mock_args_command = MockArgsCommand::new();
+        execute_parsed_command(
+            args,
+            &mut mock_entrypoint,
+            &mock_args_command,
+            &config,
+            config_path,
+        )
+        .await;
+    }
+
+    /// Test execute_parsed_command with None command and hosts
+    #[tokio::test]
+    async fn test_execute_parsed_command_none_with_hosts() {
+        let mut mock_entrypoint = MockEntrypoint::new();
+        let config = Config::default();
+        let config_path = "test-config.toml";
+
+        // Set up expectations
+        mock_entrypoint
+            .expect_main()
+            .with(eq(config_path), always(), always())
+            .times(1)
+            .returning(|_, _, _| {});
+
+        let args = Args {
+            command: None,
+            username: Some("testuser".to_string()),
+            port: Some(3333),
+            hosts: vec!["host1".to_string(), "host2".to_string()],
+            debug: false,
+        };
+
+        let mock_args_command = MockArgsCommand::new();
+        execute_parsed_command(
+            args,
+            &mut mock_entrypoint,
+            &mock_args_command,
+            &config,
+            config_path,
+        )
+        .await;
+    }
+
+    /// Test execute_parsed_command with None command and no hosts (should show help)
+    #[tokio::test]
+    async fn test_execute_parsed_command_none_no_hosts() {
+        let mut mock_entrypoint = MockEntrypoint::new();
+        let mut mock_args_command = MockArgsCommand::new();
+        let config = Config::default();
+        let config_path = "test-config.toml";
+
+        // Set up expectation that print_help will be called
+        mock_args_command
+            .expect_print_help()
+            .times(1)
+            .returning(|| return Ok(()));
+
+        let args = Args {
+            command: None,
+            username: None,
+            port: None,
+            hosts: vec![],
+            debug: false,
+        };
+
+        execute_parsed_command(
+            args,
+            &mut mock_entrypoint,
+            &mock_args_command,
+            &config,
+            config_path,
+        )
+        .await;
+    }
+}


### PR DESCRIPTION
With this change the default behavior of csshw when being called WITHOUT any arguments is changed.
When called from an existing console window the help text will be printed.
When launched from the FileExplorer or otherwise in a new console window, it will enter interactive mode.

In interactive mode CLI arguments can be entered in the new console window which will remain open until closed.
The CLI arguments will parsed and daemon + client windows will open accordingly.

Fixes: #69

Code generated by Cline using anthropic--claude-4-sonnet