### PR TITLE
Extract commit and GitHub PR conventions into Claude skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: commit
+description: Write a git commit message that follows csshW's subject/body/trailer conventions, including the mandatory Co-authored-by trailer for AI-generated commits.
+---
+
+# Commit Messages
+
+Commit messages follow the standard three-block layout: a single-line
+**subject**, an optional wrapped prose **body**, and a **footer** block
+of Git trailers — each block separated from the next by a blank line.
+
+## Subject line
+
+- Imperative mood, first word capitalized (`Add`, `Fix`, `Bump`,
+  `Update`, `Support`, `Remove`, `Refactor`, `Replace`, `Improve`,
+  `Migrate`).
+- Optional lowercase scope prefix followed by `: ` when the change is
+  confined to a single area (e.g. `client:`, `control mode:`,
+  `post-pr-comment:`, `news-fragment-check:`). Mirror the scope style
+  already used in `git log` — do not invent new scopes.
+- No trailing period. Keep under ~72 characters.
+- Do not pre-append a PR number in parentheses (`(#165)`) — GitHub's
+  squash-merge adds that automatically when the PR lands.
+
+## Body
+
+- Separate the subject from the body with a blank line.
+- Wrap lines at ~72–76 characters.
+- Explain **why** the change is being made. Describe observable
+  behavior before/after when relevant. "With this change …" is a
+  common and acceptable opening.
+- Use `-` for bullet lists.
+- Reference advisories/URLs inline in the body when fixing CVEs or
+  Dependabot alerts.
+
+## Footer (trailers)
+
+Trailers go in a final block separated from the body by a blank line.
+Order: issue/PR references first, then co-author trailers.
+
+- **GitHub references**: use `GitHub: #<number>` — one per line, in
+  the footer, never in the subject or body prose. Do not use `Fixes:`
+  (legacy style).
+- **AI co-authorship (MANDATORY for AI-generated commits)**: include
+  a `Co-authored-by:` trailer naming the model. For example:
+
+  ```
+  Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
+  ```
+
+  - Use the exact model name in use (e.g. `Claude Opus 4.6`,
+    `Claude Sonnet 4.6`, `Claude Haiku 4.5`).
+  - Email must be `<noreply@anthropic.com>`.
+  - Use the Git-canonical casing `Co-authored-by:` (lowercase
+    `authored`/`by`). GitHub recognizes other casings too, but
+    lowercase matches Git's own trailer convention and avoids
+    duplicate trailers when tooling re-adds one.
+  - Emit the trailer **exactly once** — never both `Co-Authored-By:`
+    and `Co-authored-by:` for the same author.
+
+## Example
+
+```
+client: handle zero-byte pipe reads gracefully
+
+Previously a partial read from the daemon's named pipe was treated as
+an EOF and caused every client to exit. Distinguish between
+`0 bytes read` (daemon gone) and `n>0 bytes read` (buffer not yet
+complete) so large pastes no longer tear down the cluster.
+
+GitHub: #142
+Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+## How to actually commit
+
+Use a single-quoted heredoc (`<<'EOF'`) so backticks and `$` in the
+body are not expanded by the shell:
+
+```sh
+git add <paths>        # prefer explicit paths over `git add -A`
+git commit -m "$(cat <<'EOF'
+<subject line>
+
+<wrapped body>
+
+GitHub: #<N>
+Co-authored-by: <Model Name> <noreply@anthropic.com>
+EOF
+)"
+```
+
+Never pass `--no-verify` or `--no-gpg-sign` unless the user has
+explicitly asked for it. If a pre-commit hook fails, fix the issue
+and create a new commit — do not `--amend` to "retry" a commit
+that never happened.

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -49,8 +49,11 @@ or "handle the review comments".
 #### 1. Discover PR context
 
 ```sh
