### PR TITLE
Add `[t]oggle enabled` control mode option

### DIFF
--- a/news/168.feature.md
+++ b/news/168.feature.md
@@ -1,0 +1,3 @@
+Added a new `[t]oggle enabled` control-mode option that suspends input
+forwarding to all currently-enabled client windows, so keystrokes typed
+in the daemon console no longer reach them until toggled back on.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -71,6 +71,8 @@ const SENDER_CAPACITY: usize = 1024 * 1024;
 enum PipeServerState {
     /// Forward all input records to the client.
     Enabled,
+    /// Consume input records without forwarding them to the client.
+    Disabled,
 }
 
 /// Representation of a client
@@ -500,7 +502,9 @@ impl<'a> Daemon<'a> {
             if self.control_mode_state == ControlModeState::Initiated {
                 clear_screen(windows_api);
                 println!("Control Mode (Esc to exit)");
-                println!("[c]reate window(s), [r]etile, copy active [h]ostname(s)");
+                println!(
+                    "[c]reate window(s), [r]etile, [t]oggle enabled, copy active [h]ostname(s)"
+                );
                 self.control_mode_state = ControlModeState::Active;
                 return;
             }
@@ -524,7 +528,13 @@ impl<'a> Daemon<'a> {
                     // TODO: Select windows
                 }
                 (VK_T, 0) => {
-                    // TODO: trigger input on selected windows
+                    for client in clients.lock().unwrap().iter() {
+                        let mut state = client.pipe_server_state.lock().unwrap();
+                        if *state == PipeServerState::Enabled {
+                            *state = PipeServerState::Disabled;
+                        }
+                    }
+                    self.quit_control_mode(windows_api);
                 }
                 (VK_C, 0) => {
                     clear_screen(windows_api);
@@ -970,6 +980,36 @@ fn launch_client_console<W: WindowsApi>(
     );
 }
 
+/// Probe `server` with a non-blocking keep-alive write to detect a closed pipe.
+///
+/// Writes a single [`TAG_KEEP_ALIVE`] byte — the zero-payload keep-alive frame
+/// of the daemon-to-client protocol — so the client side recognises and
+/// discards it. Treated as alive on success or `WouldBlock`; any other error
+/// means the pipe is closed.
+///
+/// # Arguments
+///
+/// * `server` - The named pipe server to probe.
+///
+/// # Returns
+///
+/// `true` if the pipe is still alive, `false` if it is closed and the
+/// caller's routine should stop. The caller is responsible for emitting
+/// any closed-pipe log message.
+fn probe_pipe_alive(server: &NamedPipeServer) -> bool {
+    match server.try_write(&[TAG_KEEP_ALIVE]) {
+        Ok(_) => return true,
+        Err(e) if e.kind() == io::ErrorKind::WouldBlock => return true,
+        Err(_) => {
+            debug!(
+                "Named pipe server ({:?}) is closed, stopping named pipe server routine",
+                server
+            );
+            return false;
+        }
+    }
+}
+
 /// Wait for the named pipe server to connect, correlate the client by
 /// its process id, then forward serialized input records read from the
 /// broadcast channel to the named pipe server.
@@ -988,8 +1028,8 @@ fn launch_client_console<W: WindowsApi>(
 ///
 /// If writing to the pipe fails the pipe is considered closed and the routine ends.
 /// To detect if a client is still alive even if we are currently
-/// not sending data, we send a "keep alive packet",
-/// [`SERIALIZED_INPUT_RECORD_0_LENGTH`] bytes of `1`s. If that fails, the routine ends.
+/// not sending data, we send a tagged keep-alive frame ([`TAG_KEEP_ALIVE`]).
+/// If that fails, the routine ends.
 ///
 /// # Arguments
 ///
@@ -1041,19 +1081,10 @@ async fn named_pipe_server_routine(
             Ok(val) => val,
             Err(TryRecvError::Empty) => {
                 tokio::time::sleep(Duration::from_millis(5)).await;
-                // Send a tagged keep-alive frame to detect early if the pipe is
-                // closed because the client exited.
-                match server.try_write(&[TAG_KEEP_ALIVE]) {
-                    Ok(_) => continue,
-                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                    Err(_) => {
-                        debug!(
-                            "Named pipe server ({:?}) is closed, stopping named pipe server routine",
-                            server
-                        );
-                        return;
-                    }
+                if !probe_pipe_alive(&server) {
+                    return;
                 }
+                continue;
             }
             Err(err) => {
                 error!("{}", err);
@@ -1061,8 +1092,22 @@ async fn named_pipe_server_routine(
             }
         };
         // Only forward to the client if its pipe server state allows it.
-        match *pipe_server_state.lock().unwrap() {
+        // Copy the state out so the mutex guard does not span the `.await`
+        // below — `MutexGuard` is not `Send` and would prevent the routine
+        // from being spawned on a multi-threaded runtime.
+        let state = *pipe_server_state.lock().unwrap();
+        match state {
             PipeServerState::Enabled => {}
+            PipeServerState::Disabled => {
+                // Still probe the pipe while disabled so client disconnects
+                // are detected promptly under sustained input.
+                if !probe_pipe_alive(&server) {
+                    return;
+                }
+                // Yield so we don't tight-loop when the broadcast channel is busy.
+                tokio::task::yield_now().await;
+                continue;
+            }
         }
         // Build the tagged input-record frame: [TAG_INPUT_RECORD][13-byte payload].
         let mut frame = [0u8; FRAMED_INPUT_RECORD_LENGTH];

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -309,6 +309,120 @@ mod daemon_test {
         return Ok(());
     }
 
+    /// Construct a [`Clients`] collection holding a single [`Client`] whose
+    /// `process_id` equals `pid`, returning both the collection and the
+    /// shared [`PipeServerState`] handle so the caller can mutate it.
+    fn make_clients_with_pid_and_state(
+        pid: u32,
+    ) -> (Arc<Mutex<Clients>>, Arc<Mutex<PipeServerState>>) {
+        let state = Arc::new(Mutex::new(PipeServerState::Enabled));
+        let mut clients = Clients::new();
+        clients.push(Client {
+            hostname: format!("test-host-{pid}"),
+            window_handle: HWND(std::ptr::null_mut()),
+            process_handle: HANDLE::default(),
+            process_id: pid,
+            pipe_server_state: Arc::clone(&state),
+        });
+        return (Arc::new(Mutex::new(clients)), state);
+    }
+
+    /// Verifies that when a client's [`PipeServerState`] is set to
+    /// [`PipeServerState::Disabled`], the pipe server routine consumes
+    /// broadcast messages but does not forward them through the pipe.
+    /// Only keep-alive packets should arrive on the client side.
+    #[tokio::test]
+    async fn test_named_pipe_server_routine_disabled() -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_PID: u32 = 66666;
+        // Use a per-test unique pipe name so parallel test runs don't collide
+        // on the global PIPE_NAME.
+        let pipe_name = format!(r"\\.\pipe\csshw-test-disabled-{}", std::process::id());
+        let (sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
+            SERIALIZED_INPUT_RECORD_0_LENGTH,
+        );
+        let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
+            .access_outbound(true)
+            .pipe_mode(PipeMode::Message)
+            .create(&pipe_name)?;
+        let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
+        let (clients, pipe_server_state) = make_clients_with_pid_and_state(TEST_PID);
+        send_pid(&named_pipe_client, TEST_PID).await?;
+        let future = tokio::spawn(async move {
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
+        });
+
+        // First, verify data flows while enabled. The pipe carries
+        // tagged frames now: keep-alive frames are a single
+        // `TAG_KEEP_ALIVE` byte, input-record frames are
+        // `[TAG_INPUT_RECORD][13-byte payload]`.
+        sender.send([2; SERIALIZED_INPUT_RECORD_0_LENGTH])?;
+        let mut got_data = false;
+        loop {
+            named_pipe_client.readable().await?;
+            let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+            match named_pipe_client.try_read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => match buf[0] {
+                    TAG_KEEP_ALIVE => {
+                        assert_eq!(FRAMED_KEEP_ALIVE_LENGTH, n);
+                    }
+                    TAG_INPUT_RECORD => {
+                        assert_eq!(FRAMED_INPUT_RECORD_LENGTH, n);
+                        assert_eq!([2; SERIALIZED_INPUT_RECORD_0_LENGTH], buf[1..]);
+                        got_data = true;
+                        break;
+                    }
+                    other => panic!("Unexpected tag byte 0x{other:02X}"),
+                },
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        assert!(got_data);
+
+        // Disable the client.
+        *pipe_server_state.lock().unwrap() = PipeServerState::Disabled;
+
+        // Send more data — it must NOT arrive at the client.
+        const SENDS: usize = 5;
+        for _ in 0..SENDS {
+            sender.send([3; SERIALIZED_INPUT_RECORD_0_LENGTH])?;
+        }
+
+        // The disabled branch writes one keep-alive frame per consumed
+        // broadcast record, so we expect at least `SENDS` keep-alive
+        // frames to arrive. Read exactly that many and assert each is
+        // a `TAG_KEEP_ALIVE` byte — any `TAG_INPUT_RECORD` frame would
+        // be a leak of broadcast data and must fail the test.
+        let mut received = 0;
+        while received < SENDS {
+            named_pipe_client.readable().await?;
+            let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+            match named_pipe_client.try_read(&mut buf) {
+                Ok(n) => match buf[0] {
+                    TAG_KEEP_ALIVE => {
+                        assert_eq!(
+                            FRAMED_KEEP_ALIVE_LENGTH, n,
+                            "Keep-alive frame must be exactly one byte"
+                        );
+                        received += 1;
+                    }
+                    TAG_INPUT_RECORD => panic!(
+                        "Received input-record frame after disabling — broadcast data leaked through"
+                    ),
+                    other => panic!("Unexpected tag byte 0x{other:02X}"),
+                },
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        drop(named_pipe_client);
+        future.await?;
+        return Ok(());
+    }
+
     #[test]
     #[should_panic(expected = "Duplicate client PID")]
     fn test_clients_push_duplicate_pid_panics() {


### PR DESCRIPTION
Disable all currently enabled client windows so their pipe servers
consume but no longer forward input records.

GitHub: #168

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
