### PR TITLE
Bump Playwright from 1.49.1 to 1.59.1 (CVE-2025-59288)

### DIFF
--- a/xtask/social-preview/README.md
+++ b/xtask/social-preview/README.md
@@ -69,7 +69,7 @@ together in the same commit. The current pinning is:
 
 | Docker tag                                        | `@playwright/test` |
 | ------------------------------------------------- | ------------------ |
-| `mcr.microsoft.com/playwright:v1.49.1-noble`      | `1.49.1`           |
+| `mcr.microsoft.com/playwright:v1.59.1-noble`      | `1.59.1`           |
 
 ## Template authoring
 

--- a/xtask/social-preview/package-lock.json
+++ b/xtask/social-preview/package-lock.json
@@ -8,16 +8,16 @@
       "name": "csshw-social-preview",
       "version": "0.0.0",
       "dependencies": {
-        "@playwright/test": "1.49.1"
+        "@playwright/test": "1.59.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -41,12 +41,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/xtask/social-preview/package.json
+++ b/xtask/social-preview/package.json
@@ -8,6 +8,6 @@
     "generate": "node generate.mjs"
   },
   "dependencies": {
-    "@playwright/test": "1.49.1"
+    "@playwright/test": "1.59.1"
   }
 }

--- a/xtask/src/social_preview.rs
+++ b/xtask/src/social_preview.rs
@@ -15,11 +15,11 @@ use anyhow::{bail, Context, Result};
 
 /// Pinned Playwright Docker image tag.
 ///
-/// The numeric portion (e.g. `v1.49.1`) must match `@playwright/test` in
+/// The numeric portion (e.g. `v1.59.1`) must match `@playwright/test` in
 /// `xtask/social-preview/package.json`. Playwright refuses to run when
 /// these versions diverge, so bump both in the same commit. See
 /// `xtask/social-preview/README.md` for details.
-const PLAYWRIGHT_IMAGE: &str = "mcr.microsoft.com/playwright:v1.49.1-noble";
+const PLAYWRIGHT_IMAGE: &str = "mcr.microsoft.com/playwright:v1.59.1-noble";
 
 /// Default output path for the generated PNG, relative to the workspace
 /// root. Lives under `target/` so it shares Cargo's build-artifact


### PR DESCRIPTION
## Summary
- Upgrades Playwright from 1.49.1 to 1.59.1 to fix **CVE-2025-59288** (high severity — browser installer scripts used `curl -k`, disabling SSL certificate verification)
- Updates Docker image tag, npm dependency, lockfile, and version coupling docs in lockstep
- Resolves [Dependabot alert #7](https://github.com/whme/csshw/security/dependabot/7)

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo lint` — no warnings
- [x] `cargo test` — 120 tests pass
- [x] `cargo doc-tests` — 12 doc-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)