-# Owner/repo of the current clone
-gh repo view --json nameWithOwner --jq .nameWithOwner
+# Owner of the current clone
+gh repo view --json owner --jq .owner.login
+
+# Repo name of the current clone
+gh repo view --json name --jq .name
 
 # PR number for the current branch (fails if no PR exists)
 gh pr view --json number --jq .number

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: github-pr
+description: Create a GitHub pull request, or work on an existing one — address review comments, push updates, reply to and resolve each unresolved thread.
+---
+
+# GitHub Pull Requests
+
+Use this skill to **create** a new PR or to **respond to review
+feedback** on an existing one.
+
+## Creating a PR
+
+Create PRs from the commit message — do not re-author the prose in
+the PR form:
+
+```sh
+# Standard case
+gh pr create --fill
+
+# PR has no user-facing changes (skips the news-fragment check)
+gh pr create --fill --label no-news-fragment-needed
+```
+
+`--fill` uses the most recent commit's subject as the PR title and
+its body as the PR description, so a well-formed commit
+(see [`../commit/SKILL.md`](../commit/SKILL.md)) produces a
+well-formed PR automatically.
+
+## Addressing review feedback on an existing PR
+
+Use this whenever you are asked to address feedback, update a PR,
+or "handle the review comments".
+
+### Core rules
+
+- **Reply to every unresolved review comment** — even when the fix
+  is "done in commit abc123". Never leave a thread silently
+  addressed.
+- **Resolve each thread only after** (a) the fix is pushed and
+  (b) a reply has been posted.
+- **Push to update the PR.** Local commits alone do not count.
+- No force-push to `main`. No `--no-verify`. No `git commit --amend`
+  to rewrite commits that have already been pushed for review.
+- Commit changes per [`../commit/SKILL.md`](../commit/SKILL.md) —
+  including the mandatory `Co-authored-by:` trailer.
+
+### Workflow (run these commands; substitute the placeholders in `<>`)
+
+#### 1. Discover PR context
+
+```sh
+# Owner/repo of the current clone
+gh repo view --json nameWithOwner --jq .nameWithOwner
+
+# PR number for the current branch (fails if no PR exists)
+gh pr view --json number --jq .number
+
+# Or, if the PR number N was given explicitly, check it out:
+gh pr checkout <N>
+```
+
+Capture `<OWNER>`, `<REPO>`, and `<N>` for the rest of the steps.
+
+#### 2. List every unresolved review thread
+
+The REST endpoint `/pulls/:n/comments` does **not** expose thread
+resolution state. Always use GraphQL:
+
+```sh
+gh api graphql -f query='
+  query($owner:String!,$name:String!,$number:Int!){
+    repository(owner:$owner,name:$name){
+      pullRequest(number:$number){
+        reviewThreads(first:100){
+          nodes{
+            id isResolved isOutdated
+            comments(first:50){
+              nodes{ id databaseId author{login} path line body }
+            }
+          }
+        }
+      }
+    }
+  }' -F owner=<OWNER> -F name=<REPO> -F number=<N>
+```
+
+Filter client-side to `isResolved == false`. From each unresolved
+thread you need:
+
+- the thread `id` (GraphQL node id) → used to **resolve** the thread
+  in step 5.
+- the `databaseId` of the **first** comment in the thread → used to
+  **reply** to the thread in step 4.
+
+#### 3. Make the code changes, commit, push
+
+Commit per [`../commit/SKILL.md`](../commit/SKILL.md). Then push:
+
+```sh
+git push                                           # already-tracked branch
+git push -u origin "$(git branch --show-current)"  # first push of a new branch
+```
+
+Capture the commit SHA (`git rev-parse HEAD`) to reference in your
+replies.
+
+#### 4. Reply to each unresolved thread
+
+Reply to the **first** comment in the thread (its `databaseId` from
+step 2). GitHub threads your reply underneath automatically:
+
+```sh
+gh api --method POST \
+  repos/<OWNER>/<REPO>/pulls/<N>/comments/<COMMENT_DATABASE_ID>/replies \
+  -f body='Fixed in <SHA>. <optional short explanation>.'
+```
+
+Do **not** use `gh pr comment` — that posts a top-level PR comment,
+which does not count as answering the review thread.
+
+#### 5. Resolve each thread
+
+Use the thread node `id` from step 2 (the GraphQL `id`, **not**
+`databaseId`):
+
+```sh
+gh api graphql -f query='
+  mutation($threadId:ID!){
+    resolveReviewThread(input:{threadId:$threadId}){
+      thread{ id isResolved }
+    }
+  }' -F threadId=<THREAD_NODE_ID>
+```
+
+The mutation returns `isResolved: true` on success.
+
+#### 6. Verify
+
+Re-run the step-2 query. Every thread you addressed should now have
+`isResolved: true`. Any that remain unresolved either still need a
+fix or were intentionally deferred — never silently skip one.
+
+### Anti-patterns
+
+- Posting a top-level PR comment (`gh pr comment`) instead of
+  threading the reply on the review comment.
+- Resolving without replying, or replying without resolving.
+- Pushing before committing per [`../commit/SKILL.md`](../commit/SKILL.md)
+  (skips the mandatory `Co-authored-by:` trailer).
+- Force-pushing to shared branches to "clean up history" mid-review.
+- Using `--amend` on commits that have already been pushed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,72 +91,10 @@ Always run `cargo fmt`, `cargo lint`, and both test commands before considering 
 
 ## Commit Messages
 
