### PR TITLE
paseo.json: fix teardown hook for Windows PowerShell

### DIFF
--- a/paseo.json
+++ b/paseo.json
@@ -4,8 +4,8 @@
       "git config --local core.hooksPath .githooks/"
     ],
     "teardown": [
-      "git -C \"$PASEO_WORKTREE_PATH\" checkout --detach",
-      "git -C \"$PASEO_SOURCE_CHECKOUT_PATH\" branch -D \"$PASEO_BRANCH_NAME\" || true"
+      "git -C \"$env:PASEO_WORKTREE_PATH\" checkout --detach; $global:LASTEXITCODE = 0",
+      "git -C \"$env:PASEO_SOURCE_CHECKOUT_PATH\" branch -D \"$env:PASEO_BRANCH_NAME\"; $global:LASTEXITCODE = 0"
     ]
   }
 }


### PR DESCRIPTION
Paseo runs worktree lifecycle commands via
`powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command`
on Windows, but the teardown step added in c121429 used bash syntax
and broke on every archive:

    Worktree teardown command failed:
      git -C "$PASEO_WORKTREE_PATH" checkout --detach
    fatal: cannot change to 'checkout': No such file or directory

Two PowerShell-specific issues:

- `$PASEO_WORKTREE_PATH` addresses a PowerShell session variable, not
  an env var, so it expanded to an empty string. The quoted empty
  argument was then dropped from argv and git treated `checkout` as
  the `-C` directory. Use `$env:PASEO_WORKTREE_PATH` (and the other
  two vars likewise) to actually read the process environment.
- `|| true` requires pipeline-chain operators introduced in
  PowerShell 7. `powershell.exe` on Windows is Windows PowerShell
  5.1, which rejects `||` outright. Replace it with
  `; $global:LASTEXITCODE = 0`, which is the idiomatic 5.1-compatible
  way to swallow a native command's non-zero exit status (try/catch
  does not work for native exit codes). Apply the same suffix to the
  detach step so best-effort cleanup never aborts the archive.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
