### PR TITLE
Maintain GitHub labels in repository

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,6 @@
+# GitHub Labels Configuration
+# This file defines the labels used in the repository for automated workflows
+
+- name: "no-news-fragment-needed"
+  color: "7bb344"
+  description: "Indicates that this PR does not require a news fragment"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,28 @@
+#
+#   Sync Labels
+#
+# Synchronizes repository labels with the labels.yml configuration file.
+# Runs on pushes to main that modify the labels configuration.
+
+name: Sync Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.yml'
+  workflow_dispatch:
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          yaml-file: .github/labels.yml
+          skip-delete: true


### PR DESCRIPTION
This change adds the sync-labels workflow that updates the GitHub labels based on the labels.yml file in the repository.
Note the default set of labels remains untouched.