### PR TITLE
Improve social preview design

### DIFF
--- a/templates/social-preview.html
+++ b/templates/social-preview.html
@@ -177,7 +177,7 @@
         </div>
       </div>
       <div class="card-right">
-        <img class="logo" src="{{LOGO_DATA_URI}}" alt="logo" />
+        <img class="logo" src="{{LOGO_DATA_URI}}" alt="{{REPO_NAME}} logo" />
       </div>
     </div>
     <script type="application/json" id="languages">

--- a/templates/social-preview.html
+++ b/templates/social-preview.html
@@ -36,8 +36,16 @@
         width: 1280px;
         height: 640px;
         font-family: "DejaVu Sans Mono", "Courier New", monospace;
-        color: #0d1117;
-        background: #ffffff;
+        color: #e6edf3;
+        background:
+          repeating-linear-gradient(
+            0deg,
+            transparent,
+            transparent 3px,
+            rgba(255, 255, 255, 0.015) 3px,
+            rgba(255, 255, 255, 0.015) 4px
+          ),
+          linear-gradient(135deg, #0d1117 0%, #161b22 100%);
         overflow: hidden;
       }
       .card {
@@ -46,71 +54,80 @@
         height: 640px;
         padding: 56px 72px;
         display: grid;
-        grid-template-rows: auto 1fr auto;
+        grid-template-columns: 3fr 2fr;
+        grid-template-rows: 1fr;
+        gap: 48px;
+      }
+      .card-left {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
         gap: 24px;
       }
