### PR TITLE
Add paseo.json to install hooks and clean up branches

### DIFF
--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,11 @@
+{
+  "worktree": {
+    "setup": [
+      "git config --local core.hooksPath .githooks/"
+    ],
+    "teardown": [
+      "git -C \"$PASEO_WORKTREE_PATH\" checkout --detach",
+      "git -C \"$PASEO_SOURCE_CHECKOUT_PATH\" branch -D \"$PASEO_BRANCH_NAME\" || true"
+    ]
+  }
+}


### PR DESCRIPTION
Pre-commit enforcement was silently skipped in Paseo worktrees because
`core.hooksPath` is a per-local-config setting and is not inherited
from the source checkout. On top of that, archiving a Paseo worktree
removed the worktree directory but left the per-worktree branch
behind in the source checkout, causing branches to accumulate over
time.

With this change:

- `worktree.setup` runs `git config --local core.hooksPath .githooks/`
  once per new worktree, so the existing `.githooks/pre-commit` hook
  (cargo fmt, lint, build, docs, update-readme-help) applies
  automatically to agent commits.
- `worktree.teardown` detaches HEAD inside the worktree and then
  force-deletes the branch from the source checkout. Detaching first
  is required because at teardown time git still considers the branch
  checked out in the worktree and refuses a plain `branch -D`. The
  delete is suffixed with `|| true` so teardown stays non-fatal if
  the branch has already been cleaned up by other means.

Co-authored-by: Claude Opus 4 <noreply@anthropic.com>
