### PR TITLE
Add .gitattributes to enforce CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=crlf


### PR DESCRIPTION
The duckscript offset calculations in the update-readme-help task assume CRLF, this change enforces this for the repo.