### PR TITLE
Identify pipe server connections via client PID

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -23,7 +23,10 @@ use windows::Win32::System::Console::{
 };
 
 use crate::{
-    serde::{deserialization::deserialize_input_record_0, SERIALIZED_INPUT_RECORD_0_LENGTH},
+    serde::{
+        deserialization::deserialize_input_record_0, serialization::serialize_pid,
+        SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+    },
     utils::constants::{PIPE_NAME, PKG_NAME},
 };
 
@@ -312,17 +315,15 @@ fn replace_argument_placeholders(
 ///
 /// Panics if the pipe write fails in a way that cannot be retried.
 async fn send_pid_handshake(named_pipe_client: &NamedPipeClient) {
-    let pid_bytes = std::process::id().to_le_bytes();
+    let pid_bytes = serialize_pid(std::process::id());
     let mut written = 0usize;
-    while written < pid_bytes.len() {
+    while written < SERIALIZED_PID_LENGTH {
         named_pipe_client.writable().await.unwrap_or_else(|err| {
-            error!("{}", err);
-            panic!("Named pipe client is not writable for PID handshake",)
+            panic!("Named pipe client is not writable for PID handshake: {err}")
         });
         match named_pipe_client.try_write(&pid_bytes[written..]) {
             Ok(0) => {
-                error!("Named pipe closed before PID handshake could complete");
-                panic!("Named pipe closed before PID handshake could complete",);
+                panic!("Named pipe closed before PID handshake could complete");
             }
             Ok(n) => {
                 written += n;
@@ -331,8 +332,7 @@ async fn send_pid_handshake(named_pipe_client: &NamedPipeClient) {
                 continue;
             }
             Err(e) => {
-                error!("{}", e);
-                panic!("Failed to send PID handshake to daemon",);
+                panic!("Failed to send PID handshake to daemon: {e}");
             }
         }
     }
@@ -365,8 +365,7 @@ async fn run(api: &dyn WindowsApi, child: &mut Child) {
     };
     // Identify ourselves to the daemon's pipe server by sending our PID.
     // The daemon uses this to correlate this pipe connection to the corresponding
-    // client in its internal bookkeeping. Without this handshake the daemon
-    // cannot forward input to us.
+    // client in its internal bookkeeping.
     send_pid_handshake(&named_pipe_client).await;
     let mut child_error = false;
     let mut internal_buffer: Vec<u8> = Vec::new();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -297,6 +297,48 @@ fn replace_argument_placeholders(
         .collect();
 }
 
+/// Send this process's id over the pipe to the daemon as a 4 byte
+/// little-endian sequence.
+///
+/// The daemon uses the PID to match the pipe connection to the correct
+/// [`crate::daemon`] `Client` entry. Without this handshake the daemon will
+/// not forward any input records.
+///
+/// # Arguments
+///
+/// * `named_pipe_client` - The connected pipe client to write the PID to.
+///
+/// # Panics
+///
+/// Panics if the pipe write fails in a way that cannot be retried.
+async fn send_pid_handshake(named_pipe_client: &NamedPipeClient) {
+    let pid_bytes = std::process::id().to_le_bytes();
+    let mut written = 0usize;
+    while written < pid_bytes.len() {
+        named_pipe_client.writable().await.unwrap_or_else(|err| {
+            error!("{}", err);
+            panic!("Named pipe client is not writable for PID handshake",)
+        });
+        match named_pipe_client.try_write(&pid_bytes[written..]) {
+            Ok(0) => {
+                error!("Named pipe closed before PID handshake could complete");
+                panic!("Named pipe closed before PID handshake could complete",);
+            }
+            Ok(n) => {
+                written += n;
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                continue;
+            }
+            Err(e) => {
+                error!("{}", e);
+                panic!("Failed to send PID handshake to daemon",);
+            }
+        }
+    }
+    return;
+}
+
 /// The main run loop of the client.
 ///
 /// Connects to the named pipe opened by the daemon, reads all input records from it
@@ -321,6 +363,11 @@ async fn run(api: &dyn WindowsApi, child: &mut Child) {
             }
         }
     };
+    // Authenticate ourselves to the daemon's pipe server by sending our PID.
+    // The daemon uses this to match this pipe connection to the corresponding
+    // client in its internal bookkeeping. Without this handshake the daemon
+    // cannot forward input to us.
+    send_pid_handshake(&named_pipe_client).await;
     let mut child_error = false;
     let mut internal_buffer: Vec<u8> = Vec::new();
     loop {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -363,8 +363,8 @@ async fn run(api: &dyn WindowsApi, child: &mut Child) {
             }
         }
     };
-    // Authenticate ourselves to the daemon's pipe server by sending our PID.
-    // The daemon uses this to match this pipe connection to the corresponding
+    // Identify ourselves to the daemon's pipe server by sending our PID.
+    // The daemon uses this to correlate this pipe connection to the corresponding
     // client in its internal bookkeeping. Without this handshake the daemon
     // cannot forward input to us.
     send_pid_handshake(&named_pipe_client).await;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -124,8 +124,18 @@ impl Clients {
     /// # Arguments
     ///
     /// * `client` - The [Client] to add.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a client with the same process id is already present, as
+    /// duplicate PIDs indicate broken daemon bookkeeping.
     fn push(&mut self, client: Client) {
         let index = self.list.len();
+        assert!(
+            !self.pid_index.contains_key(&client.process_id),
+            "Duplicate client PID {} — daemon bookkeeping broken",
+            client.process_id,
+        );
         self.pid_index.insert(client.process_id, index);
         self.list.push(client);
     }
@@ -1001,7 +1011,7 @@ async fn named_pipe_server_routine(
     // wait for a client to connect
     server.connect().await.unwrap_or_else(|err| {
         error!("{}", err);
-        panic!("Timeded out waiting for clients to connect to named pipe server",)
+        panic!("Timed out waiting for clients to connect to named pipe server",)
     });
 
     // Authenticate the connecting client by reading its 4 byte PID.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -82,25 +82,25 @@ struct Client {
     process_handle: HANDLE,
     /// Process id of the client process.
     ///
-    /// Used by the pipe server task to authenticate which client has connected
+    /// Used by the pipe server task to correlate which client has connected
     /// to it, via a handshake over the named pipe.
     process_id: u32,
     /// Shared state between this client and its assigned pipe server task.
     ///
-    /// Populated at [Client] construction; cloned by the pipe server task upon
-    /// successful PID authentication and consulted during input forwarding to
+    /// Populated at [`Client`] construction; cloned by the pipe server task upon
+    /// successful PID correlation and consulted during input forwarding to
     /// determine whether records should be sent to the client.
     pipe_server_state: Arc<Mutex<PipeServerState>>,
 }
 
 unsafe impl Send for Client {}
 
-/// Collection of [Client]s maintaining insertion order and a PID-indexed
+/// Collection of [`Client`]s maintaining insertion order and a PID-indexed
 /// lookup table.
 ///
 /// The ordered list preserves client window placement semantics, while the
 /// index enables O(1) lookup by process id — required by the pipe server task
-/// during PID authentication and future per-client pipe server control.
+/// during PID correlation and future per-client pipe server control.
 struct Clients {
     /// Ordered list of clients; order matches launch order and is used for
     /// window arrangement and z-order synchronization.
@@ -123,7 +123,7 @@ impl Clients {
     ///
     /// # Arguments
     ///
-    /// * `client` - The [Client] to add.
+    /// * `client` - The [`Client`] to add.
     ///
     /// # Panics
     ///
@@ -181,7 +181,7 @@ impl Clients {
     ///
     /// # Arguments
     ///
-    /// * `f` - Predicate applied to each [Client]; kept when it returns `true`.
+    /// * `f` - Predicate applied to each [`Client`]; kept when it returns `true`.
     fn retain<F: FnMut(&Client) -> bool>(&mut self, mut f: F) {
         self.list.retain(|client| return f(client));
         self.pid_index.clear();
@@ -966,19 +966,19 @@ fn launch_client_console<W: WindowsApi>(
     );
 }
 
-/// Wait for the named pipe server to connect, authenticate the client by
+/// Wait for the named pipe server to connect, correlate the client by
 /// its process id, then forward serialized input records read from the
 /// broadcast channel to the named pipe server.
 ///
-/// Authentication: after [NamedPipeServer::connect] resolves, the client is
+/// Correlation: after [`NamedPipeServer::connect`] resolves, the client is
 /// expected to write its 4 byte little-endian process id into the pipe. The
-/// routine looks up the [Client] with that PID in the daemon's `clients`
-/// collection; if it is not found, the routine logs an error and panics —
-/// an unknown PID indicates either broken daemon bookkeeping or an
-/// unauthorized process connecting to the pipe, and is unrecoverable.
+/// routine looks up the [`Client`] with that PID in the daemon's `clients`
+/// collection; if it is not found, the routine logs an error and terminates
+/// the daemon — an unknown PID indicates broken daemon bookkeeping and is
+/// unrecoverable.
 ///
 /// Forwarding: on every broadcast record, the routine matches on the
-/// [`PipeServerState`] cloned from the authenticated client; only
+/// [`PipeServerState`] cloned from the correlated client; only
 /// [`PipeServerState::Enabled`] writes the record to the pipe. The keep-alive
 /// write stays unconditional so dead pipes are detected regardless of state.
 ///
@@ -996,7 +996,7 @@ fn launch_client_console<W: WindowsApi>(
 ///                thread that are to be sent to the client via the named
 ///                pipe.
 /// * `clients`  - The daemon's collection of tracked clients, used to
-///                authenticate the connecting client by PID and to obtain
+///                correlate the connecting client by PID and to obtain
 ///                the shared [`PipeServerState`] reference for this server.
 ///
 /// # Panics
@@ -1014,19 +1014,21 @@ async fn named_pipe_server_routine(
         panic!("Timed out waiting for clients to connect to named pipe server",)
     });
 
-    // Authenticate the connecting client by reading its 4 byte PID.
+    // Correlate the connecting client by reading its 4 byte PID.
     let pid = read_client_pid(&server).await;
     let pipe_server_state = match clients.lock().unwrap().get_by_pid(pid) {
         Some(client) => Arc::clone(&client.pipe_server_state),
         None => {
             error!(
-                "Named pipe server received unknown PID {} during authentication",
+                "Named pipe server received unknown PID {} — daemon bookkeeping broken",
                 pid
             );
-            panic!(
-                "Unknown client PID {} connected to named pipe server — daemon bookkeeping broken or unauthorized process",
-                pid
-            );
+            // In production this exits the daemon; in tests process::exit would kill
+            // the test runner, so we panic instead so tokio::spawn can catch it.
+            #[cfg(not(test))]
+            std::process::exit(1);
+            #[cfg(test)]
+            panic!("Unknown client PID {} — daemon bookkeeping broken", pid);
         }
     };
 
@@ -1098,7 +1100,7 @@ async fn named_pipe_server_routine(
 ///
 /// Reads exactly 4 bytes from `server`, retrying on `WouldBlock`, and decodes
 /// them as a `u32`. Any non-recoverable I/O error panics, as a client that
-/// cannot send its PID cannot be authenticated and forwarding would be
+/// cannot send its PID cannot be correlated and forwarding would be
 /// impossible.
 ///
 /// # Arguments

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -5,6 +5,7 @@
 #![warn(missing_docs)]
 
 use std::cmp::max;
+use std::collections::HashMap;
 use std::{
     io,
     sync::{Arc, Mutex},
@@ -58,6 +59,18 @@ mod workspace;
 /// to the named pipe servers connected to each client in parallel.
 const SENDER_CAPACITY: usize = 1024 * 1024;
 
+/// Runtime state of a client's assigned pipe server task.
+///
+/// Observed by the pipe server on each input record; determines whether
+/// the record is forwarded to the client over the named pipe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PipeServerState {
+    /// Forward all input records to the client.
+    Enabled,
+    // Future variants (e.g. Paused, Disabled) will expand the control surface
+    // without requiring architectural changes.
+}
+
 /// Representation of a client
 #[derive(Clone)]
 struct Client {
@@ -67,9 +80,106 @@ struct Client {
     window_handle: HWND,
     /// Process handle to the client process.
     process_handle: HANDLE,
+    /// Process id of the client process.
+    ///
+    /// Used by the pipe server task to authenticate which client has connected
+    /// to it, via a handshake over the named pipe.
+    process_id: u32,
+    /// Shared state between this client and its assigned pipe server task.
+    ///
+    /// Populated at [Client] construction; cloned by the pipe server task upon
+    /// successful PID authentication and consulted during input forwarding to
+    /// determine whether records should be sent to the client.
+    pipe_server_state: Arc<Mutex<PipeServerState>>,
 }
 
 unsafe impl Send for Client {}
+
+/// Collection of [Client]s maintaining insertion order and a PID-indexed
+/// lookup table.
+///
+/// The ordered list preserves client window placement semantics, while the
+/// index enables O(1) lookup by process id — required by the pipe server task
+/// during PID authentication and future per-client pipe server control.
+struct Clients {
+    /// Ordered list of clients; order matches launch order and is used for
+    /// window arrangement and z-order synchronization.
+    list: Vec<Client>,
+    /// Maps a client's process id to its index in [`list`](Clients::list).
+    pid_index: HashMap<u32, usize>,
+}
+
+impl Clients {
+    /// Creates a new empty collection.
+    fn new() -> Self {
+        return Clients {
+            list: Vec::new(),
+            pid_index: HashMap::new(),
+        };
+    }
+
+    /// Appends a client to the collection and records its position in the
+    /// PID index.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - The [Client] to add.
+    fn push(&mut self, client: Client) {
+        let index = self.list.len();
+        self.pid_index.insert(client.process_id, index);
+        self.list.push(client);
+    }
+
+    /// Returns a reference to the client with the given process id, if any.
+    ///
+    /// # Arguments
+    ///
+    /// * `pid` - The process id of the client to look up.
+    ///
+    /// # Returns
+    ///
+    /// `Some(&Client)` if a client with the given PID exists, `None` otherwise.
+    fn get_by_pid(&self, pid: u32) -> Option<&Client> {
+        return self
+            .pid_index
+            .get(&pid)
+            .map(|&index| return &self.list[index]);
+    }
+
+    /// Returns an iterator over the clients in insertion order.
+    fn iter(&self) -> std::slice::Iter<'_, Client> {
+        return self.list.iter();
+    }
+
+    /// Returns the clients as a slice in insertion order.
+    fn as_slice(&self) -> &[Client] {
+        return self.list.as_slice();
+    }
+
+    /// Returns the number of clients in the collection.
+    fn len(&self) -> usize {
+        return self.list.len();
+    }
+
+    /// Returns whether the collection is empty.
+    fn is_empty(&self) -> bool {
+        return self.list.is_empty();
+    }
+
+    /// Retains only the clients for which the predicate returns `true`,
+    /// rebuilding the PID index to reflect the new positions.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - Predicate applied to each [Client]; kept when it returns `true`.
+    fn retain<F: FnMut(&Client) -> bool>(&mut self, mut f: F) {
+        self.list.retain(|client| return f(client));
+        self.pid_index.clear();
+        for (index, client) in self.list.iter().enumerate() {
+            self.pid_index.insert(client.process_id, index);
+        }
+    }
+}
 
 /// Hacky wrapper around a window handle.
 ///
@@ -183,19 +293,22 @@ impl<'a> Daemon<'a> {
             CONSOLE_CHARACTER_ATTRIBUTES(self.config.console_color),
         );
 
-        let mut clients = Arc::new(Mutex::new(
-            launch_clients(
-                windows_api,
-                self.hosts.to_vec(),
-                &self.username,
-                self.port,
-                self.debug,
-                &workspace_area,
-                self.config.aspect_ratio_adjustement,
-                0,
-            )
-            .await,
-        ));
+        let launched = launch_clients(
+            windows_api,
+            self.hosts.to_vec(),
+            &self.username,
+            self.port,
+            self.debug,
+            &workspace_area,
+            self.config.aspect_ratio_adjustement,
+            0,
+        )
+        .await;
+        let mut clients_collection = Clients::new();
+        for client in launched.into_iter() {
+            clients_collection.push(client);
+        }
+        let mut clients = Arc::new(Mutex::new(clients_collection));
 
         // Now that all clients started, focus the daemon console again.
         let daemon_console = windows_api.get_console_window();
@@ -233,13 +346,15 @@ impl<'a> Daemon<'a> {
     async fn run<W: WindowsApi + Clone + 'static>(
         &mut self,
         windows_api: &W,
-        clients: &mut Arc<Mutex<Vec<Client>>>,
+        clients: &mut Arc<Mutex<Clients>>,
         workspace_area: &workspace::WorkspaceArea,
     ) {
         let (sender, _) =
             broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(SENDER_CAPACITY);
 
-        let mut servers = Arc::new(Mutex::new(self.launch_named_pipe_servers(&sender)));
+        let mut servers = Arc::new(Mutex::new(
+            self.launch_named_pipe_servers(&sender, Arc::clone(clients)),
+        ));
 
         // Monitor client processes
         let clients_clone = Arc::clone(clients);
@@ -292,10 +407,11 @@ impl<'a> Daemon<'a> {
     fn launch_named_pipe_servers(
         &self,
         sender: &Sender<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>,
+        clients: Arc<Mutex<Clients>>,
     ) -> Vec<JoinHandle<()>> {
         let mut servers: Vec<JoinHandle<()>> = Vec::new();
         for _ in &self.hosts {
-            self.launch_named_pipe_server(&mut servers, sender);
+            self.launch_named_pipe_server(&mut servers, sender, Arc::clone(&clients));
         }
         return servers;
     }
@@ -313,8 +429,10 @@ impl<'a> Daemon<'a> {
         &self,
         servers: &mut Vec<JoinHandle<()>>,
         sender: &Sender<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>,
+        clients: Arc<Mutex<Clients>>,
     ) {
         let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
             .access_outbound(true)
             .pipe_mode(PipeMode::Message)
             .create(PIPE_NAME)
@@ -324,7 +442,7 @@ impl<'a> Daemon<'a> {
             });
         let mut receiver = sender.subscribe();
         servers.push(tokio::spawn(async move {
-            named_pipe_server_routine(named_pipe_server, &mut receiver).await;
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
         }));
     }
 
@@ -361,7 +479,7 @@ impl<'a> Daemon<'a> {
         windows_api: &W,
         sender: &Sender<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>,
         input_record: INPUT_RECORD_0,
-        clients: &mut Arc<Mutex<Vec<Client>>>,
+        clients: &mut Arc<Mutex<Clients>>,
         workspace_area: &workspace::WorkspaceArea,
         servers: &mut Arc<Mutex<Vec<JoinHandle<()>>>>,
     ) {
@@ -384,7 +502,7 @@ impl<'a> Daemon<'a> {
                 (VK_R, 0) => {
                     self.rearrange_client_windows(
                         windows_api,
-                        &clients.lock().unwrap(),
+                        clients.lock().unwrap().as_slice(),
                         workspace_area,
                     );
                     self.arrange_daemon_console(windows_api, workspace_area);
@@ -426,7 +544,11 @@ impl<'a> Daemon<'a> {
                             .await;
                             for client in new_clients.into_iter() {
                                 clients.lock().unwrap().push(client);
-                                self.launch_named_pipe_server(&mut servers.lock().unwrap(), sender);
+                                self.launch_named_pipe_server(
+                                    &mut servers.lock().unwrap(),
+                                    sender,
+                                    Arc::clone(clients),
+                                );
                             }
                         }
                         Err(error) => {
@@ -436,7 +558,7 @@ impl<'a> Daemon<'a> {
                     toggle_processed_input_mode(windows_api); // Re-disable processed input mode.
                     self.rearrange_client_windows(
                         windows_api,
-                        &clients.lock().unwrap(),
+                        clients.lock().unwrap().as_slice(),
                         workspace_area,
                     );
                     self.arrange_daemon_console(windows_api, workspace_area);
@@ -706,7 +828,7 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
 
         // Use spawn_blocking to run the synchronous launch_client_console in parallel
         let task = tokio::task::spawn_blocking(move || {
-            let (window_handle, process_handle) = launch_client_console(
+            let (window_handle, process_handle, process_id) = launch_client_console(
                 windows_api_clone.as_ref(),
                 &host,
                 username_client,
@@ -723,6 +845,8 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
                     hostname: host,
                     window_handle,
                     process_handle,
+                    process_id,
+                    pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
                 },
             );
         });
@@ -771,7 +895,8 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
 ///
 /// # Returns
 ///
-/// A tuple containing the window handle and process handle of the client process.
+/// A tuple containing the window handle, process handle, and process id of the
+/// client process.
 fn launch_client_console<W: WindowsApi>(
     windows_api: &W,
     host: &str,
@@ -782,7 +907,7 @@ fn launch_client_console<W: WindowsApi>(
     workspace_area: &workspace::WorkspaceArea,
     number_of_consoles: usize,
     aspect_ratio_adjustment: f64,
-) -> (HWND, HANDLE) {
+) -> (HWND, HANDLE, u32) {
     // The first argument must be `--` to ensure all following arguments are treated
     // as positional arguments and not as options if they start with `-`.
     let mut client_args: Vec<String> = Vec::new();
@@ -824,13 +949,30 @@ fn launch_client_console<W: WindowsApi>(
         number_of_consoles,
         aspect_ratio_adjustment,
     );
-    return (client_window_handle, process_handle);
+    return (
+        client_window_handle,
+        process_handle,
+        process_info.dwProcessId,
+    );
 }
 
-/// Wait for the named pipe server to connect, then forward serialized
-/// input records read from the broadcast channel to the named pipe server.
+/// Wait for the named pipe server to connect, authenticate the client by
+/// its process id, then forward serialized input records read from the
+/// broadcast channel to the named pipe server.
 ///
-/// If writing to the pipe fails the pipe is closed and the routine ends.
+/// Authentication: after [NamedPipeServer::connect] resolves, the client is
+/// expected to write its 4 byte little-endian process id into the pipe. The
+/// routine looks up the [Client] with that PID in the daemon's `clients`
+/// collection; if it is not found, the routine logs an error and panics —
+/// an unknown PID indicates either broken daemon bookkeeping or an
+/// unauthorized process connecting to the pipe, and is unrecoverable.
+///
+/// Forwarding: on every broadcast record, the routine matches on the
+/// [`PipeServerState`] cloned from the authenticated client; only
+/// [`PipeServerState::Enabled`] writes the record to the pipe. The keep-alive
+/// write stays unconditional so dead pipes are detected regardless of state.
+///
+/// If writing to the pipe fails the pipe is considered closed and the routine ends.
 /// To detect if a client is still alive even if we are currently
 /// not sending data, we send a "keep alive packet",
 /// [`SERIALIZED_INPUT_RECORD_0_LENGTH`] bytes of `1`s. If that fails, the routine ends.
@@ -843,15 +985,41 @@ fn launch_client_console<W: WindowsApi>(
 ///                which we get the serialize input records from the main
 ///                thread that are to be sent to the client via the named
 ///                pipe.
+/// * `clients`  - The daemon's collection of tracked clients, used to
+///                authenticate the connecting client by PID and to obtain
+///                the shared [`PipeServerState`] reference for this server.
+///
+/// # Panics
+///
+/// Panics if the connecting client sends a PID that is not present in
+/// `clients`.
 async fn named_pipe_server_routine(
     server: NamedPipeServer,
     receiver: &mut Receiver<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>,
+    clients: Arc<Mutex<Clients>>,
 ) {
     // wait for a client to connect
     server.connect().await.unwrap_or_else(|err| {
         error!("{}", err);
         panic!("Timeded out waiting for clients to connect to named pipe server",)
     });
+
+    // Authenticate the connecting client by reading its 4 byte PID.
+    let pid = read_client_pid(&server).await;
+    let pipe_server_state = match clients.lock().unwrap().get_by_pid(pid) {
+        Some(client) => Arc::clone(&client.pipe_server_state),
+        None => {
+            error!(
+                "Named pipe server received unknown PID {} during authentication",
+                pid
+            );
+            panic!(
+                "Unknown client PID {} connected to named pipe server — daemon bookkeeping broken or unauthorized process",
+                pid
+            );
+        }
+    };
+
     loop {
         let ser_input_record = match receiver.try_recv() {
             Ok(val) => val,
@@ -875,6 +1043,10 @@ async fn named_pipe_server_routine(
                 panic!("Failed to receive data from the Receiver");
             }
         };
+        // Only forward to the client if its pipe server state allows it.
+        match *pipe_server_state.lock().unwrap() {
+            PipeServerState::Enabled => {}
+        }
         loop {
             server.writable().await.unwrap_or_else(|err| {
                 error!("{}", err);
@@ -910,6 +1082,53 @@ async fn named_pipe_server_routine(
             }
         }
     }
+}
+
+/// Read the connecting client's 4 byte little-endian process id from the pipe.
+///
+/// Reads exactly 4 bytes from `server`, retrying on `WouldBlock`, and decodes
+/// them as a `u32`. Any non-recoverable I/O error panics, as a client that
+/// cannot send its PID cannot be authenticated and forwarding would be
+/// impossible.
+///
+/// # Arguments
+///
+/// * `server` - The connected named pipe server to read from.
+///
+/// # Returns
+///
+/// The process id sent by the client.
+///
+/// # Panics
+///
+/// Panics if the pipe is closed before 4 bytes can be read, or if any
+/// non-`WouldBlock` I/O error occurs.
+async fn read_client_pid(server: &NamedPipeServer) -> u32 {
+    let mut buf = [0u8; 4];
+    let mut read = 0usize;
+    while read < buf.len() {
+        server.readable().await.unwrap_or_else(|err| {
+            error!("{}", err);
+            panic!("Named pipe server is not readable for PID handshake",)
+        });
+        match server.try_read(&mut buf[read..]) {
+            Ok(0) => {
+                error!("Named pipe server closed before PID handshake completed");
+                panic!("Named pipe server closed before PID handshake completed",);
+            }
+            Ok(n) => {
+                read += n;
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                continue;
+            }
+            Err(e) => {
+                error!("{}", e);
+                panic!("Failed to read PID from named pipe client",);
+            }
+        }
+    }
+    return u32::from_le_bytes(buf);
 }
 
 /// Re-sizes and re-positions the given client window based on the total number of clients,
@@ -1079,7 +1298,7 @@ fn get_console_rect(
 ///                   background thread.
 fn ensure_client_z_order_in_sync_with_daemon<W: WindowsApi + Send + Sync + 'static>(
     windows_api: Arc<W>,
-    clients: Arc<Mutex<Vec<Client>>>,
+    clients: Arc<Mutex<Clients>>,
 ) {
     tokio::spawn(async move {
         let daemon_handle = get_console_window_wrapper(windows_api.as_ref());
@@ -1098,7 +1317,7 @@ fn ensure_client_z_order_in_sync_with_daemon<W: WindowsApi + Send + Sync + 'stat
             {
                 defer_windows(
                     windows_api.as_ref(),
-                    &clients.lock().unwrap(),
+                    clients.lock().unwrap().as_slice(),
                     &daemon_handle.hwdn,
                 );
             }
@@ -1126,6 +1345,8 @@ fn defer_windows<W: WindowsApi>(windows_api: &W, clients: &[Client], daemon_hand
         hostname: "root".to_owned(),
         window_handle: *daemon_handle,
         process_handle: HANDLE::default(),
+        process_id: 0,
+        pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
     }]) {
         let placement = match windows_api.get_window_placement(client.window_handle) {
             Ok(placement) => placement,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -18,7 +18,10 @@ use crate::utils::config::{Cluster, DaemonConfig};
 use crate::utils::debug::StringRepr;
 use crate::utils::windows::{clear_screen, set_console_color, WindowsApi};
 use crate::{
-    serde::{serialization::serialize_input_record_0, SERIALIZED_INPUT_RECORD_0_LENGTH},
+    serde::{
+        deserialization::deserialize_pid, serialization::serialize_input_record_0,
+        SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+    },
     spawn_console_process,
     utils::{
         constants::{PIPE_NAME, PKG_NAME},
@@ -67,8 +70,6 @@ const SENDER_CAPACITY: usize = 1024 * 1024;
 enum PipeServerState {
     /// Forward all input records to the client.
     Enabled,
-    // Future variants (e.g. Paused, Disabled) will expand the control surface
-    // without requiring architectural changes.
 }
 
 /// Representation of a client
@@ -156,26 +157,6 @@ impl Clients {
             .map(|&index| return &self.list[index]);
     }
 
-    /// Returns an iterator over the clients in insertion order.
-    fn iter(&self) -> std::slice::Iter<'_, Client> {
-        return self.list.iter();
-    }
-
-    /// Returns the clients as a slice in insertion order.
-    fn as_slice(&self) -> &[Client] {
-        return self.list.as_slice();
-    }
-
-    /// Returns the number of clients in the collection.
-    fn len(&self) -> usize {
-        return self.list.len();
-    }
-
-    /// Returns whether the collection is empty.
-    fn is_empty(&self) -> bool {
-        return self.list.is_empty();
-    }
-
     /// Retains only the clients for which the predicate returns `true`,
     /// rebuilding the PID index to reflect the new positions.
     ///
@@ -188,6 +169,30 @@ impl Clients {
         for (index, client) in self.list.iter().enumerate() {
             self.pid_index.insert(client.process_id, index);
         }
+    }
+}
+
+/// Allows treating a [`Clients`] collection as a `&[Client]`, so callers can
+/// use `&clients` where a slice is expected and get slice methods
+/// (`iter`, `len`, `is_empty`, ...) via deref coercion.
+impl std::ops::Deref for Clients {
+    type Target = [Client];
+
+    fn deref(&self) -> &[Client] {
+        return &self.list;
+    }
+}
+
+/// Consumes the collection and yields its clients in insertion order.
+///
+/// Used when merging a freshly launched [`Clients`] batch into an existing
+/// collection while also spawning per-client pipe servers.
+impl IntoIterator for Clients {
+    type Item = Client;
+    type IntoIter = std::vec::IntoIter<Client>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        return self.list.into_iter();
     }
 }
 
@@ -303,22 +308,19 @@ impl<'a> Daemon<'a> {
             CONSOLE_CHARACTER_ATTRIBUTES(self.config.console_color),
         );
 
-        let launched = launch_clients(
-            windows_api,
-            self.hosts.to_vec(),
-            &self.username,
-            self.port,
-            self.debug,
-            &workspace_area,
-            self.config.aspect_ratio_adjustement,
-            0,
-        )
-        .await;
-        let mut clients_collection = Clients::new();
-        for client in launched.into_iter() {
-            clients_collection.push(client);
-        }
-        let mut clients = Arc::new(Mutex::new(clients_collection));
+        let mut clients = Arc::new(Mutex::new(
+            launch_clients(
+                windows_api,
+                self.hosts.to_vec(),
+                &self.username,
+                self.port,
+                self.debug,
+                &workspace_area,
+                self.config.aspect_ratio_adjustement,
+                0,
+            )
+            .await,
+        ));
 
         // Now that all clients started, focus the daemon console again.
         let daemon_console = windows_api.get_console_window();
@@ -512,7 +514,7 @@ impl<'a> Daemon<'a> {
                 (VK_R, 0) => {
                     self.rearrange_client_windows(
                         windows_api,
-                        clients.lock().unwrap().as_slice(),
+                        &clients.lock().unwrap(),
                         workspace_area,
                     );
                     self.arrange_daemon_console(windows_api, workspace_area);
@@ -568,7 +570,7 @@ impl<'a> Daemon<'a> {
                     toggle_processed_input_mode(windows_api); // Re-disable processed input mode.
                     self.rearrange_client_windows(
                         windows_api,
-                        clients.lock().unwrap().as_slice(),
+                        &clients.lock().unwrap(),
                         workspace_area,
                     );
                     self.arrange_daemon_console(windows_api, workspace_area);
@@ -810,8 +812,8 @@ pub fn resolve_cluster_tags<'a>(hosts: Vec<&'a str>, clusters: &'a [Cluster]) ->
 ///
 /// # Returns
 ///
-/// A mapping from the order a client console window was launched at
-/// in relation to the other client windows and the clients console window handle.
+/// A [`Clients`] collection preserving the launch order and indexed by
+/// process id for pipe-server correlation.
 async fn launch_clients<W: WindowsApi + 'static + Clone>(
     windows_api: &W,
     hosts: Vec<String>,
@@ -821,7 +823,7 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
     workspace_area: &workspace::WorkspaceArea,
     aspect_ratio_adjustment: f64,
     index_offset: usize,
-) -> Vec<Client> {
+) -> Clients {
     let len_hosts = hosts.len();
     let _guard = WindowsSettingsDefaultTerminalApplicationGuard::new();
 
@@ -876,10 +878,11 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
     // Sort results by index to maintain order
     results.sort_by_key(|(index, _)| return *index);
 
-    return results
-        .into_iter()
-        .map(|(_, client)| return client)
-        .collect();
+    let mut clients = Clients::new();
+    for (_, client) in results.into_iter() {
+        clients.push(client);
+    }
+    return clients;
 }
 
 /// Launchs a `client` console process with its own window with the given
@@ -1116,17 +1119,15 @@ async fn named_pipe_server_routine(
 /// Panics if the pipe is closed before 4 bytes can be read, or if any
 /// non-`WouldBlock` I/O error occurs.
 async fn read_client_pid(server: &NamedPipeServer) -> u32 {
-    let mut buf = [0u8; 4];
+    let mut buf = [0u8; SERIALIZED_PID_LENGTH];
     let mut read = 0usize;
-    while read < buf.len() {
+    while read < SERIALIZED_PID_LENGTH {
         server.readable().await.unwrap_or_else(|err| {
-            error!("{}", err);
-            panic!("Named pipe server is not readable for PID handshake",)
+            panic!("Named pipe server is not readable for PID handshake: {err}")
         });
         match server.try_read(&mut buf[read..]) {
             Ok(0) => {
-                error!("Named pipe server closed before PID handshake completed");
-                panic!("Named pipe server closed before PID handshake completed",);
+                panic!("Named pipe server closed before PID handshake completed");
             }
             Ok(n) => {
                 read += n;
@@ -1135,12 +1136,11 @@ async fn read_client_pid(server: &NamedPipeServer) -> u32 {
                 continue;
             }
             Err(e) => {
-                error!("{}", e);
-                panic!("Failed to read PID from named pipe client",);
+                panic!("Failed to read PID from named pipe client: {e}");
             }
         }
     }
-    return u32::from_le_bytes(buf);
+    return deserialize_pid(&buf);
 }
 
 /// Re-sizes and re-positions the given client window based on the total number of clients,
@@ -1329,7 +1329,7 @@ fn ensure_client_z_order_in_sync_with_daemon<W: WindowsApi + Send + Sync + 'stat
             {
                 defer_windows(
                     windows_api.as_ref(),
-                    clients.lock().unwrap().as_slice(),
+                    &clients.lock().unwrap(),
                     &daemon_handle.hwdn,
                 );
             }

--- a/src/serde/deserialization.rs
+++ b/src/serde/deserialization.rs
@@ -3,6 +3,8 @@ use windows::Win32::{
     System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0},
 };
 
+use crate::serde::SERIALIZED_PID_LENGTH;
+
 /// Deserialize a [KEY_EVENT_RECORD_0] from a u8 slice using custom binary format.
 ///
 /// Tries to read a u16 from the given slice in little-endian format.
@@ -48,4 +50,10 @@ pub fn deserialize_input_record_0(slice: &[u8]) -> INPUT_RECORD_0 {
     return INPUT_RECORD_0 {
         KeyEvent: key_event,
     };
+}
+
+/// Deserialize a process id from its little-endian byte representation used
+/// by the named-pipe PID handshake.
+pub fn deserialize_pid(bytes: &[u8; SERIALIZED_PID_LENGTH]) -> u32 {
+    return u32::from_le_bytes(*bytes);
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -14,6 +14,10 @@ pub mod serialization;
 /// [1]: https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/Console/union.INPUT_RECORD_0.html
 pub const SERIALIZED_INPUT_RECORD_0_LENGTH: usize = 13;
 
+/// Length of a serialized process id exchanged during the named-pipe PID
+/// handshake. Matches the size of a `u32` on all supported platforms.
+pub const SERIALIZED_PID_LENGTH: usize = 4;
+
 #[cfg(test)]
 #[path = "../tests/serde/test_mod.rs"]
 mod test_mod;

--- a/src/serde/serialization.rs
+++ b/src/serde/serialization.rs
@@ -1,6 +1,6 @@
 use windows::Win32::System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0};
 
-use crate::serde::SERIALIZED_INPUT_RECORD_0_LENGTH;
+use crate::serde::{SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH};
 
 /// Serialize a [KEY_EVENT_RECORD_0] into a `Vec<u8>` using custom binary format.
 ///
@@ -42,4 +42,10 @@ pub fn serialize_key_event_record(record: &KEY_EVENT_RECORD) -> Vec<u8> {
 /// Panics if the [INPUT_RECORD_0] is not a `KeyEvent`.
 pub fn serialize_input_record_0(record: &INPUT_RECORD_0) -> Vec<u8> {
     return serialize_key_event_record(&unsafe { record.KeyEvent });
+}
+
+/// Serialize a process id into its little-endian byte representation used by
+/// the named-pipe PID handshake.
+pub fn serialize_pid(pid: u32) -> [u8; SERIALIZED_PID_LENGTH] {
+    return pid.to_le_bytes();
 }

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -543,9 +543,10 @@ async fn test_send_pid_handshake() -> Result<(), Box<dyn std::error::Error>> {
     server.connect().await?;
 
     // Read the 4-byte PID from the server side.
-    let mut buf = [0u8; 4];
+    use crate::serde::{deserialization::deserialize_pid, SERIALIZED_PID_LENGTH};
+    let mut buf = [0u8; SERIALIZED_PID_LENGTH];
     let mut total_read = 0;
-    while total_read < buf.len() {
+    while total_read < SERIALIZED_PID_LENGTH {
         server.readable().await?;
         match server.try_read(&mut buf[total_read..]) {
             Ok(0) => {
@@ -557,7 +558,7 @@ async fn test_send_pid_handshake() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    assert_eq!(buf, std::process::id().to_le_bytes());
+    assert_eq!(deserialize_pid(&buf), std::process::id());
     handshake.await?;
     return Ok(());
 }

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -11,7 +11,7 @@ use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 
 use crate::client::{
     build_ssh_arguments, is_alt_shift_c_combination, is_keep_alive_packet, resolve_username,
-    write_console_input,
+    send_pid_handshake, write_console_input,
 };
 use crate::serde::SERIALIZED_INPUT_RECORD_0_LENGTH;
 use crate::utils::config::ClientConfig;
@@ -515,4 +515,41 @@ fn test_write_console_input() {
         // Execute the function under test
         write_console_input(&mock_api, test_input_record);
     }
+}
+
+#[tokio::test]
+async fn test_send_pid_handshake() -> Result<(), Box<dyn std::error::Error>> {
+    use std::io;
+    use tokio::net::windows::named_pipe::{ClientOptions, PipeMode, ServerOptions};
+
+    use crate::utils::constants::PIPE_NAME;
+
+    let server = ServerOptions::new()
+        .access_inbound(true)
+        .pipe_mode(PipeMode::Message)
+        .create(PIPE_NAME)?;
+    let client = ClientOptions::new().open(PIPE_NAME)?;
+
+    // Run the handshake concurrently with reading from the server side.
+    let handshake = tokio::spawn(async move {
+        send_pid_handshake(&client).await;
+    });
+
+    server.connect().await?;
+
+    // Read the 4-byte PID from the server side.
+    let mut buf = [0u8; 4];
+    let mut total_read = 0;
+    while total_read < buf.len() {
+        server.readable().await?;
+        match server.try_read(&mut buf[total_read..]) {
+            Ok(n) => total_read += n,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    assert_eq!(buf, std::process::id().to_le_bytes());
+    handshake.await?;
+    return Ok(());
 }

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -522,13 +522,18 @@ async fn test_send_pid_handshake() -> Result<(), Box<dyn std::error::Error>> {
     use std::io;
     use tokio::net::windows::named_pipe::{ClientOptions, PipeMode, ServerOptions};
 
-    use crate::utils::constants::PIPE_NAME;
+    // Use a per-test unique pipe name so parallel test runs don't collide
+    // on the global PIPE_NAME.
+    let pipe_name = format!(
+        r"\\.\pipe\csshw-test-send-pid-handshake-{}",
+        std::process::id()
+    );
 
     let server = ServerOptions::new()
         .access_inbound(true)
         .pipe_mode(PipeMode::Message)
-        .create(PIPE_NAME)?;
-    let client = ClientOptions::new().open(PIPE_NAME)?;
+        .create(&pipe_name)?;
+    let client = ClientOptions::new().open(&pipe_name)?;
 
     // Run the handshake concurrently with reading from the server side.
     let handshake = tokio::spawn(async move {
@@ -543,6 +548,9 @@ async fn test_send_pid_handshake() -> Result<(), Box<dyn std::error::Error>> {
     while total_read < buf.len() {
         server.readable().await?;
         match server.try_read(&mut buf[total_read..]) {
+            Ok(0) => {
+                return Err("pipe closed before PID handshake completed".into());
+            }
             Ok(n) => total_read += n,
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
             Err(e) => return Err(e.into()),

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -129,7 +129,7 @@ mod daemon_test {
             .pipe_mode(PipeMode::Message)
             .create(PIPE_NAME)?;
         let named_pipe_client = ClientOptions::new().open(PIPE_NAME)?;
-        // Build a Clients collection containing the test PID so authentication succeeds.
+        // Build a Clients collection containing the test PID so PID correlation succeeds.
         let clients = make_clients_with_pid(TEST_PID);
         // Complete the PID handshake expected by the pipe server routine.
         send_pid(&named_pipe_client, TEST_PID).await?;
@@ -197,7 +197,7 @@ mod daemon_test {
             .pipe_mode(PipeMode::Message)
             .create(PIPE_NAME)?;
         let named_pipe_client = ClientOptions::new().open(PIPE_NAME)?;
-        // Build a Clients collection containing the test PID so authentication succeeds.
+        // Build a Clients collection containing the test PID so PID correlation succeeds.
         let clients = make_clients_with_pid(TEST_PID);
         // Complete the PID handshake expected by the pipe server routine.
         send_pid(&named_pipe_client, TEST_PID).await?;
@@ -247,6 +247,9 @@ mod daemon_test {
     {
         const REGISTERED_PID: u32 = 33333;
         const SENT_PID: u32 = 44444;
+        // Use a per-test unique pipe name so parallel test runs don't collide
+        // on the global PIPE_NAME.
+        let pipe_name = format!(r"\\.\pipe\csshw-test-pid-mismatch-{}", std::process::id());
         // Setup sender and receiver
         let (_sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
             SERIALIZED_INPUT_RECORD_0_LENGTH,
@@ -255,8 +258,8 @@ mod daemon_test {
             .access_inbound(true)
             .access_outbound(true)
             .pipe_mode(PipeMode::Message)
-            .create(PIPE_NAME)?;
-        let named_pipe_client = ClientOptions::new().open(PIPE_NAME)?;
+            .create(&pipe_name)?;
+        let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
         // Daemon only knows about REGISTERED_PID, but the client will send SENT_PID.
         let clients = make_clients_with_pid(REGISTERED_PID);
         send_pid(&named_pipe_client, SENT_PID).await?;
@@ -272,6 +275,12 @@ mod daemon_test {
     async fn test_named_pipe_server_routine_client_closes_before_pid_handshake(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const TEST_PID: u32 = 55555;
+        // Use a per-test unique pipe name so parallel test runs don't collide
+        // on the global PIPE_NAME.
+        let pipe_name = format!(
+            r"\\.\pipe\csshw-test-client-closes-before-pid-{}",
+            std::process::id()
+        );
         let (_sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
             SERIALIZED_INPUT_RECORD_0_LENGTH,
         );
@@ -279,8 +288,8 @@ mod daemon_test {
             .access_inbound(true)
             .access_outbound(true)
             .pipe_mode(PipeMode::Message)
-            .create(PIPE_NAME)?;
-        let named_pipe_client = ClientOptions::new().open(PIPE_NAME)?;
+            .create(&pipe_name)?;
+        let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
         let clients = make_clients_with_pid(TEST_PID);
         // Drop the client immediately without sending any PID bytes.
         drop(named_pipe_client);

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -16,7 +16,9 @@ mod daemon_test {
             named_pipe_server_routine, resolve_cluster_tags, Client, Clients, HWNDWrapper,
             PipeServerState,
         },
-        serde::SERIALIZED_INPUT_RECORD_0_LENGTH,
+        serde::{
+            serialization::serialize_pid, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+        },
         utils::{config::Cluster, constants::PIPE_NAME},
     };
 
@@ -24,9 +26,9 @@ mod daemon_test {
     ///
     /// Mirrors the client-side PID handshake used by [`crate::client`].
     async fn send_pid(client: &NamedPipeClient, pid: u32) -> io::Result<()> {
-        let bytes = pid.to_le_bytes();
+        let bytes = serialize_pid(pid);
         let mut written = 0usize;
-        while written < bytes.len() {
+        while written < SERIALIZED_PID_LENGTH {
             client.writable().await?;
             match client.try_write(&bytes[written..]) {
                 Ok(0) => return Err(io::Error::other("pipe closed before handshake")),
@@ -367,11 +369,8 @@ mod daemon_test {
         assert!(clients.get_by_pid(2000).is_none());
         assert_eq!(clients.get_by_pid(1000).unwrap().hostname, "host-a");
         assert_eq!(clients.get_by_pid(3000).unwrap().hostname, "host-c");
-        let hostnames_after_retain: Vec<&str> = clients
-            .as_slice()
-            .iter()
-            .map(|c| return c.hostname.as_str())
-            .collect();
+        let hostnames_after_retain: Vec<&str> =
+            clients.iter().map(|c| return c.hostname.as_str()).collect();
         assert_eq!(hostnames_after_retain, vec!["host-a", "host-c"]);
     }
 }

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -183,7 +183,7 @@ mod daemon_test {
     }
 
     #[tokio::test]
-    async fn test_named_pipe_server_routine_sender_closes_unexpectidly(
+    async fn test_named_pipe_server_routine_sender_closes_unexpectedly(
     ) -> Result<(), Box<dyn std::error::Error>> {
         const TEST_PID: u32 = 22222;
         // Setup sender and receiver
@@ -263,7 +263,31 @@ mod daemon_test {
         let future = tokio::spawn(async move {
             named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
         });
-        // Unknown PID is unrecoverable — the routine must panic.
+        // Unknown PID is unrecoverable — the routine must panic (exits the daemon in production).
+        assert!(future.await.unwrap_err().is_panic());
+        return Ok(());
+    }
+
+    #[tokio::test]
+    async fn test_named_pipe_server_routine_client_closes_before_pid_handshake(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_PID: u32 = 55555;
+        let (_sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
+            SERIALIZED_INPUT_RECORD_0_LENGTH,
+        );
+        let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
+            .access_outbound(true)
+            .pipe_mode(PipeMode::Message)
+            .create(PIPE_NAME)?;
+        let named_pipe_client = ClientOptions::new().open(PIPE_NAME)?;
+        let clients = make_clients_with_pid(TEST_PID);
+        // Drop the client immediately without sending any PID bytes.
+        drop(named_pipe_client);
+        let future = tokio::spawn(async move {
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
+        });
+        // Pipe closed before handshake completed — the routine must panic.
         assert!(future.await.unwrap_err().is_panic());
         return Ok(());
     }

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -269,6 +269,23 @@ mod daemon_test {
     }
 
     #[test]
+    #[should_panic(expected = "Duplicate client PID")]
+    fn test_clients_push_duplicate_pid_panics() {
+        let mut clients = Clients::new();
+        let make_client = |pid: u32| {
+            return Client {
+                hostname: "host".to_owned(),
+                window_handle: HWND(std::ptr::null_mut()),
+                process_handle: HANDLE::default(),
+                process_id: pid,
+                pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+            };
+        };
+        clients.push(make_client(1000));
+        clients.push(make_client(1000)); // duplicate — must panic
+    }
+
+    #[test]
     fn test_clients_push_and_lookup() {
         let mut clients = Clients::new();
         assert!(clients.is_empty());

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -1,17 +1,57 @@
 mod daemon_test {
-    use std::{ffi::c_void, io};
+    use std::{
+        ffi::c_void,
+        io,
+        sync::{Arc, Mutex},
+    };
 
     use tokio::{
-        net::windows::named_pipe::{ClientOptions, PipeMode, ServerOptions},
+        net::windows::named_pipe::{ClientOptions, NamedPipeClient, PipeMode, ServerOptions},
         sync::broadcast,
     };
-    use windows::Win32::Foundation::HWND;
+    use windows::Win32::Foundation::{HANDLE, HWND};
 
     use crate::{
-        daemon::{named_pipe_server_routine, resolve_cluster_tags, HWNDWrapper},
+        daemon::{
+            named_pipe_server_routine, resolve_cluster_tags, Client, Clients, HWNDWrapper,
+            PipeServerState,
+        },
         serde::SERIALIZED_INPUT_RECORD_0_LENGTH,
         utils::{config::Cluster, constants::PIPE_NAME},
     };
+
+    /// Send `pid` as a 4 byte little-endian sequence to the pipe server.
+    ///
+    /// Mirrors the client-side PID handshake used by [`crate::client`].
+    async fn send_pid(client: &NamedPipeClient, pid: u32) -> io::Result<()> {
+        let bytes = pid.to_le_bytes();
+        let mut written = 0usize;
+        while written < bytes.len() {
+            client.writable().await?;
+            match client.try_write(&bytes[written..]) {
+                Ok(0) => return Err(io::Error::other("pipe closed before handshake")),
+                Ok(n) => written += n,
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        return Ok(());
+    }
+
+    /// Construct a [`Clients`] collection holding a single [`Client`] whose
+    /// `process_id` equals `pid`. All other fields carry sentinel values as
+    /// they are unused by the pipe server routine.
+    fn make_clients_with_pid(pid: u32) -> Arc<Mutex<Clients>> {
+        let mut clients = Clients::new();
+        clients.push(Client {
+            hostname: format!("test-host-{pid}"),
+            window_handle: HWND(std::ptr::null_mut()),
+            process_handle: HANDLE::default(),
+            process_id: pid,
+            pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+        });
+        return Arc::new(Mutex::new(clients));
+    }
 
     #[test]
     fn test_hwnd_wrapper_equality() {
@@ -77,19 +117,25 @@ mod daemon_test {
 
     #[tokio::test]
     async fn test_named_pipe_server_routine() -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_PID: u32 = 11111;
         // Setup sender and receiver
         let (sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
             SERIALIZED_INPUT_RECORD_0_LENGTH,
         );
         // and named pipe server and client
         let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
             .access_outbound(true)
             .pipe_mode(PipeMode::Message)
             .create(PIPE_NAME)?;
         let named_pipe_client = ClientOptions::new().open(PIPE_NAME)?;
+        // Build a Clients collection containing the test PID so authentication succeeds.
+        let clients = make_clients_with_pid(TEST_PID);
+        // Complete the PID handshake expected by the pipe server routine.
+        send_pid(&named_pipe_client, TEST_PID).await?;
         // Spawn named pipe server routine
         let future = tokio::spawn(async move {
-            named_pipe_server_routine(named_pipe_server, &mut receiver).await;
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
         });
 
         let mut keep_alive_received = false;
@@ -139,19 +185,25 @@ mod daemon_test {
     #[tokio::test]
     async fn test_named_pipe_server_routine_sender_closes_unexpectidly(
     ) -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_PID: u32 = 22222;
         // Setup sender and receiver
         let (sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
             SERIALIZED_INPUT_RECORD_0_LENGTH,
         );
         // and named pipe server and client
         let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
             .access_outbound(true)
             .pipe_mode(PipeMode::Message)
             .create(PIPE_NAME)?;
         let named_pipe_client = ClientOptions::new().open(PIPE_NAME)?;
+        // Build a Clients collection containing the test PID so authentication succeeds.
+        let clients = make_clients_with_pid(TEST_PID);
+        // Complete the PID handshake expected by the pipe server routine.
+        send_pid(&named_pipe_client, TEST_PID).await?;
         // Spawn named pipe server routine
         let future = tokio::spawn(async move {
-            named_pipe_server_routine(named_pipe_server, &mut receiver).await;
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
         });
         // Send data to the routine
         sender.send([2; SERIALIZED_INPUT_RECORD_0_LENGTH])?;
@@ -188,5 +240,88 @@ mod daemon_test {
         // This is unexpected, we should panic
         assert!(future.await.unwrap_err().is_panic());
         return Ok(());
+    }
+
+    #[tokio::test]
+    async fn test_named_pipe_server_routine_pid_mismatch() -> Result<(), Box<dyn std::error::Error>>
+    {
+        const REGISTERED_PID: u32 = 33333;
+        const SENT_PID: u32 = 44444;
+        // Setup sender and receiver
+        let (_sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
+            SERIALIZED_INPUT_RECORD_0_LENGTH,
+        );
+        let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
+            .access_outbound(true)
+            .pipe_mode(PipeMode::Message)
+            .create(PIPE_NAME)?;
+        let named_pipe_client = ClientOptions::new().open(PIPE_NAME)?;
+        // Daemon only knows about REGISTERED_PID, but the client will send SENT_PID.
+        let clients = make_clients_with_pid(REGISTERED_PID);
+        send_pid(&named_pipe_client, SENT_PID).await?;
+        let future = tokio::spawn(async move {
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
+        });
+        // Unknown PID is unrecoverable — the routine must panic.
+        assert!(future.await.unwrap_err().is_panic());
+        return Ok(());
+    }
+
+    #[test]
+    fn test_clients_push_and_lookup() {
+        let mut clients = Clients::new();
+        assert!(clients.is_empty());
+        assert_eq!(clients.len(), 0);
+
+        let client_a = Client {
+            hostname: "host-a".to_owned(),
+            window_handle: HWND(std::ptr::null_mut()),
+            process_handle: HANDLE::default(),
+            process_id: 1000,
+            pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+        };
+        let client_b = Client {
+            hostname: "host-b".to_owned(),
+            window_handle: HWND(std::ptr::null_mut()),
+            process_handle: HANDLE::default(),
+            process_id: 2000,
+            pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+        };
+        let client_c = Client {
+            hostname: "host-c".to_owned(),
+            window_handle: HWND(std::ptr::null_mut()),
+            process_handle: HANDLE::default(),
+            process_id: 3000,
+            pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+        };
+
+        clients.push(client_a);
+        clients.push(client_b);
+        clients.push(client_c);
+
+        assert_eq!(clients.len(), 3);
+        assert!(!clients.is_empty());
+        assert_eq!(clients.get_by_pid(1000).unwrap().hostname, "host-a");
+        assert_eq!(clients.get_by_pid(2000).unwrap().hostname, "host-b");
+        assert_eq!(clients.get_by_pid(3000).unwrap().hostname, "host-c");
+        assert!(clients.get_by_pid(9999).is_none());
+
+        // iter preserves insertion order
+        let hostnames: Vec<&str> = clients.iter().map(|c| return c.hostname.as_str()).collect();
+        assert_eq!(hostnames, vec!["host-a", "host-b", "host-c"]);
+
+        // retain rebuilds the PID index so lookups remain consistent
+        clients.retain(|client| return client.process_id != 2000);
+        assert_eq!(clients.len(), 2);
+        assert!(clients.get_by_pid(2000).is_none());
+        assert_eq!(clients.get_by_pid(1000).unwrap().hostname, "host-a");
+        assert_eq!(clients.get_by_pid(3000).unwrap().hostname, "host-c");
+        let hostnames_after_retain: Vec<&str> = clients
+            .as_slice()
+            .iter()
+            .map(|c| return c.hostname.as_str())
+            .collect();
+        assert_eq!(hostnames_after_retain, vec!["host-a", "host-c"]);
     }
 }

--- a/src/tests/serde/test_mod.rs
+++ b/src/tests/serde/test_mod.rs
@@ -5,7 +5,10 @@ use windows::Win32::{
     System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0},
 };
 
-use crate::serde::SERIALIZED_INPUT_RECORD_0_LENGTH;
+use crate::serde::{SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH};
+
+const EXPECTED_PID: u32 = 0x04030201;
+const EXPECTED_PID_SEQUENCE: [u8; SERIALIZED_PID_LENGTH] = [0x01, 0x02, 0x03, 0x04];
 
 const EXPECTED_KEY_EVENT_RECORD_0: KEY_EVENT_RECORD_0 = KEY_EVENT_RECORD_0 { UnicodeChar: 61u16 };
 const EXPECTED_KEY_EVENT_RECORD: KEY_EVENT_RECORD = KEY_EVENT_RECORD {
@@ -63,6 +66,11 @@ mod serialization_test {
             EXPECTED_KEY_EVENT_RECORD_SEQUENCE.to_vec()
         )
     }
+
+    #[test]
+    fn test_serialize_pid() {
+        assert_eq!(serialize_pid(EXPECTED_PID), EXPECTED_PID_SEQUENCE);
+    }
 }
 
 mod deserialization_test {
@@ -118,5 +126,17 @@ mod deserialization_test {
             deserialize_input_record_0(&EXPECTED_INPUT_RECORD_0_SEQUENCE)
                 .equals(EXPECTED_INPUT_RECORD_0),
         )
+    }
+
+    #[test]
+    fn test_deserialize_pid() {
+        assert_eq!(deserialize_pid(&EXPECTED_PID_SEQUENCE), EXPECTED_PID);
+    }
+
+    #[test]
+    fn test_pid_round_trip() {
+        use crate::serde::serialization::serialize_pid;
+        let pid = 0xDEADBEEFu32;
+        assert_eq!(deserialize_pid(&serialize_pid(pid)), pid);
     }
 }


### PR DESCRIPTION
Client writes its PID on pipe connect; the daemon's pipe server task looks it up in a new Clients collection to bind itself to the matching Client's PipeServerState, laying groundwork for per-client forwarding control. Unknown PIDs panic as unrecoverable.

GitHub: #151 