### PR TITLE
Changed logic of cmd window detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,7 @@ pub fn init_logger_with_fs<F: FileSystem>(fs: &F, name: &str) {
 /// Detect if application was launched from Windows Explorer (GUI) vs command line using the provided console API.
 ///
 /// Returns true if launched from GUI (separate console), false if from existing console.
-/// Based on: <https://stackoverflow.com/a/513574>
+/// Based on: <https://devblogs.microsoft.com/oldnewthing/20160125-00/?p=92922>
 ///
 /// # Arguments
 ///
@@ -367,24 +367,7 @@ pub fn init_logger_with_fs<F: FileSystem>(fs: &F, name: &str) {
 /// * `true` - Application was launched from GUI (Explorer, double-click, etc.)
 /// * `false` - Application was launched from existing console (command line)
 pub fn is_launched_from_gui<W: WindowsApi>(windows_api: &W) -> bool {
-    match windows_api.get_stdout_handle() {
-        Ok(handle) => {
-            match windows_api.get_console_screen_buffer_info_with_handle(handle) {
-                Ok(csbi) => {
-                    // The cursor has not moved from the initial 0,0 position -> launched in separate console
-                    return csbi.dwCursorPosition.X == 0 && csbi.dwCursorPosition.Y == 0;
-                }
-                Err(err) => {
-                    warn!("GetConsoleScreenBufferInfo failed: {:?}", err);
-                    return false;
-                }
-            }
-        }
-        Err(err) => {
-            warn!("Failed to get stdout handle: {:?}", err);
-            return false;
-        }
-    }
+    return windows_api.get_console_attached_process_count() == 1;
 }
 
 #[cfg(test)]

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -20,10 +20,10 @@ use windows::Win32::Foundation::{BOOL, COLORREF, FALSE, HANDLE, HWND, LPARAM, TR
 use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_BORDER_COLOR};
 use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
 use windows::Win32::System::Console::{
-    FillConsoleOutputAttribute, GetConsoleScreenBufferInfo, GetConsoleWindow, GetStdHandle,
-    ReadConsoleInputW, SetConsoleTextAttribute, CONSOLE_CHARACTER_ATTRIBUTES,
-    CONSOLE_SCREEN_BUFFER_INFO, COORD, INPUT_RECORD, INPUT_RECORD_0, STD_HANDLE, STD_INPUT_HANDLE,
-    STD_OUTPUT_HANDLE,
+    FillConsoleOutputAttribute, GetConsoleProcessList, GetConsoleScreenBufferInfo,
+    GetConsoleWindow, GetStdHandle, ReadConsoleInputW, SetConsoleTextAttribute,
+    CONSOLE_CHARACTER_ATTRIBUTES, CONSOLE_SCREEN_BUFFER_INFO, COORD, INPUT_RECORD, INPUT_RECORD_0,
+    STD_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
 };
 use windows::Win32::System::Console::{GetConsoleMode, SetConsoleMode, CONSOLE_MODE};
 use windows::Win32::System::Console::{
@@ -257,10 +257,7 @@ pub trait WindowsApi: Send + Sync {
     /// # Returns
     ///
     /// Console screen buffer information or error
-    fn get_console_screen_buffer_info_with_handle(
-        &self,
-        handle: HANDLE,
-    ) -> windows::core::Result<CONSOLE_SCREEN_BUFFER_INFO>;
+    fn get_console_attached_process_count(&self) -> u32;
 
     /// Create a new process
     ///
@@ -664,13 +661,9 @@ impl WindowsApi for DefaultWindowsApi {
         return self.get_std_handle(STD_OUTPUT_HANDLE);
     }
 
-    fn get_console_screen_buffer_info_with_handle(
-        &self,
-        handle: HANDLE,
-    ) -> windows::core::Result<CONSOLE_SCREEN_BUFFER_INFO> {
-        let mut csbi = CONSOLE_SCREEN_BUFFER_INFO::default();
-        unsafe { GetConsoleScreenBufferInfo(handle, &mut csbi) }?;
-        return Ok(csbi);
+    fn get_console_attached_process_count(&self) -> u32 {
+        let mut value: [u32; 1] = [0];
+        unsafe { return GetConsoleProcessList(&mut value) };
     }
 
     fn get_window_handle_for_process(&self, process_id: u32) -> HWND {


### PR DESCRIPTION
Simplified the detection of launching from a GUI versus launching from a command prompt.

Inspired by the writings of Raymond Chen: https://devblogs.microsoft.com/oldnewthing/20160125-00/?p=92922

The method is also used in my own project to either launch in console mode or show a GUI. 