-Commit messages follow the standard three-block layout: a single-line
-**subject**, an optional wrapped prose **body**, and a **footer** block
-of Git trailers — each block separated from the next by a blank line.
-
-### Subject line
-
-- Imperative mood, first word capitalized (`Add`, `Fix`, `Bump`,
-  `Update`, `Support`, `Remove`, `Refactor`, `Replace`, `Improve`,
-  `Migrate`).
-- Optional lowercase scope prefix followed by `: ` when the change is
-  confined to a single area (e.g. `client:`, `control mode:`,
-  `post-pr-comment:`, `news-fragment-check:`). Mirror the scope style
-  already used in `git log` — do not invent new scopes.
-- No trailing period. Keep under ~72 characters.
-- Do not pre-append a PR number in parentheses (`(#165)`) — GitHub's
-  squash-merge adds that automatically when the PR lands.
-
-### Body
-
-- Separate the subject from the body with a blank line.
-- Wrap lines at ~72–76 characters.
-- Explain **why** the change is being made. Describe observable
-  behavior before/after when relevant. "With this change …" is a
-  common and acceptable opening.
-- Use `-` for bullet lists.
-- Reference advisories/URLs inline in the body when fixing CVEs or
-  Dependabot alerts.
-
-### Footer (trailers)
-
-Trailers go in a final block separated from the body by a blank line.
-Order: issue/PR references first, then co-author trailers.
-
-- **GitHub references**: use `GitHub: #<number>` — one per line, in
-  the footer, never in the subject or body prose. Do not use `Fixes:`
-  (legacy style).
-- **AI co-authorship (MANDATORY for AI-generated commits)**: include
-  a `Co-authored-by:` trailer naming the model. For example:
-
-  ```
-  Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
-  ```
-
-  - Use the exact model name in use (e.g. `Claude Opus 4.6`,
-    `Claude Sonnet 4.6`, `Claude Haiku 4.5`).
-  - Email must be `<noreply@anthropic.com>`.
-  - Use the Git-canonical casing `Co-authored-by:` (lowercase
-    `authored`/`by`). GitHub recognizes other casings too, but
-    lowercase matches Git's own trailer convention and avoids
-    duplicate trailers when tooling re-adds one.
-  - Emit the trailer **exactly once** — never both `Co-Authored-By:`
-    and `Co-authored-by:` for the same author.
-
-### Example
-
-```
-client: handle zero-byte pipe reads gracefully
-
-Previously a partial read from the daemon's named pipe was treated as
-an EOF and caused every client to exit. Distinguish between
-`0 bytes read` (daemon gone) and `n>0 bytes read` (buffer not yet
-complete) so large pastes no longer tear down the cluster.
-
-GitHub: #142
-Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
-```
+Follow the conventions in
+[`.claude/skills/commit/SKILL.md`](.claude/skills/commit/SKILL.md).
+AI-generated commits MUST include a `Co-authored-by:` trailer
+naming the model.
 
 ## User Interaction
 
@@ -166,8 +104,10 @@ Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
 
 ## GitHub Pull Requests
 
-- Always create PRs with `gh pr create --fill` — the commit message drives the PR title and body
-- If a PR has no user-facing changes, add `--label no-news-fragment-needed`
+Both PR creation and addressing review feedback are covered in
+[`.claude/skills/github-pr/SKILL.md`](.claude/skills/github-pr/SKILL.md).
+When addressing feedback: reply to every unresolved review comment,
+mark each thread resolved once addressed, and push to update the PR.
 
 ## Completion Checklist
 


### PR DESCRIPTION
The Commit Messages section of AGENTS.md was ~68 lines (≈38% of the
file) yet only relevant at commit time, paying a constant context
cost for intermittent value. The GitHub Pull Requests section was
similarly only relevant when creating or reviewing a PR, and had no
concrete commands for replying to / resolving review threads — an
agent had to research the GraphQL shape every time.

With this change both sections are moved into on-demand Claude
skills under `.claude/skills/`:

- `.claude/skills/commit/SKILL.md` — full subject/body/trailer
  conventions plus an executable `git commit` heredoc pattern.
- `.claude/skills/github-pr/SKILL.md` — PR creation
  (`gh pr create --fill`, `--label no-news-fragment-needed`) plus
  the exact `gh api graphql` commands to list unresolved review
  threads, reply to each via the REST `/replies` endpoint, and
  resolve them via the `resolveReviewThread` GraphQL mutation.

AGENTS.md keeps short pointer sections so any AGENTS.md-aware agent
(not just Claude Code's native skill loader) can still find the
content by path. The file shrinks from 177 to 111 lines.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
