### PR TITLE
Propagate client state changes to clients

### DIFF
--- a/news/181.feature.md
+++ b/news/181.feature.md
@@ -1,4 +1,0 @@
-Propagate per-client `ClientState` (`Active` / `Disabled`) from the daemon
-to each client over the named pipe, unifying the daemon-side input gate
-with the wire-visible state. Clients now learn their own state via a
-tagged state-change frame and can render themselves accordingly.

--- a/news/181.feature.md
+++ b/news/181.feature.md
@@ -1,0 +1,4 @@
+Propagate per-client `ClientState` (`Active` / `Disabled`) from the daemon
+to each client over the named pipe, unifying the daemon-side input gate
+with the wire-visible state. Clients now learn their own state via a
+tagged state-change frame and can render themselves accordingly.

--- a/news/181.feature.md
+++ b/news/181.feature.md
@@ -1,0 +1,4 @@
+Disabled clients now repaint their console window with a muted dark-grey
+background and revert to their original colors when re-enabled, giving an
+immediate visual confirmation that the daemon's `[t]oggle enabled` and
+`e[n]able all` control-mode bindings landed on the right window.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -25,7 +25,8 @@ use windows::Win32::System::Console::{
 use crate::{
     protocol::{
         deserialization::parse_daemon_to_client_messages, serialization::serialize_pid,
-        DaemonToClientMessage, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+        ClientState, DaemonToClientMessage, SERIALIZED_INPUT_RECORD_0_LENGTH,
+        SERIALIZED_PID_LENGTH,
     },
     utils::constants::{PIPE_NAME, PKG_NAME},
 };
@@ -191,9 +192,11 @@ async fn launch_ssh_process(
 ///
 /// Input records are written to the console input buffer using the provided API
 /// and their key-event payloads are returned via `ReadWriteResult::Success` so
-/// the caller can detect the Alt+Shift+C close combination. Keep-alive frames
-/// are ignored. Partial trailing frames are returned as `remainder` for the
-/// next call to prepend.
+/// the caller can detect the Alt+Shift+C close combination. State-change frames
+/// update the [`ClientState`] referenced by `current_state` so the client's
+/// main loop always sees its authoritative state. Keep-alive frames are
+/// ignored. Partial trailing frames are returned as `remainder` for the next
+/// call to prepend.
 ///
 /// # Arguments
 ///
@@ -202,6 +205,9 @@ async fn launch_ssh_process(
 ///                           the named pipe created by the daemon.
 /// * `internal_buffer`     - Vector containing the unconsumed bytes (possibly an
 ///                           incomplete trailing frame) from a previous call.
+/// * `current_state`       - The client's authoritative [`ClientState`].
+///                           Updated in place when the daemon pushes a
+///                           [`DaemonToClientMessage::StateChange`].
 /// # Returns
 ///
 /// A `ReadWriteResult` indicating whether we were able to read from the named pipe and write the available INPUT_RECORDs
@@ -212,6 +218,7 @@ async fn read_write_loop(
     api: &dyn WindowsApi,
     named_pipe_client: &NamedPipeClient,
     internal_buffer: &mut Vec<u8>,
+    current_state: &mut ClientState,
 ) -> ReadWriteResult {
     let mut buf: [u8; SERIALIZED_INPUT_RECORD_0_LENGTH * 10] =
         [0; SERIALIZED_INPUT_RECORD_0_LENGTH * 10];
@@ -231,6 +238,9 @@ async fn read_write_loop(
                     DaemonToClientMessage::InputRecord(input_record) => {
                         write_console_input(api, input_record);
                         key_event_records.push(unsafe { input_record.KeyEvent });
+                    }
+                    DaemonToClientMessage::StateChange(state) => {
+                        *current_state = state;
                     }
                     DaemonToClientMessage::KeepAlive => {}
                 }
@@ -357,6 +367,10 @@ async fn run(api: &dyn WindowsApi, child: &mut Child) {
     send_pid_handshake(&named_pipe_client).await;
     let mut child_error = false;
     let mut internal_buffer: Vec<u8> = Vec::new();
+    // Authoritative client state, updated whenever the daemon pushes a
+    // [`DaemonToClientMessage::StateChange`]. Lives in the main loop so any
+    // future state-dependent logic can read it directly without a lock.
+    let mut current_state: ClientState = ClientState::Active;
     loop {
         named_pipe_client
             .ready(Interest::READABLE)
@@ -366,7 +380,14 @@ async fn run(api: &dyn WindowsApi, child: &mut Child) {
                 panic!("Named client pipe is not ready to be read",)
             });
 
-        match read_write_loop(api, &named_pipe_client, &mut internal_buffer).await {
+        match read_write_loop(
+            api,
+            &named_pipe_client,
+            &mut internal_buffer,
+            &mut current_state,
+        )
+        .await
+        {
             ReadWriteResult::Success {
                 remainder,
                 key_event_records,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,14 +12,16 @@ use std::time::Duration;
 use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 
 use crate::utils::config::ClientConfig;
-use crate::utils::windows::{get_console_title, WindowsApi};
+use crate::utils::windows::{get_console_title, set_console_color, WindowsApi};
 use ssh2_config::{ParseRule, SshConfig};
 use tokio::net::windows::named_pipe::NamedPipeClient;
 use tokio::process::{Child, Command};
+use tokio::sync::watch;
 use tokio::{io::Interest, net::windows::named_pipe::ClientOptions};
 use windows::Win32::System::Console::{
-    INPUT_RECORD, INPUT_RECORD_0, KEY_EVENT, KEY_EVENT_RECORD, LEFT_ALT_PRESSED, RIGHT_ALT_PRESSED,
-    SHIFT_PRESSED,
+    BACKGROUND_INTENSITY, CONSOLE_CHARACTER_ATTRIBUTES, FOREGROUND_BLUE, FOREGROUND_GREEN,
+    FOREGROUND_RED, INPUT_RECORD, INPUT_RECORD_0, KEY_EVENT, KEY_EVENT_RECORD, LEFT_ALT_PRESSED,
+    RIGHT_ALT_PRESSED, SHIFT_PRESSED,
 };
 
 use crate::{
@@ -57,6 +59,54 @@ enum ReadWriteResult {
     Err,
     /// The pipe was closed.
     Disconnect,
+}
+
+/// Console attributes applied while the client is in
+/// [`ClientState::Disabled`].
+///
+/// The default-grey foreground (red+green+blue, no intensity) on a
+/// `BACKGROUND_INTENSITY`-only background paints the window as light text on
+/// a muted dark-grey background - a clear "this client is greyed out" cue
+/// that mirrors the daemon's existing reuse of `set_console_color` while
+/// staying visually distinct from the daemon's bright-red palette.
+const DISABLED_CONSOLE_ATTRIBUTES: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARACTER_ATTRIBUTES(
+    FOREGROUND_RED.0 | FOREGROUND_GREEN.0 | FOREGROUND_BLUE.0 | BACKGROUND_INTENSITY.0,
+);
+
+/// Repaint the console to reflect a [`ClientState`] transition.
+///
+/// Called from the visuals task whenever the watch channel observes a new
+/// state. Does nothing when `prev == next` (the watch channel notifies on
+/// every send, including no-op replays) and also does nothing when
+/// `original_attrs` is `None` - that signals the initial buffer-info read
+/// at startup failed, in which case we degrade gracefully and leave the
+/// console untouched.
+///
+/// # Arguments
+///
+/// * `api`             - The Windows API implementation to use.
+/// * `prev`            - State applied on the previous invocation.
+/// * `next`            - State just observed on the watch channel.
+/// * `original_attrs`  - Console attributes captured at startup. Used to
+///                       restore the pristine appearance when transitioning
+///                       back to [`ClientState::Active`].
+fn apply_state_visuals(
+    api: &dyn WindowsApi,
+    prev: ClientState,
+    next: ClientState,
+    original_attrs: Option<CONSOLE_CHARACTER_ATTRIBUTES>,
+) {
+    if prev == next {
+        return;
+    }
+    let Some(original) = original_attrs else {
+        return;
+    };
+    let attrs = match next {
+        ClientState::Active => original,
+        ClientState::Disabled => DISABLED_CONSOLE_ATTRIBUTES,
+    };
+    set_console_color(api, attrs);
 }
 
 /// Write the given [INPUT_RECORD_0] to the console input buffer using the provided API.
@@ -193,10 +243,11 @@ async fn launch_ssh_process(
 /// Input records are written to the console input buffer using the provided API
 /// and their key-event payloads are returned via `ReadWriteResult::Success` so
 /// the caller can detect the Alt+Shift+C close combination. State-change frames
-/// update the [`ClientState`] referenced by `current_state` so the client's
-/// main loop always sees its authoritative state. Keep-alive frames are
-/// ignored. Partial trailing frames are returned as `remainder` for the next
-/// call to prepend.
+/// are forwarded via [`watch::Sender::send_replace`] on `state_tx`, making the
+/// authoritative [`ClientState`] visible to every watch subscriber (currently
+/// the visuals task in [`main`]) without coupling this loop to any
+/// state-dependent rendering. Keep-alive frames are ignored. Partial trailing
+/// frames are returned as `remainder` for the next call to prepend.
 ///
 /// # Arguments
 ///
@@ -205,9 +256,9 @@ async fn launch_ssh_process(
 ///                           the named pipe created by the daemon.
 /// * `internal_buffer`     - Vector containing the unconsumed bytes (possibly an
 ///                           incomplete trailing frame) from a previous call.
-/// * `current_state`       - The client's authoritative [`ClientState`].
-///                           Updated in place when the daemon pushes a
-///                           [`DaemonToClientMessage::StateChange`].
+/// * `state_tx`            - Watch sender used to broadcast every
+///                           [`DaemonToClientMessage::StateChange`] payload as
+///                           the client's authoritative [`ClientState`].
 /// # Returns
 ///
 /// A `ReadWriteResult` indicating whether we were able to read from the named pipe and write the available INPUT_RECORDs
@@ -218,7 +269,7 @@ async fn read_write_loop(
     api: &dyn WindowsApi,
     named_pipe_client: &NamedPipeClient,
     internal_buffer: &mut Vec<u8>,
-    current_state: &mut ClientState,
+    state_tx: &watch::Sender<ClientState>,
 ) -> ReadWriteResult {
     let mut buf: [u8; SERIALIZED_INPUT_RECORD_0_LENGTH * 10] =
         [0; SERIALIZED_INPUT_RECORD_0_LENGTH * 10];
@@ -240,7 +291,7 @@ async fn read_write_loop(
                         key_event_records.push(unsafe { input_record.KeyEvent });
                     }
                     DaemonToClientMessage::StateChange(state) => {
-                        *current_state = state;
+                        state_tx.send_replace(state);
                     }
                     DaemonToClientMessage::KeepAlive => {}
                 }
@@ -346,9 +397,12 @@ async fn send_pid_handshake(named_pipe_client: &NamedPipeClient) {
 ///
 /// # Arguments
 ///
-/// * `api` - The Windows API implementation to use.
-/// * `child` - Handle to the running SSH process.
-async fn run(api: &dyn WindowsApi, child: &mut Child) {
+/// * `api`         - The Windows API implementation to use.
+/// * `child`       - Handle to the running SSH process.
+/// * `state_tx`    - Watch sender used by [`read_write_loop`] to broadcast the
+///                   client's authoritative [`ClientState`] to subscribers
+///                   such as the visuals task in [`main`].
+async fn run(api: &dyn WindowsApi, child: &mut Child, state_tx: &watch::Sender<ClientState>) {
     // Many clients trying to open the pipe at the same time can cause
     // a file not found error, so keep trying until we managed to open it
     let named_pipe_client: NamedPipeClient = loop {
@@ -367,10 +421,6 @@ async fn run(api: &dyn WindowsApi, child: &mut Child) {
     send_pid_handshake(&named_pipe_client).await;
     let mut child_error = false;
     let mut internal_buffer: Vec<u8> = Vec::new();
-    // Authoritative client state, updated whenever the daemon pushes a
-    // [`DaemonToClientMessage::StateChange`]. Lives in the main loop so any
-    // future state-dependent logic can read it directly without a lock.
-    let mut current_state: ClientState = ClientState::Active;
     loop {
         named_pipe_client
             .ready(Interest::READABLE)
@@ -380,14 +430,7 @@ async fn run(api: &dyn WindowsApi, child: &mut Child) {
                 panic!("Named client pipe is not ready to be read",)
             });
 
-        match read_write_loop(
-            api,
-            &named_pipe_client,
-            &mut internal_buffer,
-            &mut current_state,
-        )
-        .await
-        {
+        match read_write_loop(api, &named_pipe_client, &mut internal_buffer, state_tx).await {
             ReadWriteResult::Success {
                 remainder,
                 key_event_records,
@@ -461,6 +504,27 @@ pub async fn main(
     cli_port: Option<u16>,
     config: &ClientConfig,
 ) {
+    // Capture the console's original attributes before anything (title task,
+    // SSH child) gets a chance to write output. This snapshot is what the
+    // visuals task reverts to on a `Disabled -> Active` transition.
+    let original_attrs: Option<CONSOLE_CHARACTER_ATTRIBUTES> = match api
+        .get_console_screen_buffer_info()
+    {
+        Ok(info) => Some(info.wAttributes),
+        Err(err) => {
+            warn!(
+                "Failed to capture original console attributes; disabled-state visuals will be skipped: {}",
+                err
+            );
+            None
+        }
+    };
+
+    // Watch channel that carries the authoritative `ClientState` from the
+    // pipe-reading loop ([`read_write_loop`]) to the visuals task below.
+    // Mirrors the daemon-side channel pattern introduced in PR #181.
+    let (state_tx, state_rx) = watch::channel(ClientState::Active);
+
     let (host, inline_port) =
         host.rsplit_once(':')
             .map_or((host.as_str(), None), |(host, port)| {
@@ -505,15 +569,39 @@ pub async fn main(
     };
     let child_task = async {
         let mut child = launch_ssh_process(&resolved_username, host, port, config).await;
-        run(api, &mut child).await;
+        run(api, &mut child, &state_tx).await;
         return child;
     };
 
-    // Use tokio::select to run both tasks concurrently
+    // Visuals task: subscribes to the state watch channel and repaints the
+    // console whenever the daemon flips this client between Active and
+    // Disabled. Decoupling the redraw from `read_write_loop` keeps named-pipe
+    // I/O off the critical path of the (potentially slow) per-row
+    // `fill_console_output_attribute` calls inside `set_console_color`.
+    let visuals_task = {
+        let mut state_rx = state_rx;
+        async move {
+            let mut prev = *state_rx.borrow_and_update();
+            while state_rx.changed().await.is_ok() {
+                let next = *state_rx.borrow_and_update();
+                apply_state_visuals(api, prev, next, original_attrs);
+                prev = next;
+            }
+        }
+    };
+
+    // Use tokio::select to run all tasks concurrently. The title and visuals
+    // tasks are infinite by construction: as long as `state_tx` lives in this
+    // scope the watch channel stays open, so `visuals_task` cannot fall out
+    // of its loop. If either ever does complete, that is a logic bug, not a
+    // shutdown path.
     let child = tokio::select! {
         child = child_task => child,
         _ = title_task => {
             panic!("Title task should never complete");
+        }
+        _ = visuals_task => {
+            panic!("Visuals task should never complete");
         }
     };
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1060,6 +1060,13 @@ fn launch_client_console<W: WindowsApi>(
 /// the daemon - an unknown PID indicates broken daemon bookkeeping and is
 /// unrecoverable.
 ///
+/// Right after `subscribe`, the routine writes one
+/// [`TAG_STATE_CHANGE`] frame carrying the current authoritative
+/// [`ClientState`] so the client converges immediately even if the
+/// daemon called [`Daemon::set_client_state`] before the client
+/// connected; without this push the freshly-subscribed receiver would
+/// not observe the pre-existing value via `changed`.
+///
 /// Multiplexing: a biased [`tokio::select`] polls three branches per
 /// iteration in order - (a) the broadcast `receiver` for input records,
 /// (b) `state_rx.changed` for [`ClientState`] updates pushed by the
@@ -1120,6 +1127,21 @@ async fn named_pipe_server_routine(
             panic!("Unknown client PID {} - daemon bookkeeping broken", pid);
         }
     };
+
+    // Push the current authoritative state immediately so the client
+    // converges right after the PID handshake. `state_rx.changed()`
+    // only fires on transitions observed *after* `subscribe`, so a
+    // state set before this point (e.g. via `Daemon::set_client_state`
+    // during the brief window between `Client` construction and
+    // `subscribe`) would otherwise leave the client stuck on its
+    // default `ClientState::Active` even though the daemon already
+    // gates forwarding on the new value.
+    let initial_state = *state_rx.borrow_and_update();
+    let initial_frame: [u8; FRAMED_STATE_CHANGE_LENGTH] =
+        [TAG_STATE_CHANGE, serialize_client_state(initial_state)];
+    if !write_framed_message(&server, &initial_frame).await {
+        return;
+    }
 
     loop {
         tokio::select! {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -15,9 +15,11 @@ use std::{thread, time};
 
 use crate::get_console_window_handle;
 use crate::protocol::{
-    deserialization::deserialize_pid, serialization::serialize_input_record_0,
-    FRAMED_INPUT_RECORD_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
-    TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+    deserialization::deserialize_pid,
+    serialization::{serialize_client_state, serialize_input_record_0},
+    ClientState, FRAMED_INPUT_RECORD_LENGTH, FRAMED_STATE_CHANGE_LENGTH,
+    SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+    TAG_STATE_CHANGE,
 };
 use crate::utils::config::{Cluster, DaemonConfig};
 use crate::utils::debug::StringRepr;
@@ -35,10 +37,12 @@ use crate::{
 };
 use bracoxide::explode;
 use log::{debug, error, warn};
-use tokio::sync::broadcast::error::TryRecvError;
 use tokio::{
     net::windows::named_pipe::{NamedPipeServer, PipeMode, ServerOptions},
-    sync::broadcast::{self, Receiver, Sender},
+    sync::{
+        broadcast::{self, error::RecvError, Receiver, Sender},
+        watch,
+    },
     task::JoinHandle,
 };
 use windows::Win32::System::Console::{
@@ -63,18 +67,6 @@ mod workspace;
 /// to the named pipe servers connected to each client in parallel.
 const SENDER_CAPACITY: usize = 1024 * 1024;
 
-/// Runtime state of a client's assigned pipe server task.
-///
-/// Observed by the pipe server on each input record; determines whether
-/// the record is forwarded to the client over the named pipe.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PipeServerState {
-    /// Forward all input records to the client.
-    Enabled,
-    /// Consume input records without forwarding them to the client.
-    Disabled,
-}
-
 /// Representation of a client
 #[derive(Clone)]
 struct Client {
@@ -89,12 +81,15 @@ struct Client {
     /// Used by the pipe server task to correlate which client has connected
     /// to it, via a handshake over the named pipe.
     process_id: u32,
-    /// Shared state between this client and its assigned pipe server task.
+    /// Authoritative source for this client's [`ClientState`].
     ///
-    /// Populated at [`Client`] construction; cloned by the pipe server task upon
-    /// successful PID correlation and consulted during input forwarding to
-    /// determine whether records should be sent to the client.
-    pipe_server_state: Arc<Mutex<PipeServerState>>,
+    /// The daemon owns the [`watch::Sender`] and uses it to broadcast new
+    /// state values; the assigned pipe-server task subscribes upon
+    /// successful PID correlation and forwards every change to the client
+    /// over the named pipe. Wrapped in [`Arc`] because [`watch::Sender`]
+    /// itself is not [`Clone`] and the [`Client`] struct must remain
+    /// cloneable.
+    state_tx: Arc<watch::Sender<ClientState>>,
 }
 
 unsafe impl Send for Client {}
@@ -183,26 +178,6 @@ impl std::ops::Deref for Clients {
 
     fn deref(&self) -> &[Client] {
         return &self.list;
-    }
-}
-
-/// Flips each client's [`PipeServerState`] independently, so every
-/// `Enabled` client becomes `Disabled` and vice versa.
-///
-/// Calling this twice in a row restores the original state of every
-/// client.
-///
-/// # Arguments
-///
-/// * `clients` - The collection of clients whose pipe-server states should
-///   be flipped.
-fn toggle_pipe_server_states(clients: &Clients) {
-    for client in clients.iter() {
-        let mut state = client.pipe_server_state.lock().unwrap();
-        *state = match *state {
-            PipeServerState::Enabled => PipeServerState::Disabled,
-            PipeServerState::Disabled => PipeServerState::Enabled,
-        };
     }
 }
 
@@ -548,13 +523,36 @@ impl<'a> Daemon<'a> {
                     // TODO: Select windows
                 }
                 (VK_T, 0) => {
-                    toggle_pipe_server_states(&clients.lock().unwrap());
+                    let clients_guard = clients.lock().unwrap();
+                    // Snapshot each client's current state before flipping so
+                    // every client toggles independently and the loop does not
+                    // observe its own writes.
+                    let toggles: Vec<(u32, ClientState)> = clients_guard
+                        .iter()
+                        .map(|client| {
+                            let flipped = match *client.state_tx.borrow() {
+                                ClientState::Active => ClientState::Disabled,
+                                ClientState::Disabled => ClientState::Active,
+                            };
+                            return (client.process_id, flipped);
+                        })
+                        .collect();
+                    for (pid, state) in toggles {
+                        self.set_client_state(&clients_guard, pid, state);
+                    }
+                    drop(clients_guard);
                     self.quit_control_mode(windows_api);
                 }
                 (VK_N, 0) => {
-                    for client in clients.lock().unwrap().iter() {
-                        *client.pipe_server_state.lock().unwrap() = PipeServerState::Enabled;
+                    let clients_guard = clients.lock().unwrap();
+                    let pids: Vec<u32> = clients_guard
+                        .iter()
+                        .map(|client| return client.process_id)
+                        .collect();
+                    for pid in pids {
+                        self.set_client_state(&clients_guard, pid, ClientState::Active);
                     }
+                    drop(clients_guard);
                     self.quit_control_mode(windows_api);
                 }
                 (VK_C, 0) => {
@@ -743,6 +741,32 @@ impl<'a> Daemon<'a> {
         }
     }
 
+    /// Push a new [`ClientState`] to the client identified by `pid`.
+    ///
+    /// Looks the client up by PID and broadcasts the new state through its
+    /// [`watch::Sender`]. The pipe-server task subscribed to that sender
+    /// observes the change and forwards a [`crate::protocol::TAG_STATE_CHANGE`]
+    /// frame to the client over the named pipe.
+    ///
+    /// Currently unused; provided so the parallel issue #179 follow-up that
+    /// introduces `ClientState::Disabled` (and the control-mode binding to
+    /// toggle it) has a stable call site to plug into.
+    ///
+    /// # Arguments
+    ///
+    /// * `clients` - The daemon's tracked clients.
+    /// * `pid`     - Process id of the client whose state should change.
+    /// * `state`   - The new state to broadcast.
+    fn set_client_state(&self, clients: &Clients, pid: u32, state: ClientState) {
+        if let Some(client) = clients.get_by_pid(pid) {
+            // `send` returns Err only if there are no receivers, which can
+            // happen briefly between PID correlation and pipe-server task
+            // setup. Either way the next subscriber sees the latest value
+            // via `borrow`, so the error is intentionally ignored.
+            let _ = client.state_tx.send(state);
+        }
+    }
+
     /// Re-sizes and re-positions the daemon console window on the screen
     /// based on the daemon height configuration.
     ///
@@ -883,6 +907,11 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
                 len_hosts + index_offset,
                 aspect_ratio_adjustment,
             );
+            // The receiver is dropped immediately; pipe-server tasks acquire
+            // their own receivers via `state_tx.subscribe()` after PID
+            // correlation. Holding the sender on the [`Client`] keeps the
+            // channel alive for the lifetime of the client.
+            let (state_tx, _state_rx) = watch::channel(ClientState::Active);
             return (
                 index,
                 Client {
@@ -890,7 +919,7 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
                     window_handle,
                     process_handle,
                     process_id,
-                    pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+                    state_tx: Arc::new(state_tx),
                 },
             );
         });
@@ -1001,39 +1030,9 @@ fn launch_client_console<W: WindowsApi>(
     );
 }
 
-/// Probe `server` with a non-blocking keep-alive write to detect a closed pipe.
-///
-/// Writes a single [`TAG_KEEP_ALIVE`] byte - the zero-payload keep-alive frame
-/// of the daemon-to-client protocol - so the client side recognises and
-/// discards it. Treated as alive on success or `WouldBlock`; any other error
-/// means the pipe is closed.
-///
-/// # Arguments
-///
-/// * `server` - The named pipe server to probe.
-///
-/// # Returns
-///
-/// `true` if the pipe is still alive, `false` if it is closed and the
-/// caller's routine should stop. The caller is responsible for emitting
-/// any closed-pipe log message.
-fn probe_pipe_alive(server: &NamedPipeServer) -> bool {
-    match server.try_write(&[TAG_KEEP_ALIVE]) {
-        Ok(_) => return true,
-        Err(e) if e.kind() == io::ErrorKind::WouldBlock => return true,
-        Err(_) => {
-            debug!(
-                "Named pipe server ({:?}) is closed, stopping named pipe server routine",
-                server
-            );
-            return false;
-        }
-    }
-}
-
 /// Wait for the named pipe server to connect, correlate the client by
-/// its process id, then forward serialized input records read from the
-/// broadcast channel to the named pipe server.
+/// its process id, then multiplex broadcast input records, [`ClientState`]
+/// updates, and idle keep-alives onto the named pipe.
 ///
 /// Correlation: after [`NamedPipeServer::connect`] resolves, the client is
 /// expected to write its 4 byte little-endian process id into the pipe. The
@@ -1042,27 +1041,33 @@ fn probe_pipe_alive(server: &NamedPipeServer) -> bool {
 /// the daemon - an unknown PID indicates broken daemon bookkeeping and is
 /// unrecoverable.
 ///
-/// Forwarding: on every broadcast record, the routine matches on the
-/// [`PipeServerState`] cloned from the correlated client; only
-/// [`PipeServerState::Enabled`] writes the record to the pipe. The keep-alive
-/// write stays unconditional so dead pipes are detected regardless of state.
+/// Multiplexing: a biased [`tokio::select`] polls three branches per
+/// iteration in order - (a) the broadcast `receiver` for input records,
+/// (b) `state_rx.changed` for [`ClientState`] updates pushed by the
+/// daemon, (c) a 5 ms timer that emits a keep-alive frame so dead pipes
+/// are detected even when the daemon has nothing to send. The biased
+/// ordering ensures the keep-alive branch only fires when neither input
+/// nor state-change is ready, so it cannot interrupt active traffic.
+/// Input records are gated on the current [`ClientState`] read via
+/// `*state_rx.borrow()`: [`ClientState::Active`] forwards the record,
+/// [`ClientState::Disabled`] drops it and yields so the daemon does not
+/// tight-loop while the client is suppressed.
 ///
-/// If writing to the pipe fails the pipe is considered closed and the routine ends.
-/// To detect if a client is still alive even if we are currently
-/// not sending data, we send a tagged keep-alive frame ([`TAG_KEEP_ALIVE`]).
-/// If that fails, the routine ends.
+/// If any write to the pipe fails the pipe is considered closed and the
+/// routine ends. If the [`watch::Sender`] is dropped (i.e. the daemon
+/// removed the client from its bookkeeping) the routine likewise ends.
 ///
 /// # Arguments
 ///
 /// * `server`   - The named pipe server over which we send data to the
 ///                client.
 /// * `receiver` - The receiving end of the broadcast channel through
-///                which we get the serialize input records from the main
+///                which we get the serialized input records from the main
 ///                thread that are to be sent to the client via the named
 ///                pipe.
 /// * `clients`  - The daemon's collection of tracked clients, used to
 ///                correlate the connecting client by PID and to obtain
-///                the shared [`PipeServerState`] reference for this server.
+///                the shared [`watch::Sender`] reference for this server.
 ///
 /// # Panics
 ///
@@ -1081,8 +1086,8 @@ async fn named_pipe_server_routine(
 
     // Correlate the connecting client by reading its 4 byte PID.
     let pid = read_client_pid(&server).await;
-    let pipe_server_state = match clients.lock().unwrap().get_by_pid(pid) {
-        Some(client) => Arc::clone(&client.pipe_server_state),
+    let mut state_rx = match clients.lock().unwrap().get_by_pid(pid) {
+        Some(client) => client.state_tx.subscribe(),
         None => {
             error!(
                 "Named pipe server received unknown PID {} - daemon bookkeeping broken",
@@ -1098,101 +1103,133 @@ async fn named_pipe_server_routine(
     };
 
     loop {
-        let ser_input_record = match receiver.try_recv() {
-            Ok(val) => val,
-            Err(TryRecvError::Empty) => {
-                tokio::time::sleep(Duration::from_millis(5)).await;
-                if !probe_pipe_alive(&server) {
+        tokio::select! {
+            biased;
+            recv_result = receiver.recv() => {
+                let ser_input_record = match recv_result {
+                    Ok(val) => val,
+                    Err(RecvError::Lagged(skipped)) => {
+                        // A slow consumer (typically a disabled client throttling
+                        // its read loop) can fall behind the bounded broadcast
+                        // buffer. Drop the skipped records and continue rather
+                        // than killing the routine - the missed keystrokes are
+                        // unrecoverable, but the pipe is still useful. Logged at
+                        // `debug!` because lagged drops can fire repeatedly and
+                        // are not actionable per occurrence.
+                        debug!(
+                            "Named pipe server routine lagged behind broadcast channel - dropping {} record(s)",
+                            skipped
+                        );
+                        continue;
+                    }
+                    Err(RecvError::Closed) => {
+                        error!("Broadcast channel closed");
+                        panic!("Failed to receive data from the Receiver");
+                    }
+                };
+                // Gate forwarding on the current state. The match is exhaustive
+                // so the compiler will flag this site when new variants are
+                // added. Copy the value out before any `.await` so the
+                // `watch::Ref` (not `Send`) does not span the await.
+                let current_state = *state_rx.borrow();
+                match current_state {
+                    ClientState::Active => {}
+                    ClientState::Disabled => {
+                        // Yield so we don't tight-loop when the broadcast
+                        // channel is busy. The keep-alive branch will detect
+                        // pipe death even while the client is suppressed.
+                        tokio::task::yield_now().await;
+                        continue;
+                    }
+                }
+                // Build the tagged input-record frame: [TAG_INPUT_RECORD][13-byte payload].
+                let mut frame = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+                frame[0] = TAG_INPUT_RECORD;
+                frame[1..].copy_from_slice(&ser_input_record);
+                if !write_framed_message(&server, &frame).await {
                     return;
                 }
-                continue;
             }
-            Err(TryRecvError::Lagged(skipped)) => {
-                // A slow consumer (typically a disabled client throttling
-                // its read loop) can fall behind the bounded broadcast
-                // buffer. Drop the skipped records and continue rather
-                // than killing the routine - the missed keystrokes are
-                // unrecoverable, but the pipe is still useful.
-                //
-                // Throttle the same way the `Empty` arm does so a
-                // sustained overflow cannot busy-spin, and log at
-                // `debug!` because lagged drops can fire repeatedly
-                // and are not actionable per occurrence.
-                debug!(
-                    "Named pipe server routine lagged behind broadcast channel - dropping {} record(s)",
-                    skipped
-                );
-                tokio::time::sleep(Duration::from_millis(5)).await;
-                if !probe_pipe_alive(&server) {
-                    return;
-                }
-                continue;
-            }
-            Err(err) => {
-                error!("{}", err);
-                panic!("Failed to receive data from the Receiver");
-            }
-        };
-        // Only forward to the client if its pipe server state allows it.
-        // Copy the state out so the mutex guard does not span the `.await`
-        // below - `MutexGuard` is not `Send` and would prevent the routine
-        // from being spawned on a multi-threaded runtime.
-        let state = *pipe_server_state.lock().unwrap();
-        match state {
-            PipeServerState::Enabled => {}
-            PipeServerState::Disabled => {
-                // Still probe the pipe while disabled so client disconnects
-                // are detected promptly under sustained input.
-                if !probe_pipe_alive(&server) {
-                    return;
-                }
-                // Yield so we don't tight-loop when the broadcast channel is busy.
-                tokio::task::yield_now().await;
-                continue;
-            }
-        }
-        // Build the tagged input-record frame: [TAG_INPUT_RECORD][13-byte payload].
-        let mut frame = [0u8; FRAMED_INPUT_RECORD_LENGTH];
-        frame[0] = TAG_INPUT_RECORD;
-        frame[1..].copy_from_slice(&ser_input_record);
-        // Track how many bytes of `frame` have already been written so that
-        // a partial write retries only the unwritten suffix; otherwise a
-        // retry of the full frame would duplicate the already-written prefix
-        // (including the tag byte) and corrupt the stream.
-        let mut written = 0usize;
-        loop {
-            server.writable().await.unwrap_or_else(|err| {
-                error!("{}", err);
-                panic!("Timed out waiting for named pipe server to become writable",)
-            });
-            match server.try_write(&frame[written..]) {
-                Ok(n) if written + n == FRAMED_INPUT_RECORD_LENGTH => {
-                    debug!("Successfully written all data");
-                    break;
-                }
-                Ok(n) => {
-                    // The data was only written partially, try again with the suffix.
-                    written += n;
-                    warn!(
-                        "Partially written data, expected {} but only wrote {} so far",
-                        FRAMED_INPUT_RECORD_LENGTH, written
-                    );
-                    continue;
-                }
-                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                    // Try again
-                    debug!("Writing to named pipe server would have blocked");
-                    continue;
-                }
-                Err(_) => {
-                    // Can happen if the pipe is closed because the
-                    // client exited
+            changed_result = state_rx.changed() => {
+                // Sender dropped - the daemon has removed this client from its
+                // bookkeeping, so there is nothing left to forward.
+                if changed_result.is_err() {
                     debug!(
-                        "Named pipe server ({:?}) is closed, stopping named pipe server routine",
+                        "Client state sender dropped, stopping named pipe server routine ({:?})",
                         server
                     );
                     return;
                 }
+                let state = *state_rx.borrow_and_update();
+                let frame: [u8; FRAMED_STATE_CHANGE_LENGTH] =
+                    [TAG_STATE_CHANGE, serialize_client_state(state)];
+                if !write_framed_message(&server, &frame).await {
+                    return;
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(5)) => {
+                if !write_framed_message(&server, &[TAG_KEEP_ALIVE]).await {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Write all of `frame` to the named pipe server, retrying partial writes
+/// and `WouldBlock` results until the buffer is fully drained.
+///
+/// Shared by every write path inside [`named_pipe_server_routine`] so the
+/// partial-write retry loop and pipe-closed detection live in one place.
+///
+/// # Arguments
+///
+/// * `server` - The connected named pipe server to write to.
+/// * `frame`  - The complete framed wire bytes to push to the client.
+///
+/// # Returns
+///
+/// `true` once the entire frame has been written. `false` if the pipe is
+/// closed (typically because the client process exited); the caller treats
+/// this as a signal to terminate the routine.
+///
+/// # Panics
+///
+/// Panics if waiting for the pipe to become writable returns an error, as
+/// the daemon cannot recover from a broken pipe handle.
+async fn write_framed_message(server: &NamedPipeServer, frame: &[u8]) -> bool {
+    loop {
+        server.writable().await.unwrap_or_else(|err| {
+            error!("{}", err);
+            panic!("Timed out waiting for named pipe server to become writable",)
+        });
+        match server.try_write(frame) {
+            Ok(n) if n == frame.len() => {
+                debug!("Successfully written all data");
+                return true;
+            }
+            Ok(n) => {
+                // The data was only written partially, try again
+                warn!(
+                    "Partially written data, expected {} but only wrote {}",
+                    frame.len(),
+                    n
+                );
+                continue;
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                // Try again
+                debug!("Writing to named pipe server would have blocked");
+                continue;
+            }
+            Err(_) => {
+                // Can happen if the pipe is closed because the
+                // client exited
+                debug!(
+                    "Named pipe server ({:?}) is closed, stopping named pipe server routine",
+                    server
+                );
+                return false;
             }
         }
     }
@@ -1457,7 +1494,7 @@ fn defer_windows<W: WindowsApi>(windows_api: &W, clients: &[Client], daemon_hand
         window_handle: *daemon_handle,
         process_handle: HANDLE::default(),
         process_id: 0,
-        pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+        state_tx: Arc::new(watch::channel(ClientState::Active).0),
     }]) {
         let placement = match windows_api.get_window_placement(client.window_handle) {
             Ok(placement) => placement,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1198,24 +1198,33 @@ async fn named_pipe_server_routine(
 /// Panics if waiting for the pipe to become writable returns an error, as
 /// the daemon cannot recover from a broken pipe handle.
 async fn write_framed_message(server: &NamedPipeServer, frame: &[u8]) -> bool {
-    loop {
+    let mut written = 0usize;
+    while written < frame.len() {
         server.writable().await.unwrap_or_else(|err| {
             error!("{}", err);
             panic!("Timed out waiting for named pipe server to become writable",)
         });
-        match server.try_write(frame) {
-            Ok(n) if n == frame.len() => {
-                debug!("Successfully written all data");
-                return true;
+        match server.try_write(&frame[written..]) {
+            Ok(0) => {
+                // A zero-byte successful write means the pipe is closed
+                // (typically because the client exited).
+                debug!(
+                    "Named pipe server ({:?}) is closed, stopping named pipe server routine",
+                    server
+                );
+                return false;
             }
             Ok(n) => {
-                // The data was only written partially, try again
-                warn!(
-                    "Partially written data, expected {} but only wrote {}",
-                    frame.len(),
-                    n
-                );
-                continue;
+                written += n;
+                if written < frame.len() {
+                    // The data was only written partially, retry the
+                    // remaining suffix on the next iteration.
+                    warn!(
+                        "Partially written data, expected {} but only wrote {} so far",
+                        frame.len(),
+                        written
+                    );
+                }
             }
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                 // Try again
@@ -1233,6 +1242,8 @@ async fn write_framed_message(server: &NamedPipeServer, frame: &[u8]) -> bool {
             }
         }
     }
+    debug!("Successfully written all data");
+    return true;
 }
 
 /// Read the connecting client's 4 byte little-endian process id from the pipe.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -83,13 +83,12 @@ struct Client {
     process_id: u32,
     /// Authoritative source for this client's [`ClientState`].
     ///
-    /// The daemon owns the [`watch::Sender`] and uses it to broadcast new
-    /// state values; the assigned pipe-server task subscribes upon
-    /// successful PID correlation and forwards every change to the client
-    /// over the named pipe. Wrapped in [`Arc`] because [`watch::Sender`]
-    /// itself is not [`Clone`] and the [`Client`] struct must remain
-    /// cloneable.
-    state_tx: Arc<watch::Sender<ClientState>>,
+    /// The daemon broadcasts new state values through the [`watch::Sender`];
+    /// the assigned pipe-server task subscribes upon successful PID
+    /// correlation and forwards every change to the client over the named
+    /// pipe. [`watch::Sender`] is itself [`Clone`], so cloning a [`Client`]
+    /// produces another sender that drives the same channel.
+    state_tx: watch::Sender<ClientState>,
 }
 
 unsafe impl Send for Client {}
@@ -523,36 +522,30 @@ impl<'a> Daemon<'a> {
                     // TODO: Select windows
                 }
                 (VK_T, 0) => {
-                    let clients_guard = clients.lock().unwrap();
                     // Snapshot each client's current state before flipping so
                     // every client toggles independently and the loop does not
                     // observe its own writes.
-                    let toggles: Vec<(u32, ClientState)> = clients_guard
-                        .iter()
-                        .map(|client| {
-                            let flipped = match *client.state_tx.borrow() {
-                                ClientState::Active => ClientState::Disabled,
-                                ClientState::Disabled => ClientState::Active,
-                            };
-                            return (client.process_id, flipped);
-                        })
-                        .collect();
-                    for (pid, state) in toggles {
-                        self.set_client_state(&clients_guard, pid, state);
-                    }
-                    drop(clients_guard);
+                    self.update_client_states(clients, |clients_guard| {
+                        return clients_guard
+                            .iter()
+                            .map(|client| {
+                                let flipped = match *client.state_tx.borrow() {
+                                    ClientState::Active => ClientState::Disabled,
+                                    ClientState::Disabled => ClientState::Active,
+                                };
+                                return (client.process_id, flipped);
+                            })
+                            .collect();
+                    });
                     self.quit_control_mode(windows_api);
                 }
                 (VK_N, 0) => {
-                    let clients_guard = clients.lock().unwrap();
-                    let pids: Vec<u32> = clients_guard
-                        .iter()
-                        .map(|client| return client.process_id)
-                        .collect();
-                    for pid in pids {
-                        self.set_client_state(&clients_guard, pid, ClientState::Active);
-                    }
-                    drop(clients_guard);
+                    self.update_client_states(clients, |clients_guard| {
+                        return clients_guard
+                            .iter()
+                            .map(|client| return (client.process_id, ClientState::Active))
+                            .collect();
+                    });
                     self.quit_control_mode(windows_api);
                 }
                 (VK_C, 0) => {
@@ -741,16 +734,40 @@ impl<'a> Daemon<'a> {
         }
     }
 
+    /// Apply a batch of [`ClientState`] updates while holding the
+    /// [`Clients`] mutex exactly once.
+    ///
+    /// Locks `clients`, invokes `f` with the guard so the caller can build
+    /// the list of `(pid, new_state)` pairs while observing a stable
+    /// snapshot, applies each update via [`Daemon::set_client_state`], and
+    /// releases the guard. Centralises the lock-once / snapshot / apply /
+    /// release pattern shared by the `[t]oggle enabled` and `e[n]able all`
+    /// control-mode handlers.
+    ///
+    /// # Arguments
+    ///
+    /// * `clients` - Shared client collection.
+    /// * `f`       - Closure that receives a `&Clients` guard and returns
+    ///               the `(pid, new_state)` updates to broadcast.
+    fn update_client_states<F>(&self, clients: &Mutex<Clients>, f: F)
+    where
+        F: FnOnce(&Clients) -> Vec<(u32, ClientState)>,
+    {
+        let clients_guard = clients.lock().unwrap();
+        let updates = f(&clients_guard);
+        for (pid, state) in updates {
+            self.set_client_state(&clients_guard, pid, state);
+        }
+    }
+
     /// Push a new [`ClientState`] to the client identified by `pid`.
     ///
     /// Looks the client up by PID and broadcasts the new state through its
     /// [`watch::Sender`]. The pipe-server task subscribed to that sender
     /// observes the change and forwards a [`crate::protocol::TAG_STATE_CHANGE`]
-    /// frame to the client over the named pipe.
-    ///
-    /// Currently unused; provided so the parallel issue #179 follow-up that
-    /// introduces `ClientState::Disabled` (and the control-mode binding to
-    /// toggle it) has a stable call site to plug into.
+    /// frame to the client over the named pipe. Called from the
+    /// control-mode handlers for `[t]oggle enabled` and `e[n]able all` via
+    /// [`Daemon::update_client_states`].
     ///
     /// # Arguments
     ///
@@ -759,11 +776,13 @@ impl<'a> Daemon<'a> {
     /// * `state`   - The new state to broadcast.
     fn set_client_state(&self, clients: &Clients, pid: u32, state: ClientState) {
         if let Some(client) = clients.get_by_pid(pid) {
-            // `send` returns Err only if there are no receivers, which can
-            // happen briefly between PID correlation and pipe-server task
-            // setup. Either way the next subscriber sees the latest value
-            // via `borrow`, so the error is intentionally ignored.
-            let _ = client.state_tx.send(state);
+            // `send_replace` always updates the stored value (unlike `send`,
+            // which returns `Err` and leaves the value untouched when there
+            // are no active receivers). This matters during the brief window
+            // between [`Client`] construction and the pipe-server task's
+            // `subscribe()`: any state change pushed in that window must
+            // still be visible to the next subscriber via `borrow`.
+            client.state_tx.send_replace(state);
         }
     }
 
@@ -919,7 +938,7 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
                     window_handle,
                     process_handle,
                     process_id,
-                    state_tx: Arc::new(state_tx),
+                    state_tx,
                 },
             );
         });
@@ -1505,7 +1524,7 @@ fn defer_windows<W: WindowsApi>(windows_api: &W, clients: &[Client], daemon_hand
         window_handle: *daemon_handle,
         process_handle: HANDLE::default(),
         process_id: 0,
-        state_tx: Arc::new(watch::channel(ClientState::Active).0),
+        state_tx: watch::channel(ClientState::Active).0,
     }]) {
         let placement = match windows_api.get_window_placement(client.window_handle) {
             Ok(placement) => placement,

--- a/src/protocol/deserialization.rs
+++ b/src/protocol/deserialization.rs
@@ -4,8 +4,8 @@ use windows::Win32::{
 };
 
 use crate::protocol::{
-    DaemonToClientMessage, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
-    TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+    ClientState, DaemonToClientMessage, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+    TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
 };
 
 /// Deserialize a [KEY_EVENT_RECORD_0] from a u8 slice using custom binary format.
@@ -61,6 +61,31 @@ pub fn deserialize_pid(bytes: &[u8; SERIALIZED_PID_LENGTH]) -> u32 {
     return u32::from_le_bytes(*bytes);
 }
 
+/// Deserialize a single byte into a [`ClientState`] variant.
+///
+/// # Arguments
+///
+/// * `byte` - The single payload byte of a [`crate::protocol::TAG_STATE_CHANGE`]
+///            frame, equal to a [`ClientState`]'s `#[repr(u8)]` discriminant.
+///
+/// # Returns
+///
+/// The decoded [`ClientState`].
+///
+/// # Panics
+///
+/// Panics if `byte` does not match a known [`ClientState`] discriminant. An
+/// unknown value indicates either a protocol-version mismatch between the
+/// daemon and client or corruption on the pipe - both unrecoverable, matching
+/// the codebase's "broken bookkeeping -> panic" convention.
+pub fn deserialize_client_state(byte: u8) -> ClientState {
+    match byte {
+        x if x == ClientState::Active as u8 => return ClientState::Active,
+        x if x == ClientState::Disabled as u8 => return ClientState::Disabled,
+        other => panic!("Unknown ClientState byte: 0x{other:02X}"),
+    }
+}
+
 /// Parse as many complete [`DaemonToClientMessage`]s as possible from `buffer`.
 ///
 /// The parser walks `buffer` from the start, decoding one tag-prefixed frame
@@ -102,6 +127,16 @@ pub fn parse_daemon_to_client_messages(buffer: &[u8]) -> (Vec<DaemonToClientMess
                 let record = deserialize_input_record_0(&buffer[payload_start..payload_end]);
                 messages.push(DaemonToClientMessage::InputRecord(record));
                 pos = payload_end;
+            }
+            TAG_STATE_CHANGE => {
+                let payload_index = pos + 1;
+                if buffer.len() <= payload_index {
+                    // Trailing partial frame; stop and return it as remainder.
+                    break;
+                }
+                let state = deserialize_client_state(buffer[payload_index]);
+                messages.push(DaemonToClientMessage::StateChange(state));
+                pos = payload_index + 1;
             }
             TAG_KEEP_ALIVE => {
                 messages.push(DaemonToClientMessage::KeepAlive);

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -36,11 +36,11 @@ pub const SERIALIZED_PID_LENGTH: usize = 4;
 /// by [`crate::protocol::serialization::serialize_input_record_0`].
 pub const TAG_INPUT_RECORD: u8 = 0x00;
 
-/// Tag byte reserved for client state-change messages.
+/// Tag byte identifying a client state-change message on the daemon-to-client
+/// pipe.
 ///
-/// Not yet emitted by the daemon. Reserved here to lock in the wire-format
-/// numbering used by the issue #179 follow-up PR that introduces the
-/// `ClientState` plumbing.
+/// The tag byte is followed by the single-byte payload produced by
+/// [`crate::protocol::serialization::serialize_client_state`].
 pub const TAG_STATE_CHANGE: u8 = 0x01;
 
 /// Tag byte identifying a zero-payload keep-alive message on the
@@ -57,15 +57,45 @@ pub const FRAMED_INPUT_RECORD_LENGTH: usize = 1 + SERIALIZED_INPUT_RECORD_0_LENG
 /// Length on the wire of a framed keep-alive message: just the tag byte.
 pub const FRAMED_KEEP_ALIVE_LENGTH: usize = 1;
 
+/// Length on the wire of a framed state-change message: the tag byte plus
+/// a single-byte [`ClientState`] payload.
+pub const FRAMED_STATE_CHANGE_LENGTH: usize = 2;
+
+/// Runtime state of a single client.
+///
+/// Authoritative state value tracked per client by the daemon and pushed to
+/// the corresponding client over the named pipe. Both ends consult this
+/// value: the daemon to gate input forwarding, the client to know its own
+/// state inside its main loop.
+///
+/// `#[repr(u8)]` so the enum round-trips through
+/// [`crate::protocol::serialization::serialize_client_state`] /
+/// [`crate::protocol::deserialization::deserialize_client_state`] using a
+/// single byte.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientState {
+    /// Client receives and replays all input records broadcast by the
+    /// daemon.
+    Active = 0,
+    /// Daemon suppresses input forwarding for this client. The client is
+    /// informed via [`TAG_STATE_CHANGE`] so it can render itself
+    /// accordingly.
+    Disabled = 1,
+}
+
 /// Daemon-to-client message variants exchanged over the named pipe.
 ///
 /// Each variant maps to a distinct tag byte at the start of the wire
-/// representation; see [`TAG_INPUT_RECORD`] and [`TAG_KEEP_ALIVE`].
+/// representation; see [`TAG_INPUT_RECORD`], [`TAG_STATE_CHANGE`] and
+/// [`TAG_KEEP_ALIVE`].
 #[derive(Clone, Copy)]
 pub enum DaemonToClientMessage {
     /// Carries an [`INPUT_RECORD_0`] (`KeyEvent`) to be replayed to the
     /// client's console input buffer.
     InputRecord(INPUT_RECORD_0),
+    /// Carries the new [`ClientState`] the daemon assigned to this client.
+    StateChange(ClientState),
     /// Empty payload sent on idle by the daemon's pipe server to detect a
     /// closed client pipe.
     KeepAlive,

--- a/src/protocol/serialization.rs
+++ b/src/protocol/serialization.rs
@@ -1,8 +1,9 @@
 use windows::Win32::System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0};
 
 use crate::protocol::{
-    DaemonToClientMessage, FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH,
-    SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+    ClientState, DaemonToClientMessage, FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH,
+    FRAMED_STATE_CHANGE_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+    TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
 };
 
 /// Serialize a [KEY_EVENT_RECORD_0] into a `Vec<u8>` using custom binary format.
@@ -53,6 +54,20 @@ pub fn serialize_pid(pid: u32) -> [u8; SERIALIZED_PID_LENGTH] {
     return pid.to_le_bytes();
 }
 
+/// Serialize a [`ClientState`] into its single-byte wire representation.
+///
+/// # Arguments
+///
+/// * `state` - The client state to serialize.
+///
+/// # Returns
+///
+/// The state's `#[repr(u8)]` discriminant, used as the payload of a tagged
+/// [`crate::protocol::TAG_STATE_CHANGE`] frame.
+pub fn serialize_client_state(state: ClientState) -> u8 {
+    return state as u8;
+}
+
 /// Serialize a [`DaemonToClientMessage`] into its tagged-envelope wire
 /// representation.
 ///
@@ -73,6 +88,12 @@ pub fn serialize_daemon_to_client_message(msg: &DaemonToClientMessage) -> Vec<u8
             let mut buf = Vec::with_capacity(FRAMED_INPUT_RECORD_LENGTH);
             buf.push(TAG_INPUT_RECORD);
             buf.extend_from_slice(&serialize_input_record_0(record));
+            return buf;
+        }
+        DaemonToClientMessage::StateChange(state) => {
+            let mut buf = Vec::with_capacity(FRAMED_STATE_CHANGE_LENGTH);
+            buf.push(TAG_STATE_CHANGE);
+            buf.push(serialize_client_state(*state));
             return buf;
         }
         DaemonToClientMessage::KeepAlive => {

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -10,9 +10,11 @@ use windows::Win32::System::Console::{
 use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 
 use crate::client::{
-    build_ssh_arguments, is_alt_shift_c_combination, resolve_username, send_pid_handshake,
-    write_console_input,
+    build_ssh_arguments, is_alt_shift_c_combination, read_write_loop, resolve_username,
+    send_pid_handshake, write_console_input, ReadWriteResult,
 };
+use crate::protocol::serialization::{serialize_client_state, serialize_input_record_0};
+use crate::protocol::{ClientState, TAG_INPUT_RECORD, TAG_STATE_CHANGE};
 use crate::utils::config::ClientConfig;
 use crate::utils::windows::MockWindowsApi;
 
@@ -486,6 +488,97 @@ fn test_write_console_input() {
         // Execute the function under test
         write_console_input(&mock_api, test_input_record);
     }
+}
+
+#[tokio::test]
+async fn test_read_write_loop_dispatches_state_change_and_input_record(
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io;
+    use tokio::net::windows::named_pipe::{ClientOptions, PipeMode, ServerOptions};
+    use windows::Win32::System::Console::INPUT_RECORD_0;
+
+    // Use a per-test unique pipe name so parallel test runs don't collide
+    // on the global PIPE_NAME.
+    let pipe_name = format!(
+        r"\\.\pipe\csshw-test-read-write-loop-{}",
+        std::process::id()
+    );
+    let server = ServerOptions::new()
+        .access_inbound(true)
+        .access_outbound(true)
+        .pipe_mode(PipeMode::Message)
+        .create(&pipe_name)?;
+    let client = ClientOptions::new().open(&pipe_name)?;
+    server.connect().await?;
+
+    // Build a StateChange frame followed by an InputRecord frame so the
+    // test exercises both the state-update dispatch and the input-forwarding
+    // regression path in a single call.
+    let input_record = INPUT_RECORD_0 {
+        KeyEvent: KEY_EVENT_RECORD {
+            bKeyDown: true.into(),
+            wRepeatCount: 1,
+            wVirtualKeyCode: VK_C.0,
+            wVirtualScanCode: 0,
+            uChar: KEY_EVENT_RECORD_0 {
+                UnicodeChar: b'c' as u16,
+            },
+            dwControlKeyState: 0,
+        },
+    };
+    let mut payload: Vec<u8> = Vec::new();
+    payload.push(TAG_STATE_CHANGE);
+    payload.push(serialize_client_state(ClientState::Active));
+    payload.push(TAG_INPUT_RECORD);
+    payload.extend_from_slice(&serialize_input_record_0(&input_record));
+
+    // Push the framed bytes onto the pipe so the client side can consume
+    // them via [`read_write_loop`].
+    let mut written = 0usize;
+    while written < payload.len() {
+        server.writable().await?;
+        match server.try_write(&payload[written..]) {
+            Ok(0) => return Err("pipe closed before write completed".into()),
+            Ok(n) => written += n,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    // The mock API must observe exactly one [`write_console_input`] call -
+    // proves the input-forwarding path still runs after the state-change
+    // dispatch.
+    let mut mock_api = MockWindowsApi::new();
+    mock_api
+        .expect_write_console_input()
+        .times(1)
+        .returning(|_, number_written| {
+            *number_written = 1;
+            return Ok(());
+        });
+
+    let mut internal_buffer: Vec<u8> = Vec::new();
+    let mut current_state = ClientState::Active;
+    // Wait until the client side has bytes available.
+    client.readable().await?;
+    let result =
+        read_write_loop(&mock_api, &client, &mut internal_buffer, &mut current_state).await;
+
+    match result {
+        ReadWriteResult::Success {
+            remainder,
+            key_event_records,
+        } => {
+            assert!(remainder.is_empty());
+            assert_eq!(key_event_records.len(), 1);
+            assert_eq!(key_event_records[0].wVirtualKeyCode, VK_C.0);
+        }
+        _ => panic!("expected ReadWriteResult::Success"),
+    }
+    // The state byte applied through the StateChange frame must be reflected
+    // in the &mut ClientState handed back to the caller.
+    assert_eq!(current_state, ClientState::Active);
+    return Ok(());
 }
 
 #[tokio::test]

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -606,7 +606,10 @@ async fn test_read_write_loop_dispatches_disabled_state_change(
 
     // A lone StateChange(Disabled) frame - no input records this time, so
     // the API must not see any `write_console_input` calls.
-    let payload: Vec<u8> = vec![TAG_STATE_CHANGE, serialize_client_state(ClientState::Disabled)];
+    let payload: Vec<u8> = vec![
+        TAG_STATE_CHANGE,
+        serialize_client_state(ClientState::Disabled),
+    ];
 
     let mut written = 0usize;
     while written < payload.len() {

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -10,13 +10,16 @@ use windows::Win32::System::Console::{
 use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 
 use crate::client::{
-    build_ssh_arguments, is_alt_shift_c_combination, read_write_loop, resolve_username,
-    send_pid_handshake, write_console_input, ReadWriteResult,
+    apply_state_visuals, build_ssh_arguments, is_alt_shift_c_combination, read_write_loop,
+    resolve_username, send_pid_handshake, write_console_input, ReadWriteResult,
+    DISABLED_CONSOLE_ATTRIBUTES,
 };
 use crate::protocol::serialization::{serialize_client_state, serialize_input_record_0};
 use crate::protocol::{ClientState, TAG_INPUT_RECORD, TAG_STATE_CHANGE};
 use crate::utils::config::ClientConfig;
 use crate::utils::windows::MockWindowsApi;
+use tokio::sync::watch;
+use windows::Win32::System::Console::{CONSOLE_CHARACTER_ATTRIBUTES, CONSOLE_SCREEN_BUFFER_INFO};
 
 // Test constants - consistent dummy values used throughout tests
 const TEST_USERNAME: &str = "testuser";
@@ -558,11 +561,13 @@ async fn test_read_write_loop_dispatches_state_change_and_input_record(
         });
 
     let mut internal_buffer: Vec<u8> = Vec::new();
-    let mut current_state = ClientState::Active;
+    // Initialize the watch channel with the *opposite* state so that a
+    // successful dispatch is visible as a value change, not a same-value
+    // replay.
+    let (state_tx, state_rx) = watch::channel(ClientState::Disabled);
     // Wait until the client side has bytes available.
     client.readable().await?;
-    let result =
-        read_write_loop(&mock_api, &client, &mut internal_buffer, &mut current_state).await;
+    let result = read_write_loop(&mock_api, &client, &mut internal_buffer, &state_tx).await;
 
     match result {
         ReadWriteResult::Success {
@@ -576,9 +581,161 @@ async fn test_read_write_loop_dispatches_state_change_and_input_record(
         _ => panic!("expected ReadWriteResult::Success"),
     }
     // The state byte applied through the StateChange frame must be reflected
-    // in the &mut ClientState handed back to the caller.
-    assert_eq!(current_state, ClientState::Active);
+    // in the watch channel handed back to the caller.
+    assert_eq!(*state_rx.borrow(), ClientState::Active);
     return Ok(());
+}
+
+#[tokio::test]
+async fn test_read_write_loop_dispatches_disabled_state_change(
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io;
+    use tokio::net::windows::named_pipe::{ClientOptions, PipeMode, ServerOptions};
+
+    let pipe_name = format!(
+        r"\\.\pipe\csshw-test-read-write-loop-disabled-{}",
+        std::process::id()
+    );
+    let server = ServerOptions::new()
+        .access_inbound(true)
+        .access_outbound(true)
+        .pipe_mode(PipeMode::Message)
+        .create(&pipe_name)?;
+    let client = ClientOptions::new().open(&pipe_name)?;
+    server.connect().await?;
+
+    // A lone StateChange(Disabled) frame - no input records this time, so
+    // the API must not see any `write_console_input` calls.
+    let payload: Vec<u8> = vec![TAG_STATE_CHANGE, serialize_client_state(ClientState::Disabled)];
+
+    let mut written = 0usize;
+    while written < payload.len() {
+        server.writable().await?;
+        match server.try_write(&payload[written..]) {
+            Ok(0) => return Err("pipe closed before write completed".into()),
+            Ok(n) => written += n,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    let mock_api = MockWindowsApi::new();
+    let mut internal_buffer: Vec<u8> = Vec::new();
+    let (state_tx, state_rx) = watch::channel(ClientState::Active);
+
+    client.readable().await?;
+    let result = read_write_loop(&mock_api, &client, &mut internal_buffer, &state_tx).await;
+
+    match result {
+        ReadWriteResult::Success {
+            remainder,
+            key_event_records,
+        } => {
+            assert!(remainder.is_empty());
+            assert!(key_event_records.is_empty());
+        }
+        _ => panic!("expected ReadWriteResult::Success"),
+    }
+    assert_eq!(*state_rx.borrow(), ClientState::Disabled);
+    return Ok(());
+}
+
+/// Helper: build a `CONSOLE_SCREEN_BUFFER_INFO` with the buffer size used
+/// for the `apply_state_visuals` tests below.
+fn buffer_info(rows: i16) -> CONSOLE_SCREEN_BUFFER_INFO {
+    let mut info = CONSOLE_SCREEN_BUFFER_INFO::default();
+    info.dwSize.X = 80;
+    info.dwSize.Y = rows;
+    return info;
+}
+
+#[test]
+fn test_apply_state_visuals_active_to_disabled_repaints_with_disabled_palette() {
+    let original = CONSOLE_CHARACTER_ATTRIBUTES(0x07);
+    let rows: i16 = 25;
+
+    let mut mock_api = MockWindowsApi::new();
+    mock_api
+        .expect_set_console_text_attribute()
+        .with(mockall::predicate::eq(DISABLED_CONSOLE_ATTRIBUTES))
+        .times(1)
+        .returning(|_| return Ok(()));
+    mock_api
+        .expect_get_console_screen_buffer_info()
+        .times(1)
+        .return_const(Ok(buffer_info(rows)));
+    mock_api
+        .expect_fill_console_output_attribute()
+        .times(rows as usize)
+        .returning(|_, _, _| return Ok(80));
+
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Active,
+        ClientState::Disabled,
+        Some(original),
+    );
+}
+
+#[test]
+fn test_apply_state_visuals_disabled_to_active_restores_original_attrs() {
+    let original = CONSOLE_CHARACTER_ATTRIBUTES(0x5A);
+    let rows: i16 = 30;
+
+    let mut mock_api = MockWindowsApi::new();
+    mock_api
+        .expect_set_console_text_attribute()
+        .with(mockall::predicate::eq(original))
+        .times(1)
+        .returning(|_| return Ok(()));
+    mock_api
+        .expect_get_console_screen_buffer_info()
+        .times(1)
+        .return_const(Ok(buffer_info(rows)));
+    mock_api
+        .expect_fill_console_output_attribute()
+        .times(rows as usize)
+        .returning(|_, _, _| return Ok(80));
+
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Disabled,
+        ClientState::Active,
+        Some(original),
+    );
+}
+
+#[test]
+fn test_apply_state_visuals_no_op_when_state_unchanged() {
+    let original = CONSOLE_CHARACTER_ATTRIBUTES(0x07);
+
+    // No expectations set: any call to the API would cause the mockall
+    // strict-mock to fail, proving the no-transition branch is silent.
+    let mock_api = MockWindowsApi::new();
+
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Active,
+        ClientState::Active,
+        Some(original),
+    );
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Disabled,
+        ClientState::Disabled,
+        Some(original),
+    );
+}
+
+#[test]
+fn test_apply_state_visuals_skipped_when_original_attrs_unavailable() {
+    // When startup failed to capture the original attributes we degrade
+    // gracefully and leave the console untouched even on a real
+    // transition.
+    let mock_api = MockWindowsApi::new();
+
+    apply_state_visuals(&mock_api, ClientState::Active, ClientState::Disabled, None);
+    apply_state_visuals(&mock_api, ClientState::Disabled, ClientState::Active, None);
 }
 
 #[tokio::test]

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -169,6 +169,14 @@ mod daemon_test {
                         assert_eq!([2; SERIALIZED_INPUT_RECORD_0_LENGTH], buf[1..]);
                         successful_iterations += 1;
                     }
+                    TAG_STATE_CHANGE => {
+                        // Initial state push emitted right after the routine
+                        // subscribes; the default state is `Active`. Drain it
+                        // and keep reading so the rest of the assertions still
+                        // observe the input-record and keep-alive frames.
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
+                    }
                     other => panic!("Unexpected tag byte 0x{other:02X}"),
                 },
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
@@ -220,30 +228,33 @@ mod daemon_test {
         let future = tokio::spawn(async move {
             named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
         });
-        // Wait for at least one keep-alive frame; this proves the routine
-        // has finished PID correlation and reached the select! loop, which
-        // means it has also subscribed to the watch channel. Sending before
-        // the subscribe would either fail with `SendError` (no receivers)
-        // or be marked already-seen by the freshly-subscribed receiver.
+        // The routine emits the current authoritative state right after
+        // subscribing, so the very first frame on the pipe must be the
+        // initial `TAG_STATE_CHANGE(Active)` push. Receiving it also
+        // proves the subscribe has happened and any subsequent
+        // `state_tx.send` will be observed.
         loop {
             named_pipe_client.readable().await?;
             let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
             match named_pipe_client.try_read(&mut buf) {
-                Ok(0) => return Err("pipe closed before keep-alive".into()),
+                Ok(0) => return Err("pipe closed before initial state push".into()),
                 Ok(n) => match buf[0] {
-                    TAG_KEEP_ALIVE => {
-                        assert_eq!(FRAMED_KEEP_ALIVE_LENGTH, n);
+                    TAG_STATE_CHANGE => {
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
                         break;
                     }
-                    other => panic!("Unexpected tag byte 0x{other:02X}"),
+                    other => {
+                        panic!("Expected initial TAG_STATE_CHANGE, got tag byte 0x{other:02X}")
+                    }
                 },
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
                 Err(e) => return Err(e.into()),
             }
         }
-        // Push a new state through the watch sender; the routine must write a
-        // tagged state-change frame to the pipe.
-        state_tx.send(ClientState::Active)?;
+        // Push a real state transition through the watch sender; the routine
+        // must write a tagged state-change frame to the pipe.
+        state_tx.send(ClientState::Disabled)?;
         let mut state_change_seen = false;
         loop {
             named_pipe_client.readable().await?;
@@ -253,7 +264,7 @@ mod daemon_test {
                 Ok(n) => match buf[0] {
                     TAG_STATE_CHANGE => {
                         assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
-                        assert_eq!(buf[1], ClientState::Active as u8);
+                        assert_eq!(buf[1], ClientState::Disabled as u8);
                         state_change_seen = true;
                         break;
                     }
@@ -268,6 +279,110 @@ mod daemon_test {
             }
         }
         assert!(state_change_seen);
+        drop(named_pipe_client);
+        future.await?;
+        return Ok(());
+    }
+
+    /// Verifies that the pipe server routine emits a `TAG_STATE_CHANGE`
+    /// frame carrying the current authoritative state immediately after
+    /// the PID handshake, even when no transition fires after subscribe.
+    ///
+    /// `Daemon::set_client_state` may run in the brief window between
+    /// `Client` construction and the routine's `state_tx.subscribe()`
+    /// call. In that case `state_rx.changed()` would never fire for the
+    /// pre-existing value, leaving the client stuck on its default
+    /// `ClientState::Active` even though the daemon already gates
+    /// forwarding on the new value. The fix - and what this test
+    /// asserts - is that the routine pushes the snapshot from
+    /// `state_rx.borrow_and_update()` as its very first frame.
+    #[tokio::test]
+    async fn test_named_pipe_server_routine_sends_initial_state_after_subscribe(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_PID: u32 = 88888;
+        // Use a per-test unique pipe name so parallel test runs don't collide
+        // on the global PIPE_NAME.
+        let pipe_name = format!(r"\\.\pipe\csshw-test-initial-state-{}", std::process::id());
+        let (_sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
+            SERIALIZED_INPUT_RECORD_0_LENGTH,
+        );
+        let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
+            .access_outbound(true)
+            .pipe_mode(PipeMode::Message)
+            .create(&pipe_name)?;
+        let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
+        let (clients, state_tx) = make_clients_with_pid_and_state(TEST_PID);
+
+        // Pre-disable BEFORE the routine subscribes. `send_replace`
+        // updates the stored value even when there are no receivers,
+        // which is exactly the production race this test guards against:
+        // `Daemon::set_client_state` mutating the watch before the
+        // pipe-server task has had a chance to call `subscribe`. A
+        // regular `send` would error with no receivers.
+        state_tx.send_replace(ClientState::Disabled);
+
+        send_pid(&named_pipe_client, TEST_PID).await?;
+        let future = tokio::spawn(async move {
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
+        });
+
+        // The very first non-keep-alive frame on the pipe must be the
+        // initial `TAG_STATE_CHANGE(Disabled)` push. Keep-alive frames
+        // may legally interleave because the routine spawns its keep-
+        // alive timer through the same select; tolerate them but reject
+        // any other tag.
+        let read_result: Result<Result<(), Box<dyn std::error::Error>>, _> =
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    named_pipe_client.readable().await?;
+                    let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+                    match named_pipe_client.try_read(&mut buf) {
+                        Ok(0) => {
+                            return Err("pipe closed before initial state frame arrived".into());
+                        }
+                        Ok(n) => match buf[0] {
+                            TAG_STATE_CHANGE => {
+                                assert_eq!(
+                                    FRAMED_STATE_CHANGE_LENGTH, n,
+                                    "State-change frame must be exactly two bytes"
+                                );
+                                assert_eq!(
+                                    buf[1],
+                                    ClientState::Disabled as u8,
+                                    "Initial state push must reflect the value set before subscribe"
+                                );
+                                return Ok(());
+                            }
+                            TAG_KEEP_ALIVE => {
+                                // The initial state push happens before the
+                                // select loop, so a keep-alive arriving first
+                                // would mean the routine skipped the push.
+                                return Err("received keep-alive before initial state frame".into());
+                            }
+                            TAG_INPUT_RECORD => {
+                                return Err(
+                                    "received input record before initial state frame".into()
+                                );
+                            }
+                            other => {
+                                return Err(format!("Unexpected tag byte 0x{other:02X}").into());
+                            }
+                        },
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                        Err(e) => return Err(e.into()),
+                    }
+                }
+            })
+            .await;
+        match read_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                return Err("timed out waiting for initial state frame after subscribe".into());
+            }
+        }
+
         drop(named_pipe_client);
         future.await?;
         return Ok(());
@@ -317,6 +432,12 @@ mod daemon_test {
                         assert_eq!(FRAMED_INPUT_RECORD_LENGTH, n);
                         assert_eq!([2; SERIALIZED_INPUT_RECORD_0_LENGTH], buf[1..]);
                         break;
+                    }
+                    TAG_STATE_CHANGE => {
+                        // Initial state push emitted right after subscribe.
+                        // Drain it and continue reading.
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
                     }
                     other => panic!("Unexpected tag byte 0x{other:02X}"),
                 },
@@ -460,6 +581,14 @@ mod daemon_test {
                         assert_eq!([2; SERIALIZED_INPUT_RECORD_0_LENGTH], buf[1..]);
                         got_data = true;
                         break;
+                    }
+                    TAG_STATE_CHANGE => {
+                        // Initial state push emitted right after subscribe.
+                        // The default state is `Active`. Drain it and keep
+                        // reading so the assertion still observes the
+                        // input-record frame.
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
                     }
                     other => panic!("Unexpected tag byte 0x{other:02X}"),
                 },

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -7,19 +7,16 @@ mod daemon_test {
 
     use tokio::{
         net::windows::named_pipe::{ClientOptions, NamedPipeClient, PipeMode, ServerOptions},
-        sync::broadcast,
+        sync::{broadcast, watch},
     };
     use windows::Win32::Foundation::{HANDLE, HWND};
 
     use crate::{
-        daemon::{
-            named_pipe_server_routine, resolve_cluster_tags, toggle_pipe_server_states, Client,
-            Clients, HWNDWrapper, PipeServerState,
-        },
+        daemon::{named_pipe_server_routine, resolve_cluster_tags, Client, Clients, HWNDWrapper},
         protocol::{
-            serialization::serialize_pid, FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH,
-            SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH, TAG_INPUT_RECORD,
-            TAG_KEEP_ALIVE,
+            serialization::serialize_pid, ClientState, FRAMED_INPUT_RECORD_LENGTH,
+            FRAMED_KEEP_ALIVE_LENGTH, FRAMED_STATE_CHANGE_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH,
+            SERIALIZED_PID_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
         },
         utils::{config::Cluster, constants::PIPE_NAME},
     };
@@ -52,7 +49,7 @@ mod daemon_test {
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: pid,
-            pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+            state_tx: Arc::new(watch::channel(ClientState::Active).0),
         });
         return Arc::new(Mutex::new(clients));
     }
@@ -142,12 +139,17 @@ mod daemon_test {
             named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
         });
 
+        // Push 5 input records up front; once the routine drains them the
+        // broadcast channel goes idle and the 5 ms keep-alive branch of the
+        // select! starts firing, letting us assert both behaviours in one
+        // loop.
+        const TARGET_INPUT_FRAMES: usize = 5;
+        for _ in 0..TARGET_INPUT_FRAMES {
+            sender.send([2; SERIALIZED_INPUT_RECORD_0_LENGTH])?;
+        }
         let mut keep_alive_received = false;
         let mut successful_iterations = 0;
-        // Verify the routine forwards the data through the pipe
         loop {
-            // Send data to the routine
-            sender.send([2; SERIALIZED_INPUT_RECORD_0_LENGTH])?;
             // Wait for the pipe to be readable
             named_pipe_client.readable().await?;
             let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
@@ -166,9 +168,6 @@ mod daemon_test {
                         assert_eq!(FRAMED_INPUT_RECORD_LENGTH, n);
                         assert_eq!([2; SERIALIZED_INPUT_RECORD_0_LENGTH], buf[1..]);
                         successful_iterations += 1;
-                        if successful_iterations >= 5 {
-                            break;
-                        }
                     }
                     other => panic!("Unexpected tag byte 0x{other:02X}"),
                 },
@@ -179,11 +178,98 @@ mod daemon_test {
                     return Err(e.into());
                 }
             }
+            if keep_alive_received && successful_iterations >= TARGET_INPUT_FRAMES {
+                break;
+            }
         }
         assert!(keep_alive_received);
+        assert!(successful_iterations >= TARGET_INPUT_FRAMES);
         // Drop the client, closing the pipe.
         drop(named_pipe_client);
         // We expect the routine to exit gracefully.
+        future.await?;
+        return Ok(());
+    }
+
+    #[tokio::test]
+    async fn test_named_pipe_server_routine_forwards_state_change(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_PID: u32 = 66666;
+        // Use a per-test unique pipe name so parallel test runs don't collide
+        // on the global PIPE_NAME.
+        let pipe_name = format!(r"\\.\pipe\csshw-test-state-change-{}", std::process::id());
+        let (_sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
+            SERIALIZED_INPUT_RECORD_0_LENGTH,
+        );
+        let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
+            .access_outbound(true)
+            .pipe_mode(PipeMode::Message)
+            .create(&pipe_name)?;
+        let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
+        let clients = make_clients_with_pid(TEST_PID);
+        // Grab the watch sender so we can later trigger a state change push.
+        let state_tx = Arc::clone(
+            &clients
+                .lock()
+                .unwrap()
+                .get_by_pid(TEST_PID)
+                .unwrap()
+                .state_tx,
+        );
+        send_pid(&named_pipe_client, TEST_PID).await?;
+        let future = tokio::spawn(async move {
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
+        });
+        // Wait for at least one keep-alive frame; this proves the routine
+        // has finished PID correlation and reached the select! loop, which
+        // means it has also subscribed to the watch channel. Sending before
+        // the subscribe would either fail with `SendError` (no receivers)
+        // or be marked already-seen by the freshly-subscribed receiver.
+        loop {
+            named_pipe_client.readable().await?;
+            let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+            match named_pipe_client.try_read(&mut buf) {
+                Ok(0) => return Err("pipe closed before keep-alive".into()),
+                Ok(n) => match buf[0] {
+                    TAG_KEEP_ALIVE => {
+                        assert_eq!(FRAMED_KEEP_ALIVE_LENGTH, n);
+                        break;
+                    }
+                    other => panic!("Unexpected tag byte 0x{other:02X}"),
+                },
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        // Push a new state through the watch sender; the routine must write a
+        // tagged state-change frame to the pipe.
+        state_tx.send(ClientState::Active)?;
+        let mut state_change_seen = false;
+        loop {
+            named_pipe_client.readable().await?;
+            let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+            match named_pipe_client.try_read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => match buf[0] {
+                    TAG_STATE_CHANGE => {
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
+                        state_change_seen = true;
+                        break;
+                    }
+                    TAG_KEEP_ALIVE => {
+                        assert_eq!(FRAMED_KEEP_ALIVE_LENGTH, n);
+                        // Keep-alives may interleave with the state change; keep waiting.
+                    }
+                    other => panic!("Unexpected tag byte 0x{other:02X}"),
+                },
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        assert!(state_change_seen);
+        drop(named_pipe_client);
         future.await?;
         return Ok(());
     }
@@ -311,26 +397,29 @@ mod daemon_test {
 
     /// Construct a [`Clients`] collection holding a single [`Client`] whose
     /// `process_id` equals `pid`, returning both the collection and the
-    /// shared [`PipeServerState`] handle so the caller can mutate it.
+    /// shared [`watch::Sender`] handle so the caller can drive [`ClientState`]
+    /// transitions.
     fn make_clients_with_pid_and_state(
         pid: u32,
-    ) -> (Arc<Mutex<Clients>>, Arc<Mutex<PipeServerState>>) {
-        let state = Arc::new(Mutex::new(PipeServerState::Enabled));
+    ) -> (Arc<Mutex<Clients>>, Arc<watch::Sender<ClientState>>) {
+        let state_tx = Arc::new(watch::channel(ClientState::Active).0);
         let mut clients = Clients::new();
         clients.push(Client {
             hostname: format!("test-host-{pid}"),
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: pid,
-            pipe_server_state: Arc::clone(&state),
+            state_tx: Arc::clone(&state_tx),
         });
-        return (Arc::new(Mutex::new(clients)), state);
+        return (Arc::new(Mutex::new(clients)), state_tx);
     }
 
-    /// Verifies that when a client's [`PipeServerState`] is set to
-    /// [`PipeServerState::Disabled`], the pipe server routine consumes
+    /// Verifies that when a client's [`ClientState`] is set to
+    /// [`ClientState::Disabled`], the pipe server routine consumes
     /// broadcast messages but does not forward them through the pipe.
-    /// Only keep-alive packets should arrive on the client side.
+    /// Only keep-alive packets (and the [`TAG_STATE_CHANGE`] frame
+    /// announcing the transition itself) should arrive on the client
+    /// side.
     #[tokio::test]
     async fn test_named_pipe_server_routine_disabled() -> Result<(), Box<dyn std::error::Error>> {
         const TEST_PID: u32 = 66666;
@@ -346,7 +435,7 @@ mod daemon_test {
             .pipe_mode(PipeMode::Message)
             .create(&pipe_name)?;
         let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
-        let (clients, pipe_server_state) = make_clients_with_pid_and_state(TEST_PID);
+        let (clients, state_tx) = make_clients_with_pid_and_state(TEST_PID);
         send_pid(&named_pipe_client, TEST_PID).await?;
         let future = tokio::spawn(async move {
             named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
@@ -381,8 +470,9 @@ mod daemon_test {
         }
         assert!(got_data);
 
-        // Disable the client.
-        *pipe_server_state.lock().unwrap() = PipeServerState::Disabled;
+        // Disable the client. The routine emits a `TAG_STATE_CHANGE`
+        // frame as soon as it observes this transition.
+        state_tx.send(ClientState::Disabled).unwrap();
 
         // Send more data - it must NOT arrive at the client.
         const SENDS: usize = 5;
@@ -390,19 +480,21 @@ mod daemon_test {
             sender.send([3; SERIALIZED_INPUT_RECORD_0_LENGTH])?;
         }
 
-        // The disabled branch writes one keep-alive frame per consumed
-        // broadcast record, so we expect at least `SENDS` keep-alive
-        // frames to arrive. Read exactly that many and assert each is
-        // a `TAG_KEEP_ALIVE` byte - any `TAG_INPUT_RECORD` frame would
-        // be a leak of broadcast data and must fail the test.
+        // While disabled, the only frames that may arrive are the
+        // single `TAG_STATE_CHANGE(Disabled)` announcement and any
+        // number of `TAG_KEEP_ALIVE` frames. We require at least
+        // `SENDS` keep-alive frames to confirm the routine keeps
+        // running while suppressed; any `TAG_INPUT_RECORD` would be
+        // a leak of broadcast data and must fail the test.
         //
         // The whole loop is bounded by a `tokio::time::timeout` so a
         // regression that stops keep-alive emission surfaces as a
         // deterministic assertion instead of a hung test.
         let read_result: Result<Result<(), Box<dyn std::error::Error>>, _> =
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
-                let mut received = 0;
-                while received < SENDS {
+                let mut received_keep_alive = 0;
+                let mut saw_state_change = false;
+                while received_keep_alive < SENDS {
                     named_pipe_client.readable().await?;
                     let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
                     match named_pipe_client.try_read(&mut buf) {
@@ -417,7 +509,20 @@ mod daemon_test {
                                     FRAMED_KEEP_ALIVE_LENGTH, n,
                                     "Keep-alive frame must be exactly one byte"
                                 );
-                                received += 1;
+                                received_keep_alive += 1;
+                            }
+                            TAG_STATE_CHANGE => {
+                                assert!(!saw_state_change, "Disabled transition was announced more than once");
+                                assert_eq!(
+                                    FRAMED_STATE_CHANGE_LENGTH, n,
+                                    "State-change frame must be exactly two bytes"
+                                );
+                                assert_eq!(
+                                    buf[1],
+                                    ClientState::Disabled as u8,
+                                    "State-change announcement must carry Disabled"
+                                );
+                                saw_state_change = true;
                             }
                             TAG_INPUT_RECORD => panic!(
                                 "Received input-record frame after disabling - broadcast data leaked through"
@@ -428,6 +533,7 @@ mod daemon_test {
                         Err(e) => return Err(e.into()),
                     }
                 }
+                assert!(saw_state_change, "Disabled transition must be announced");
                 return Ok(());
             })
             .await;
@@ -449,15 +555,15 @@ mod daemon_test {
 
     /// Verifies that when the broadcast receiver falls behind the
     /// channel's bounded buffer, the pipe server routine handles the
-    /// resulting [`tokio::sync::broadcast::error::TryRecvError::Lagged`]
+    /// resulting [`tokio::sync::broadcast::error::RecvError::Lagged`]
     /// without panicking. This is a regression guard for the previous
     /// behaviour where any `Lagged` error propagated to the catch-all
     /// `Err(err)` arm and crashed the routine.
     ///
     /// The test deliberately disables the client so the routine
     /// throttles its consumption rate, then bursts more records than
-    /// the channel capacity through the sender so the first
-    /// `try_recv` is guaranteed to observe `Lagged`.
+    /// the channel capacity through the sender so the next `recv`
+    /// is guaranteed to observe `Lagged`.
     #[tokio::test]
     async fn test_named_pipe_server_routine_lagged() -> Result<(), Box<dyn std::error::Error>> {
         const TEST_PID: u32 = 77777;
@@ -474,11 +580,16 @@ mod daemon_test {
             .pipe_mode(PipeMode::Message)
             .create(&pipe_name)?;
         let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
-        let (clients, pipe_server_state) = make_clients_with_pid_and_state(TEST_PID);
+        let (clients, state_tx) = make_clients_with_pid_and_state(TEST_PID);
 
         // Disable up front so the routine throttles consumption and
-        // cannot drain the broadcast buffer before we overflow it.
-        *pipe_server_state.lock().unwrap() = PipeServerState::Disabled;
+        // cannot drain the broadcast buffer before we overflow it. Use
+        // `send_replace` because the routine has not yet subscribed to
+        // the watch channel, so a regular `send` would error with no
+        // receivers; `send_replace` updates the stored value either
+        // way and the routine reads it through `borrow_and_update` on
+        // its first iteration.
+        state_tx.send_replace(ClientState::Disabled);
 
         // Overflow the bounded broadcast buffer before the routine
         // begins pulling from it so the first `try_recv` observes
@@ -514,6 +625,16 @@ mod daemon_test {
                                     "Keep-alive frame must be exactly one byte"
                                 );
                                 return Ok(());
+                            }
+                            TAG_STATE_CHANGE => {
+                                // The initial Disabled transition may surface
+                                // here; drain it and continue reading so the
+                                // test still observes a keep-alive frame.
+                                assert_eq!(
+                                    FRAMED_STATE_CHANGE_LENGTH, n,
+                                    "State-change frame must be exactly two bytes"
+                                );
+                                continue;
                             }
                             TAG_INPUT_RECORD => panic!(
                                 "Received input-record frame while disabled - broadcast data leaked through after Lagged"
@@ -555,7 +676,7 @@ mod daemon_test {
                 window_handle: HWND(std::ptr::null_mut()),
                 process_handle: HANDLE::default(),
                 process_id: pid,
-                pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+                state_tx: Arc::new(watch::channel(ClientState::Active).0),
             };
         };
         clients.push(make_client(1000));
@@ -573,21 +694,21 @@ mod daemon_test {
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: 1000,
-            pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+            state_tx: Arc::new(watch::channel(ClientState::Active).0),
         };
         let client_b = Client {
             hostname: "host-b".to_owned(),
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: 2000,
-            pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+            state_tx: Arc::new(watch::channel(ClientState::Active).0),
         };
         let client_c = Client {
             hostname: "host-c".to_owned(),
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: 3000,
-            pipe_server_state: Arc::new(Mutex::new(PipeServerState::Enabled)),
+            state_tx: Arc::new(watch::channel(ClientState::Active).0),
         };
 
         clients.push(client_a);
@@ -616,32 +737,37 @@ mod daemon_test {
         assert_eq!(hostnames_after_retain, vec!["host-a", "host-c"]);
     }
 
-    /// Builds a [`Client`] with the given PID and initial [`PipeServerState`].
-    fn make_client_with_state(pid: u32, state: PipeServerState) -> Client {
+    /// Builds a [`Client`] with the given PID and initial [`ClientState`].
+    fn make_client_with_state(pid: u32, state: ClientState) -> Client {
         return Client {
             hostname: format!("host-{pid}"),
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: pid,
-            pipe_server_state: Arc::new(Mutex::new(state)),
+            state_tx: Arc::new(watch::channel(state).0),
         };
     }
 
-    /// Verifies that [`toggle_pipe_server_states`] flips each client's
-    /// [`PipeServerState`] independently and is its own inverse over two
-    /// invocations.
+    /// Verifies that the `[t]oggle enabled` control-mode handler flips each
+    /// client's [`ClientState`] independently and is its own inverse over
+    /// two invocations.
+    ///
+    /// Mirrors the snapshot-then-flip logic in
+    /// [`crate::daemon::Daemon::handle_control_mode`]'s `VK_T` arm so the
+    /// per-client toggle behaviour is exercised without standing up a full
+    /// [`crate::daemon::Daemon`].
     #[test]
-    fn test_toggle_pipe_server_states_flips_each_client_independently() {
+    fn test_toggle_flips_each_client_independently() {
         let mut clients = Clients::new();
-        clients.push(make_client_with_state(1, PipeServerState::Enabled));
-        clients.push(make_client_with_state(2, PipeServerState::Disabled));
-        clients.push(make_client_with_state(3, PipeServerState::Enabled));
-        clients.push(make_client_with_state(4, PipeServerState::Disabled));
+        clients.push(make_client_with_state(1, ClientState::Active));
+        clients.push(make_client_with_state(2, ClientState::Disabled));
+        clients.push(make_client_with_state(3, ClientState::Active));
+        clients.push(make_client_with_state(4, ClientState::Disabled));
 
-        let snapshot = |c: &Clients| -> Vec<PipeServerState> {
+        let snapshot = |c: &Clients| -> Vec<ClientState> {
             return c
                 .iter()
-                .map(|client| return *client.pipe_server_state.lock().unwrap())
+                .map(|client| return *client.state_tx.borrow())
                 .collect();
         };
 
@@ -649,27 +775,45 @@ mod daemon_test {
         assert_eq!(
             initial,
             vec![
-                PipeServerState::Enabled,
-                PipeServerState::Disabled,
-                PipeServerState::Enabled,
-                PipeServerState::Disabled,
+                ClientState::Active,
+                ClientState::Disabled,
+                ClientState::Active,
+                ClientState::Disabled,
             ]
         );
 
-        // First press of `t`: every client flips.
-        toggle_pipe_server_states(&clients);
+        // Press `t` once: snapshot every state, then flip each.
+        let toggle = |c: &Clients| {
+            let flips: Vec<ClientState> = c
+                .iter()
+                .map(|client| {
+                    return match *client.state_tx.borrow() {
+                        ClientState::Active => ClientState::Disabled,
+                        ClientState::Disabled => ClientState::Active,
+                    };
+                })
+                .collect();
+            // `send_replace` succeeds even when no task has subscribed;
+            // tests don't spin up the pipe-server routine that would
+            // normally hold the receiver.
+            for (client, flipped) in c.iter().zip(flips) {
+                client.state_tx.send_replace(flipped);
+            }
+        };
+
+        toggle(&clients);
         assert_eq!(
             snapshot(&clients),
             vec![
-                PipeServerState::Disabled,
-                PipeServerState::Enabled,
-                PipeServerState::Disabled,
-                PipeServerState::Enabled,
+                ClientState::Disabled,
+                ClientState::Active,
+                ClientState::Disabled,
+                ClientState::Active,
             ]
         );
 
-        // Second press of `t`: every client flips back to its initial state.
-        toggle_pipe_server_states(&clients);
+        // Press `t` again: every client flips back to its initial state.
+        toggle(&clients);
         assert_eq!(snapshot(&clients), initial);
     }
 }

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -49,7 +49,7 @@ mod daemon_test {
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: pid,
-            state_tx: Arc::new(watch::channel(ClientState::Active).0),
+            state_tx: watch::channel(ClientState::Active).0,
         });
         return Arc::new(Mutex::new(clients));
     }
@@ -209,14 +209,13 @@ mod daemon_test {
         let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
         let clients = make_clients_with_pid(TEST_PID);
         // Grab the watch sender so we can later trigger a state change push.
-        let state_tx = Arc::clone(
-            &clients
-                .lock()
-                .unwrap()
-                .get_by_pid(TEST_PID)
-                .unwrap()
-                .state_tx,
-        );
+        let state_tx = clients
+            .lock()
+            .unwrap()
+            .get_by_pid(TEST_PID)
+            .unwrap()
+            .state_tx
+            .clone();
         send_pid(&named_pipe_client, TEST_PID).await?;
         let future = tokio::spawn(async move {
             named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
@@ -401,15 +400,15 @@ mod daemon_test {
     /// transitions.
     fn make_clients_with_pid_and_state(
         pid: u32,
-    ) -> (Arc<Mutex<Clients>>, Arc<watch::Sender<ClientState>>) {
-        let state_tx = Arc::new(watch::channel(ClientState::Active).0);
+    ) -> (Arc<Mutex<Clients>>, watch::Sender<ClientState>) {
+        let state_tx = watch::channel(ClientState::Active).0;
         let mut clients = Clients::new();
         clients.push(Client {
             hostname: format!("test-host-{pid}"),
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: pid,
-            state_tx: Arc::clone(&state_tx),
+            state_tx: state_tx.clone(),
         });
         return (Arc::new(Mutex::new(clients)), state_tx);
     }
@@ -676,7 +675,7 @@ mod daemon_test {
                 window_handle: HWND(std::ptr::null_mut()),
                 process_handle: HANDLE::default(),
                 process_id: pid,
-                state_tx: Arc::new(watch::channel(ClientState::Active).0),
+                state_tx: watch::channel(ClientState::Active).0,
             };
         };
         clients.push(make_client(1000));
@@ -694,21 +693,21 @@ mod daemon_test {
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: 1000,
-            state_tx: Arc::new(watch::channel(ClientState::Active).0),
+            state_tx: watch::channel(ClientState::Active).0,
         };
         let client_b = Client {
             hostname: "host-b".to_owned(),
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: 2000,
-            state_tx: Arc::new(watch::channel(ClientState::Active).0),
+            state_tx: watch::channel(ClientState::Active).0,
         };
         let client_c = Client {
             hostname: "host-c".to_owned(),
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: 3000,
-            state_tx: Arc::new(watch::channel(ClientState::Active).0),
+            state_tx: watch::channel(ClientState::Active).0,
         };
 
         clients.push(client_a);
@@ -744,7 +743,7 @@ mod daemon_test {
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: pid,
-            state_tx: Arc::new(watch::channel(state).0),
+            state_tx: watch::channel(state).0,
         };
     }
 

--- a/src/tests/protocol/test_mod.rs
+++ b/src/tests/protocol/test_mod.rs
@@ -150,25 +150,45 @@ mod client_state_test {
     /// byte-level serializer / deserializer.
     const ALL_VARIANTS: &[ClientState] = &[ClientState::Active, ClientState::Disabled];
 
-    /// Compile-time guard: every [`ClientState`] variant must appear in
-    /// [`ALL_VARIANTS`]. The match has no wildcard arm, so adding a new
-    /// variant without listing it here fails to compile.
-    #[allow(dead_code)]
-    fn assert_listed(state: ClientState) {
+    /// Maps each [`ClientState`] variant to a unique single-bit mask.
+    ///
+    /// The exhaustive `match` (no wildcard) forces an update on any new
+    /// variant, where the developer must allocate a fresh bit. The bit
+    /// allocations are then OR-ed together to form the canonical
+    /// [`EXPECTED_VARIANTS_MASK`].
+    const fn variant_bit(state: ClientState) -> u32 {
         match state {
-            ClientState::Active => {
-                assert!(ALL_VARIANTS.contains(&ClientState::Active));
-            }
-            ClientState::Disabled => {
-                assert!(ALL_VARIANTS.contains(&ClientState::Disabled));
-            }
+            ClientState::Active => return 1 << 0,
+            ClientState::Disabled => return 1 << 1,
         }
     }
+
+    /// Bitmask of every known [`ClientState`] variant. Adding a variant
+    /// requires extending [`variant_bit`] AND OR-ing the new bit in here.
+    const EXPECTED_VARIANTS_MASK: u32 =
+        variant_bit(ClientState::Active) | variant_bit(ClientState::Disabled);
+
+    /// Compile-time guard: [`ALL_VARIANTS`] must list every [`ClientState`]
+    /// variant. Adding a variant fails to compile in [`variant_bit`] until
+    /// a fresh bit is allocated and OR-ed into [`EXPECTED_VARIANTS_MASK`];
+    /// once both are updated, the const evaluation below panics unless
+    /// [`ALL_VARIANTS`] was also extended to include the new variant.
+    const _: () = {
+        let mut seen: u32 = 0;
+        let mut i = 0;
+        while i < ALL_VARIANTS.len() {
+            seen |= variant_bit(ALL_VARIANTS[i]);
+            i += 1;
+        }
+        assert!(
+            seen == EXPECTED_VARIANTS_MASK,
+            "ALL_VARIANTS does not cover every ClientState variant",
+        );
+    };
 
     #[test]
     fn test_client_state_round_trip_all_variants() {
         for &state in ALL_VARIANTS {
-            assert_listed(state);
             let byte = serialize_client_state(state);
             assert_eq!(deserialize_client_state(byte), state);
         }

--- a/src/tests/protocol/test_mod.rs
+++ b/src/tests/protocol/test_mod.rs
@@ -141,19 +141,73 @@ mod deserialization_test {
     }
 }
 
+mod client_state_test {
+    use crate::protocol::deserialization::deserialize_client_state;
+    use crate::protocol::serialization::serialize_client_state;
+    use crate::protocol::ClientState;
+
+    /// Round-trip list of every [`ClientState`] variant through the
+    /// byte-level serializer / deserializer.
+    const ALL_VARIANTS: &[ClientState] = &[ClientState::Active, ClientState::Disabled];
+
+    /// Compile-time guard: every [`ClientState`] variant must appear in
+    /// [`ALL_VARIANTS`]. The match has no wildcard arm, so adding a new
+    /// variant without listing it here fails to compile.
+    #[allow(dead_code)]
+    fn assert_listed(state: ClientState) {
+        match state {
+            ClientState::Active => {
+                assert!(ALL_VARIANTS.contains(&ClientState::Active));
+            }
+            ClientState::Disabled => {
+                assert!(ALL_VARIANTS.contains(&ClientState::Disabled));
+            }
+        }
+    }
+
+    #[test]
+    fn test_client_state_round_trip_all_variants() {
+        for &state in ALL_VARIANTS {
+            assert_listed(state);
+            let byte = serialize_client_state(state);
+            assert_eq!(deserialize_client_state(byte), state);
+        }
+    }
+
+    #[test]
+    fn test_serialize_client_state_active_byte() {
+        assert_eq!(serialize_client_state(ClientState::Active), 0u8);
+    }
+
+    #[test]
+    fn test_serialize_client_state_disabled_byte() {
+        assert_eq!(serialize_client_state(ClientState::Disabled), 1u8);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unknown ClientState byte")]
+    fn test_deserialize_client_state_unknown_panics() {
+        let _ = deserialize_client_state(0xAB);
+    }
+}
+
 mod framed_message_test {
     use super::deserialization_test::Equality;
     use super::*;
     use crate::protocol::{
         deserialization::parse_daemon_to_client_messages,
-        serialization::serialize_daemon_to_client_message, DaemonToClientMessage,
-        FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+        serialization::serialize_daemon_to_client_message, ClientState, DaemonToClientMessage,
+        FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH, FRAMED_STATE_CHANGE_LENGTH,
+        TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
     };
 
     fn unwrap_input_record(msg: &DaemonToClientMessage) -> INPUT_RECORD_0 {
         match msg {
             DaemonToClientMessage::InputRecord(record) => return *record,
-            DaemonToClientMessage::KeepAlive => panic!("expected InputRecord, got KeepAlive"),
+            other => panic!(
+                "expected InputRecord, got {:?}",
+                std::mem::discriminant(other)
+            ),
         }
     }
 
@@ -183,6 +237,30 @@ mod framed_message_test {
         assert!(remainder.is_empty());
         assert_eq!(messages.len(), 1);
         assert!(unwrap_input_record(&messages[0]).equals(EXPECTED_INPUT_RECORD_0));
+    }
+
+    #[test]
+    fn test_serialize_state_change_envelope() {
+        let bytes = serialize_daemon_to_client_message(&DaemonToClientMessage::StateChange(
+            ClientState::Active,
+        ));
+        assert_eq!(bytes.len(), FRAMED_STATE_CHANGE_LENGTH);
+        assert_eq!(bytes[0], TAG_STATE_CHANGE);
+        assert_eq!(bytes[1], ClientState::Active as u8);
+    }
+
+    #[test]
+    fn test_parse_state_change_round_trip() {
+        let bytes = serialize_daemon_to_client_message(&DaemonToClientMessage::StateChange(
+            ClientState::Active,
+        ));
+        let (messages, remainder) = parse_daemon_to_client_messages(&bytes);
+        assert!(remainder.is_empty());
+        assert_eq!(messages.len(), 1);
+        match messages[0] {
+            DaemonToClientMessage::StateChange(state) => assert_eq!(state, ClientState::Active),
+            _ => panic!("expected StateChange variant"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Introduce a per-client state channel that the daemon's pipe server
task subscribes to, replacing the previous PipeServerState mutex.
Each client's connection now multiplexes input records, state-change
notifications, and keep-alives via tokio::select!, sending a
TAG_STATE_CHANGE envelope on every transition.

The wire protocol gains a ClientState enum with `Active` and
`Disabled` variants, carried as a one-byte payload after
TAG_STATE_CHANGE. The client tracks the last received state in its
read/write loop. The daemon's `[t]oggle enabled` (`VK_T`) and
`e[n]able all` (`VK_N`) control-mode bindings drive
`Daemon::set_client_state` (via the new `update_client_states`
helper) so toggling and re-enabling clients is wired up end to end.

GitHub: #179
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>