-      .header {
+      .card-right {
         display: flex;
         align-items: center;
-        gap: 32px;
+        justify-content: center;
+        background: radial-gradient(
+          circle at center,
+          rgba(197, 15, 31, 0.06) 0%,
+          transparent 70%
+        );
       }
       .logo {
-        width: 128px;
-        height: 128px;
-        flex: 0 0 128px;
+        width: 420px;
+        height: 420px;
       }
       .titles .repo-name {
-        font-size: 72px;
+        font-size: 60px;
         font-weight: 700;
         line-height: 1;
       }
       .titles .repo-full {
-        font-size: 28px;
-        color: #57606a;
+        font-size: 24px;
+        color: #8b949e;
         margin-top: 8px;
       }
       .description {
-        font-size: 32px;
+        font-size: 28px;
         line-height: 1.3;
-        color: #24292f;
-        align-self: center;
+        color: #c9d1d9;
       }
       .footer {
         display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 32px;
+        flex-direction: column;
+        gap: 16px;
+        margin-top: 8px;
       }
       .stars {
-        font-size: 36px;
+        font-size: 32px;
         font-weight: 700;
         display: flex;
         align-items: center;
-        gap: 12px;
+        gap: 10px;
       }
       .star-icon {
-        width: 40px;
-        height: 40px;
+        width: 36px;
+        height: 36px;
       }
       .languages {
-        flex: 1;
-        max-width: 760px;
+        width: 100%;
       }
       .language-bar {
         display: flex;
         width: 100%;
-        height: 16px;
-        border-radius: 8px;
+        height: 12px;
+        border-radius: 6px;
         overflow: hidden;
-        background: #ededed;
+        background: #30363d;
       }
       .language-legend {
-        margin-top: 12px;
+        margin-top: 10px;
         display: flex;
         flex-wrap: wrap;
-        gap: 16px;
-        font-size: 18px;
-        color: #57606a;
+        gap: 14px;
+        font-size: 20px;
+        color: #8b949e;
       }
       .language-legend .entry {
         display: inline-flex;
@@ -118,42 +135,49 @@
         gap: 6px;
       }
       .language-legend .swatch {
-        width: 12px;
-        height: 12px;
+        width: 14px;
+        height: 14px;
         border-radius: 2px;
+        display: inline-block;
+      }
+      .language-legend .lang-icon {
+        width: 20px;
+        height: 20px;
         display: inline-block;
       }
     </style>
   </head>
   <body>
     <div class="card">
-      <div class="header">
-        <img class="logo" src="{{LOGO_DATA_URI}}" alt="logo" />
+      <div class="card-left">
         <div class="titles">
           <div class="repo-name">{{REPO_NAME}}</div>
           <div class="repo-full">{{REPO_FULL_NAME}}</div>
         </div>
+        <div class="description">{{REPO_DESCRIPTION}}</div>
+        <div class="footer">
+          <div class="stars">
+            <svg
+              class="star-icon"
+              viewBox="0 0 16 16"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path
+                fill="#d4a72c"
+                d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"
+              />
+            </svg>
+            <span>{{STAR_COUNT}}</span>
+          </div>
+          <div class="languages">
+            <div class="language-bar" id="language-bar"></div>
+            <div class="language-legend" id="language-legend"></div>
+          </div>
+        </div>
       </div>
-      <div class="description">{{REPO_DESCRIPTION}}</div>
-      <div class="footer">
-        <div class="stars">
-          <svg
-            class="star-icon"
-            viewBox="0 0 16 16"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <path
-              fill="#d4a72c"
-              d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"
-            />
-          </svg>
-          <span>{{STAR_COUNT}}</span>
-        </div>
-        <div class="languages">
-          <div class="language-bar" id="language-bar"></div>
-          <div class="language-legend" id="language-legend"></div>
-        </div>
+      <div class="card-right">
+        <img class="logo" src="{{LOGO_DATA_URI}}" alt="logo" />
       </div>
     </div>
     <script type="application/json" id="languages">
@@ -187,10 +211,18 @@
 
           var entry = document.createElement("span");
           entry.className = "entry";
-          var swatch = document.createElement("span");
-          swatch.className = "swatch";
-          swatch.style.background = l.color;
-          entry.appendChild(swatch);
+          if (l.iconDataUri) {
+            var icon = document.createElement("img");
+            icon.className = "lang-icon";
+            icon.src = l.iconDataUri;
+            icon.alt = l.name;
+            entry.appendChild(icon);
+          } else {
+            var swatch = document.createElement("span");
+            swatch.className = "swatch";
+            swatch.style.background = l.color;
+            entry.appendChild(swatch);
+          }
           entry.appendChild(
             document.createTextNode(l.name + " " + l.pct.toFixed(1) + "%"),
           );

--- a/xtask/social-preview/generate.mjs
+++ b/xtask/social-preview/generate.mjs
@@ -52,10 +52,11 @@ const LINGUIST_COLORS_URL =
 const UNKNOWN_LANGUAGE_COLOR = "#cccccc";
 const OTHER_BUCKET_COLOR = "#ededed";
 const VIEWPORT = { width: 1280, height: 640 };
-// Final PNG matches GitHub's recommended social preview size of
-// 1280×640 (see https://docs.github.com/en/repositories/managing-your-
-// repositorys-settings-and-features/customizing-your-repository/
-// customizing-your-repositorys-social-media-preview).
+// Layout is designed at 1280×640 CSS pixels (GitHub's recommended social
+// preview size) but rendered at 2× device scale for sharper output,
+// producing a 2560×1280 PNG (see https://docs.github.com/en/repositories/
+// managing-your-repositorys-settings-and-features/customizing-your-
+// repository/customizing-your-repositorys-social-media-preview).
 const DEVICE_SCALE_FACTOR = 2;
 // Path (relative to the workspace root) where the linguist colour map is
 // cached after the first successful fetch. `target/` is gitignored, so
@@ -198,7 +199,7 @@ async function dataUri(path, mime) {
  * client-side tinting needed.
  */
 async function fetchLanguageIcon(slug, hexColor) {
-  const hex = hexColor.replace(/^#/, "");
+  const hex = hexColor.replace(/^#/, "").toLowerCase();
   const cacheFile = join(ICON_CACHE_DIR, `${slug}-${hex}.svg`);
   try {
     const cached = await readFile(cacheFile, "utf-8");
@@ -209,7 +210,7 @@ async function fetchLanguageIcon(slug, hexColor) {
   const url = `https://cdn.simpleicons.org/${slug}/${hex}`;
   console.log(`Fetching icon for ${slug} from ${url}`);
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
     if (!res.ok) {
       console.warn(
         `Icon fetch for "${slug}" returned ${res.status} — falling back to swatch.`,

--- a/xtask/social-preview/generate.mjs
+++ b/xtask/social-preview/generate.mjs
@@ -16,19 +16,20 @@
 //   GITHUB_REPO   — defaults to "csshw".
 //
 // Outputs:
-//   A 1280×640 PNG written to OUT_PATH.
+//   A 2560×1280 PNG (2× scale for sharp rendering) written to OUT_PATH.
 //
 // Design goals:
 //   - Fail loudly on any network, file, or Playwright error — no silent
 //     fallbacks. Unknown language colors are the one exception (warn +
-//     grey fallback).
+//     grey fallback). Missing language icons fall back to colored swatches.
 //   - No HTTP libraries — use Node's built-in `fetch`. Per run we make
-//     up to three outbound calls: GitHub repo metadata, GitHub language
-//     bytes, and (on cache miss) the linguist colour map from
-//     ozh/github-colors.
+//     up to three + N outbound calls: GitHub repo metadata, GitHub
+//     language bytes, (on cache miss) the linguist colour map from
+//     ozh/github-colors, and up to N language icon fetches from
+//     cdn.simpleicons.org (each cached individually after first fetch).
 
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, join } from "node:path";
 import { chromium } from "@playwright/test";
 
 const OWNER = process.env.GITHUB_OWNER || "whme";
@@ -55,11 +56,45 @@ const VIEWPORT = { width: 1280, height: 640 };
 // 1280×640 (see https://docs.github.com/en/repositories/managing-your-
 // repositorys-settings-and-features/customizing-your-repository/
 // customizing-your-repositorys-social-media-preview).
-const DEVICE_SCALE_FACTOR = 1;
+const DEVICE_SCALE_FACTOR = 2;
 // Path (relative to the workspace root) where the linguist colour map is
 // cached after the first successful fetch. `target/` is gitignored, so
 // the cache is never committed. Delete the file to force a refresh.
 const LINGUIST_COLORS_CACHE = "target/social-preview/linguist-colors.json";
+// Directory for cached Simple Icons SVGs (one file per slug+colour combo).
+const ICON_CACHE_DIR = "target/social-preview/icon-cache";
+
+// Maps GitHub linguist language names to Simple Icons slugs.
+// Only languages that have a matching Simple Icons entry need an entry
+// here — missing languages gracefully fall back to a colored swatch.
+const LANGUAGE_ICON_SLUGS = {
+  Rust: "rust",
+  JavaScript: "javascript",
+  TypeScript: "typescript",
+  HTML: "html5",
+  CSS: "css3",
+  Python: "python",
+  Shell: "gnubash",
+  PowerShell: "powershell",
+  Go: "go",
+  Java: "openjdk",
+  "C++": "cplusplus",
+  C: "c",
+  "C#": "csharp",
+  Ruby: "ruby",
+  Swift: "swift",
+  Kotlin: "kotlin",
+  Dart: "dart",
+  Lua: "lua",
+  Zig: "zig",
+};
+
+// Override the linguist colour for icons where the brand colour is more
+// recognisable than the linguist swatch. For example, linguist assigns
+// Rust a pale peach (#dea584) but the Rust brand is a warm rust-orange.
+const ICON_COLOR_OVERRIDES = {
+  Rust: "#CE422B",
+};
 
 async function githubFetch(pathname) {
   const url = `https://api.github.com/${pathname}`;
@@ -101,8 +136,10 @@ function escapeHtml(s) {
 
 /**
  * Convert raw `{language: bytes}` into an array of
- * `{name, pct, color}` sorted by pct desc, normalised to 100, with
- * sub-0.5% entries folded into an `Other` bucket.
+ * `{name, pct, color, iconDataUri}` sorted by pct desc, normalised to
+ * 100, with sub-0.5% entries folded into an `Other` bucket.
+ * `iconDataUri` is `null` for languages without a Simple Icons entry or
+ * when the icon fetch fails.
  */
 function buildLanguages(bytesByLang, colorsByLang) {
   const total = Object.values(bytesByLang).reduce((a, b) => a + b, 0);
@@ -116,7 +153,7 @@ function buildLanguages(bytesByLang, colorsByLang) {
         );
         color = UNKNOWN_LANGUAGE_COLOR;
       }
-      return { name, pct: (bytes / total) * 100, color };
+      return { name, pct: (bytes / total) * 100, color, iconDataUri: null };
     })
     .sort((a, b) => b.pct - a.pct);
 
@@ -126,7 +163,12 @@ function buildLanguages(bytesByLang, colorsByLang) {
     .reduce((a, b) => a + b.pct, 0);
   const result = [...main];
   if (otherPct > 0) {
-    result.push({ name: "Other", pct: otherPct, color: OTHER_BUCKET_COLOR });
+    result.push({
+      name: "Other",
+      pct: otherPct,
+      color: OTHER_BUCKET_COLOR,
+      iconDataUri: null,
+    });
   }
   // Normalise to sum to exactly 100 after rounding drift.
   const sum = result.reduce((a, b) => a + b.pct, 0);
@@ -144,6 +186,61 @@ function buildLanguages(bytesByLang, colorsByLang) {
 async function dataUri(path, mime) {
   const bytes = await readFile(path);
   return `data:${mime};base64,${bytes.toString("base64")}`;
+}
+
+/**
+ * Fetch a language icon from cdn.simpleicons.org as a coloured SVG,
+ * caching the result under `ICON_CACHE_DIR`. Returns a `data:` URI
+ * string on success, or `null` on any failure.
+ *
+ * The CDN URL pattern `https://cdn.simpleicons.org/{slug}/{hex}` returns
+ * the icon SVG with all paths filled in the requested colour — no
+ * client-side tinting needed.
+ */
+async function fetchLanguageIcon(slug, hexColor) {
+  const hex = hexColor.replace(/^#/, "");
+  const cacheFile = join(ICON_CACHE_DIR, `${slug}-${hex}.svg`);
+  try {
+    const cached = await readFile(cacheFile, "utf-8");
+    return `data:image/svg+xml;base64,${Buffer.from(cached).toString("base64")}`;
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+  const url = `https://cdn.simpleicons.org/${slug}/${hex}`;
+  console.log(`Fetching icon for ${slug} from ${url}`);
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn(
+        `Icon fetch for "${slug}" returned ${res.status} — falling back to swatch.`,
+      );
+      return null;
+    }
+    const svg = await res.text();
+    await mkdir(ICON_CACHE_DIR, { recursive: true });
+    await writeFile(cacheFile, svg);
+    return `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
+  } catch (err) {
+    console.warn(`Icon fetch for "${slug}" failed: ${err.message} — falling back to swatch.`);
+    return null;
+  }
+}
+
+/**
+ * For each language entry that has a Simple Icons slug, fetch the icon
+ * and populate `iconDataUri`. Icons are fetched in parallel. Each icon
+ * is tinted with the language's brand colour (preferring
+ * `ICON_COLOR_OVERRIDES`, then falling back to the linguist colour).
+ */
+async function populateLanguageIcons(langEntries) {
+  await Promise.all(
+    langEntries.map(async (entry) => {
+      const slug = LANGUAGE_ICON_SLUGS[entry.name];
+      if (!slug) return;
+      const iconColor = ICON_COLOR_OVERRIDES[entry.name] || entry.color;
+      entry.iconDataUri = await fetchLanguageIcon(slug, iconColor);
+    }),
+  );
 }
 
 /**
@@ -194,6 +291,7 @@ async function main() {
   const logoDataUri = await dataUri(LOGO_PATH, "image/svg+xml");
   const fontDataUri = await dataUri(FONT_PATH, "font/ttf");
   const langPayload = buildLanguages(languages, colors);
+  await populateLanguageIcons(langPayload);
 
   const replacements = {
     "{{REPO_NAME}}": escapeHtml(repo.name || REPO),


### PR DESCRIPTION
Redesign the social preview card with a dark terminal-themed aesthetic,
maximized logo, and official language icons from Simple Icons.

- Switch to two-column layout (text left, large logo right at 420px)
- Dark gradient background with subtle scanline texture and red glow
- Invert text colours for dark theme (GitHub dark-mode palette)
- Fetch coloured language icons from cdn.simpleicons.org (cached locally)
- Add brand-colour overrides for languages where linguist colour diverges
- Render at 2× device scale factor for sharp output (2560×1280 PNG)

GitHub: #167

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
