### PR TITLE
Block agent-introduced typographic Unicode

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -7,7 +7,7 @@ description: Write a git commit message that follows csshW's subject/body/traile
 
 Commit messages follow the standard three-block layout: a single-line
 **subject**, an optional wrapped prose **body**, and a **footer** block
-of Git trailers — each block separated from the next by a blank line.
+of Git trailers - each block separated from the next by a blank line.
 
 ## Subject line
 
@@ -17,17 +17,17 @@ of Git trailers — each block separated from the next by a blank line.
 - Optional lowercase scope prefix followed by `: ` when the change is
   confined to a single area (e.g. `client:`, `control mode:`,
   `post-pr-comment:`, `news-fragment-check:`). Mirror the scope style
-  already used in `git log` — do not invent new scopes.
+  already used in `git log` - do not invent new scopes.
 - No trailing period. Keep under ~72 characters.
-- Do not pre-append a PR number in parentheses (`(#165)`) — GitHub's
+- Do not pre-append a PR number in parentheses (`(#165)`) - GitHub's
   squash-merge adds that automatically when the PR lands.
 
 ## Body
 
 - Separate the subject from the body with a blank line.
-- Wrap lines at ~72–76 characters.
+- Wrap lines at ~72-76 characters.
 - Explain **why** the change is being made. Describe observable
-  behavior before/after when relevant. "With this change …" is a
+  behavior before/after when relevant. "With this change ..." is a
   common and acceptable opening.
 - Use `-` for bullet lists.
 - Reference advisories/URLs inline in the body when fixing CVEs or
@@ -38,7 +38,7 @@ of Git trailers — each block separated from the next by a blank line.
 Trailers go in a final block separated from the body by a blank line.
 Order: issue/PR references first, then co-author trailers.
 
-- **GitHub references**: use `GitHub: #<number>` — one per line, in
+- **GitHub references**: use `GitHub: #<number>` - one per line, in
   the footer, never in the subject or body prose. Do not use `Fixes:`
   (legacy style).
 - **AI co-authorship (MANDATORY for AI-generated commits)**: include
@@ -55,7 +55,7 @@ Order: issue/PR references first, then co-author trailers.
     `authored`/`by`). GitHub recognizes other casings too, but
     lowercase matches Git's own trailer convention and avoids
     duplicate trailers when tooling re-adds one.
-  - Emit the trailer **exactly once** — never both `Co-Authored-By:`
+  - Emit the trailer **exactly once** - never both `Co-Authored-By:`
     and `Co-authored-by:` for the same author.
 
 ## Example
@@ -92,5 +92,5 @@ EOF
 
 Never pass `--no-verify` or `--no-gpg-sign` unless the user has
 explicitly asked for it. If a pre-commit hook fails, fix the issue
-and create a new commit — do not `--amend` to "retry" a commit
+and create a new commit - do not `--amend` to "retry" a commit
 that never happened.

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pr
-description: Create a GitHub pull request, or work on an existing one — address review comments, push updates, reply to and resolve each unresolved thread.
+description: Create a GitHub pull request, or work on an existing one - address review comments, push updates, reply to and resolve each unresolved thread.
 ---
 
 # GitHub Pull Requests
@@ -10,7 +10,7 @@ feedback** on an existing one.
 
 ## Creating a PR
 
-Create PRs from the commit message — do not re-author the prose in
+Create PRs from the commit message - do not re-author the prose in
 the PR form:
 
 ```sh
@@ -33,7 +33,7 @@ or "handle the review comments".
 
 ### Core rules
 
-- **Reply to every unresolved review comment** — even when the fix
+- **Reply to every unresolved review comment** - even when the fix
   is "done in commit abc123". Never leave a thread silently
   addressed.
 - **Resolve each thread only after** (a) the fix is pushed and
@@ -41,7 +41,7 @@ or "handle the review comments".
 - **Push to update the PR.** Local commits alone do not count.
 - No force-push to `main`. No `--no-verify`. No `git commit --amend`
   to rewrite commits that have already been pushed for review.
-- Commit changes per [`../commit/SKILL.md`](../commit/SKILL.md) —
+- Commit changes per [`../commit/SKILL.md`](../commit/SKILL.md) -
   including the mandatory `Co-authored-by:` trailer.
 
 ### Workflow (run these commands; substitute the placeholders in `<>`)
@@ -90,9 +90,9 @@ gh api graphql -f query='
 Filter client-side to `isResolved == false`. From each unresolved
 thread you need:
 
-- the thread `id` (GraphQL node id) → used to **resolve** the thread
+- the thread `id` (GraphQL node id) -> used to **resolve** the thread
   in step 5.
-- the `databaseId` of the **first** comment in the thread → used to
+- the `databaseId` of the **first** comment in the thread -> used to
   **reply** to the thread in step 4.
 
 #### 3. Make the code changes, commit, push
@@ -118,7 +118,7 @@ gh api --method POST \
   -f body='Fixed in <SHA>. <optional short explanation>.'
 ```
 
-Do **not** use `gh pr comment` — that posts a top-level PR comment,
+Do **not** use `gh pr comment` - that posts a top-level PR comment,
 which does not count as answering the review thread.
 
 #### 5. Resolve each thread
@@ -141,7 +141,7 @@ The mutation returns `isResolved: true` on success.
 
 Re-run the step-2 query. Every thread you addressed should now have
 `isResolved: true`. Any that remain unresolved either still need a
-fix or were intentionally deferred — never silently skip one.
+fix or were intentionally deferred - never silently skip one.
 
 ### Anti-patterns
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,7 @@
 set -e
 cargo fmt
 cargo lint
+cargo xtask check-typography
 cargo build --workspace --all-targets
 cargo docs
 cargo xtask update-readme-help

--- a/.github/workflows/_shared-ci.yml
+++ b/.github/workflows/_shared-ci.yml
@@ -132,3 +132,15 @@ jobs:
         with: *build-cache-paths
       - name: Run check-readme-help
         run: cargo xtask check-readme-help
+
+  check-typography:
+    runs-on: *runner-version
+    needs: build
+    steps:
+      - uses: *checkout-action
+      - uses: *rust-cache-action
+        with: *rust-cache-shared-key
+      - uses: *build-cache
+        with: *build-cache-paths
+      - name: Run check-typography
+        run: cargo xtask check-typography

--- a/.github/workflows/news-fragment-check.yml
+++ b/.github/workflows/news-fragment-check.yml
@@ -80,11 +80,11 @@ jobs:
           ❌ This PR appears to be missing a news fragment.
 
           **If this change affects users** (new features, bug fixes, security fixes):
-          -> Add a news fragment in the `news/` directory
-          -> Example: `news/123.feature.md` or `news/~fix-issue.bugfix.md`
+          → Add a news fragment in the `news/` directory
+          → Example: `news/123.feature.md` or `news/~fix-issue.bugfix.md`
 
           **If this change doesn't need a news fragment** (docs, CI, internal changes):
-          -> Add the ![](https://img.shields.io/github/labels/${{ github.repository }}/${{ env.OVERRIDE_LABEL }}) label to this PR
+          → Add the ![](https://img.shields.io/github/labels/${{ github.repository }}/${{ env.OVERRIDE_LABEL }}) label to this PR
 
           For more information about news fragments, see: https://github.com/nekitdev/changelogging
           EOF

--- a/.github/workflows/news-fragment-check.yml
+++ b/.github/workflows/news-fragment-check.yml
@@ -80,11 +80,11 @@ jobs:
           ❌ This PR appears to be missing a news fragment.
 
           **If this change affects users** (new features, bug fixes, security fixes):
-          → Add a news fragment in the `news/` directory
-          → Example: `news/123.feature.md` or `news/~fix-issue.bugfix.md`
+          -> Add a news fragment in the `news/` directory
+          -> Example: `news/123.feature.md` or `news/~fix-issue.bugfix.md`
 
           **If this change doesn't need a news fragment** (docs, CI, internal changes):
-          → Add the ![](https://img.shields.io/github/labels/${{ github.repository }}/${{ env.OVERRIDE_LABEL }}) label to this PR
+          -> Add the ![](https://img.shields.io/github/labels/${{ github.repository }}/${{ env.OVERRIDE_LABEL }}) label to this PR
 
           For more information about news fragments, see: https://github.com/nekitdev/changelogging
           EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# csshW — Agent Instructions
+# csshW - Agent Instructions
 
 ## Project Overview
 
@@ -14,19 +14,19 @@ multiple hosts simultaneously with synchronized keystroke distribution.
 
 ## Key Design Philosophy
 
-- **Windows-Specific**: Not designed for cross-platform compatibility — embraces Windows APIs directly
+- **Windows-Specific**: Not designed for cross-platform compatibility - embraces Windows APIs directly
 - **User Experience**: Automatic configuration generation, sensible defaults, graceful degradation
 - **Configuration-Driven**: TOML-based configuration with auto-generation of defaults
 - **Safety First**: Extensive use of Result types and proper error handling
 
 ## Project Structure
 
-- **Binary**: `csshw.exe` — Main executable with CLI interface (`src/main.rs`, `src/cli.rs`)
-- **Library**: `csshw_lib` — Core functionality (`src/lib.rs`)
+- **Binary**: `csshw.exe` - Main executable with CLI interface (`src/main.rs`, `src/cli.rs`)
+- **Library**: `csshw_lib` - Core functionality (`src/lib.rs`)
 - **Modules**: `src/client/`, `src/daemon/`, `src/serde/`, `src/utils/`
 - **Tests**: `src/tests/` with component-based organization (`test_*.rs` naming)
-- **xtask**: `xtask/` — Developer automation tasks (README checks, release, changelog, social preview)
-- **Config**: `.config/` — grouped, shared single-line marker files consumed
+- **xtask**: `xtask/` - Developer automation tasks (README checks, release, changelog, social preview)
+- **Config**: `.config/` - grouped, shared single-line marker files consumed
   by both `xtask` and CI. Currently holds `.config/coverage/` (pinned
   nightly toolchain, pinned Python tools `diff-cover` / `pycobertura`, and
   the coverage ignore-filename regex). Filenames follow
@@ -40,17 +40,39 @@ cargo fmt                   # format (run before submitting)
 cargo lint                  # clippy (alias defined in .cargo/config.toml)
 cargo test                  # unit + integration tests
 cargo doc-tests             # documentation tests
+cargo xtask check-typography # ASCII-punctuation lint
 ```
 
 Always run `cargo fmt`, `cargo lint`, and both test commands before considering any task complete.
 
+## ASCII-Only Punctuation
+
+Do NOT use decorative or "smart" Unicode punctuation anywhere in the
+repo - not in code, comments, docstrings, commit messages, PR
+descriptions, or markdown docs. Use the ASCII equivalent:
+
+- em-dash and en-dash -> single `-` (NEVER `--`)
+- smart quotes        -> `'` or `"`
+- ellipsis            -> `...`
+- arrows              -> `->`, `<-`, `=>`, etc.
+- bullet / middle-dot -> `-` or `*`
+- non-breaking space  -> regular space
+- math glyphs         -> ASCII operators (`x`, `/`, `>=`, `<=`, `!=`)
+
+Emoji in user-visible output (e.g. CI workflow logs) are fine.
+
+This is enforced by `cargo xtask check-typography`, which runs in the
+pre-commit hook and CI. If the check fails, fix the offending
+characters - do NOT add to the allowlist.
+
 ## Code Standards
 
-- **Document everything**: modules, functions, structs, constants — no exceptions
+- **Document everything**: modules, functions, structs, constants - no exceptions
 - **Minimize inline comments**: comments explain *why*, never *what*
 - **Module-level docs**: use `//!` with `#![doc(html_no_source)]`
 - **Function docs**: include purpose, `# Arguments`, `# Returns`, and `# Examples` sections
 - **Document panics and error scenarios explicitly**
+- **ASCII-only punctuation**: see the section above; this is enforced in CI
 
 ## Development Patterns
 
@@ -72,8 +94,8 @@ Always run `cargo fmt`, `cargo lint`, and both test commands before considering 
 ## Windows-Specific Implementation
 
 ### String Conversion
-- **Rust → Windows API**: `OsString::encode_wide()` for UTF-16 encoding
-- **Windows API → Rust**: `to_string_lossy()` for safe conversion back
+- **Rust -> Windows API**: `OsString::encode_wide()` for UTF-16 encoding
+- **Windows API -> Rust**: `to_string_lossy()` for safe conversion back
 - Always ensure proper null termination for C-style strings
 
 ### Windows API Integration
@@ -86,7 +108,7 @@ Always run `cargo fmt`, `cargo lint`, and both test commands before considering 
 
 - **Naming**: `test_*.rs` files in `src/tests/`, descriptive test function names
 - **Pattern**: Arrange-Act-Assert for all tests
-- **Mocking**: Use `mockall` for all Windows API interactions — tests must have zero side-effects on the system
+- **Mocking**: Use `mockall` for all Windows API interactions - tests must have zero side-effects on the system
 - **No external state**: tests must not modify registry, filesystem, or process state
 
 ## Commit Messages
@@ -117,5 +139,6 @@ Before considering any task complete:
 2. All tests pass (`cargo doc-tests && cargo test`)
 3. Code is formatted (`cargo fmt`)
 4. No clippy warnings (`cargo lint`)
-5. All interactions with external systems are mocked in tests
-6. Configuration changes maintain backwards compatibility
+5. No forbidden Unicode (`cargo xtask check-typography`)
+6. All interactions with external systems are mocked in tests
+7. Configuration changes maintain backwards compatibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Following these guidelines helps to communicate that you respect the time of the
 
 ### What kinds of contributions we're looking for
 
-csshW is an open source project and we love to receive contributions from our community — you! There are many ways to contribute, from writing blog posts, improving the documentation, submitting bug reports and feature requests or writing code which can be incorporated into csshW itself.
+csshW is an open source project and we love to receive contributions from our community - you! There are many ways to contribute, from writing blog posts, improving the documentation, submitting bug reports and feature requests or writing code which can be incorporated into csshW itself.
 
 ## Ground Rules
 
@@ -83,7 +83,7 @@ csshW uses pre-commit git hooks to enforce code quality. These are automatically
 ### AI agent GitHub auth (optional)
 
 If you use [paseo](https://paseo.dev) to spawn AI coding agents on this
-repository, those agents inherit your full `gh` CLI login by default —
+repository, those agents inherit your full `gh` CLI login by default -
 typically a classic `repo` scope, which can delete the repository or
 force-push to `main`. You can scope an agent down by providing a
 **fine-grained** Personal Access Token:
@@ -91,7 +91,7 @@ force-push to `main`. You can scope an agent down by providing a
 1. Generate a fine-grained PAT at
    <https://github.com/settings/personal-access-tokens/new> with
    `Contents`, `Pull requests`, and `Issues` set to *Read and write*
-   (and only those — leave everything else at *No access*). Restrict it
+   (and only those - leave everything else at *No access*). Restrict it
    to your fork of `csshw`. Set a short expiration.
 2. Save the full token (including the `github_pat_` prefix) to
    `.paseo/gh-token` in your source checkout (not in a worktree). The
@@ -101,7 +101,7 @@ force-push to `main`. You can scope an agent down by providing a
 `worktree.setup` and will write the token into the worktree's
 `.claude/settings.local.json` at creation time, where Claude Code
 injects it as `GH_TOKEN` for the agent process. If the file is absent
-the step is a no-op; classic `ghp_…` or OAuth `gho_…` tokens are
+the step is a no-op; classic `ghp_...` or OAuth `gho_...` tokens are
 rejected. To rotate, overwrite `.paseo/gh-token` in the source
 checkout and either re-run `cargo xtask inject-agent-token` from there
 or recreate the worktree.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -103,7 +103,7 @@ unsafe impl Send for Client {}
 /// lookup table.
 ///
 /// The ordered list preserves client window placement semantics, while the
-/// index enables O(1) lookup by process id — required by the pipe server task
+/// index enables O(1) lookup by process id - required by the pipe server task
 /// during PID correlation and future per-client pipe server control.
 struct Clients {
     /// Ordered list of clients; order matches launch order and is used for
@@ -137,7 +137,7 @@ impl Clients {
         let index = self.list.len();
         assert!(
             !self.pid_index.contains_key(&client.process_id),
-            "Duplicate client PID {} — daemon bookkeeping broken",
+            "Duplicate client PID {} - daemon bookkeeping broken",
             client.process_id,
         );
         self.pid_index.insert(client.process_id, index);
@@ -1018,7 +1018,7 @@ fn probe_pipe_alive(server: &NamedPipeServer) -> bool {
 /// expected to write its 4 byte little-endian process id into the pipe. The
 /// routine looks up the [`Client`] with that PID in the daemon's `clients`
 /// collection; if it is not found, the routine logs an error and terminates
-/// the daemon — an unknown PID indicates broken daemon bookkeeping and is
+/// the daemon - an unknown PID indicates broken daemon bookkeeping and is
 /// unrecoverable.
 ///
 /// Forwarding: on every broadcast record, the routine matches on the
@@ -1064,7 +1064,7 @@ async fn named_pipe_server_routine(
         Some(client) => Arc::clone(&client.pipe_server_state),
         None => {
             error!(
-                "Named pipe server received unknown PID {} — daemon bookkeeping broken",
+                "Named pipe server received unknown PID {} - daemon bookkeeping broken",
                 pid
             );
             // In production this exits the daemon; in tests process::exit would kill
@@ -1072,7 +1072,7 @@ async fn named_pipe_server_routine(
             #[cfg(not(test))]
             std::process::exit(1);
             #[cfg(test)]
-            panic!("Unknown client PID {} — daemon bookkeeping broken", pid);
+            panic!("Unknown client PID {} - daemon bookkeeping broken", pid);
         }
     };
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -982,8 +982,8 @@ fn launch_client_console<W: WindowsApi>(
 
 /// Probe `server` with a non-blocking keep-alive write to detect a closed pipe.
 ///
-/// Writes a single [`TAG_KEEP_ALIVE`] byte — the zero-payload keep-alive frame
-/// of the daemon-to-client protocol — so the client side recognises and
+/// Writes a single [`TAG_KEEP_ALIVE`] byte - the zero-payload keep-alive frame
+/// of the daemon-to-client protocol - so the client side recognises and
 /// discards it. Treated as alive on success or `WouldBlock`; any other error
 /// means the pipe is closed.
 ///
@@ -1093,7 +1093,7 @@ async fn named_pipe_server_routine(
         };
         // Only forward to the client if its pipe server state allows it.
         // Copy the state out so the mutex guard does not span the `.await`
-        // below — `MutexGuard` is not `Send` and would prevent the routine
+        // below - `MutexGuard` is not `Send` and would prevent the routine
         // from being spawned on a multi-threaded runtime.
         let state = *pipe_server_state.lock().unwrap();
         match state {

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -384,7 +384,7 @@ mod daemon_test {
         // Disable the client.
         *pipe_server_state.lock().unwrap() = PipeServerState::Disabled;
 
-        // Send more data — it must NOT arrive at the client.
+        // Send more data - it must NOT arrive at the client.
         const SENDS: usize = 5;
         for _ in 0..SENDS {
             sender.send([3; SERIALIZED_INPUT_RECORD_0_LENGTH])?;
@@ -393,7 +393,7 @@ mod daemon_test {
         // The disabled branch writes one keep-alive frame per consumed
         // broadcast record, so we expect at least `SENDS` keep-alive
         // frames to arrive. Read exactly that many and assert each is
-        // a `TAG_KEEP_ALIVE` byte — any `TAG_INPUT_RECORD` frame would
+        // a `TAG_KEEP_ALIVE` byte - any `TAG_INPUT_RECORD` frame would
         // be a leak of broadcast data and must fail the test.
         let mut received = 0;
         while received < SENDS {
@@ -409,7 +409,7 @@ mod daemon_test {
                         received += 1;
                     }
                     TAG_INPUT_RECORD => panic!(
-                        "Received input-record frame after disabling — broadcast data leaked through"
+                        "Received input-record frame after disabling - broadcast data leaked through"
                     ),
                     other => panic!("Unexpected tag byte 0x{other:02X}"),
                 },

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -274,7 +274,7 @@ mod daemon_test {
         let future = tokio::spawn(async move {
             named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
         });
-        // Unknown PID is unrecoverable — the routine must panic (exits the daemon in production).
+        // Unknown PID is unrecoverable - the routine must panic (exits the daemon in production).
         assert!(future.await.unwrap_err().is_panic());
         return Ok(());
     }
@@ -304,7 +304,7 @@ mod daemon_test {
         let future = tokio::spawn(async move {
             named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
         });
-        // Pipe closed before handshake completed — the routine must panic.
+        // Pipe closed before handshake completed - the routine must panic.
         assert!(future.await.unwrap_err().is_panic());
         return Ok(());
     }
@@ -437,7 +437,7 @@ mod daemon_test {
             };
         };
         clients.push(make_client(1000));
-        clients.push(make_client(1000)); // duplicate — must panic
+        clients.push(make_client(1000)); // duplicate - must panic
     }
 
     #[test]

--- a/templates/github-pages-index.html
+++ b/templates/github-pages-index.html
@@ -159,7 +159,7 @@
     </div>
 
     <div class="footer">
-        <p>Generated from the latest <strong>main</strong> branch • <a href="https://github.com/whme/csshw/blob/main/templates/github-pages-index.html">View on GitHub</a></p>
+        <p>Generated from the latest <strong>main</strong> branch * <a href="https://github.com/whme/csshw/blob/main/templates/github-pages-index.html">View on GitHub</a></p>
     </div>
 </body>
 </html>

--- a/templates/github-pages-index.html
+++ b/templates/github-pages-index.html
@@ -159,7 +159,7 @@
     </div>
 
     <div class="footer">
-        <p>Generated from the latest <strong>main</strong> branch * <a href="https://github.com/whme/csshw/blob/main/templates/github-pages-index.html">View on GitHub</a></p>
+        <p>Generated from the latest <strong>main</strong> branch • <a href="https://github.com/whme/csshw/blob/main/templates/github-pages-index.html">View on GitHub</a></p>
     </div>
 </body>
 </html>

--- a/templates/social-preview.html
+++ b/templates/social-preview.html
@@ -1,25 +1,25 @@
 <!doctype html>
 <!--
-  Social preview card — 1280×640.
+  Social preview card - 1280x640.
 
   Rendered to PNG by xtask/social-preview/generate.mjs via headless
   Chromium inside the pinned Playwright Docker image.
 
   This file is the source of truth for the visual design. The generator
-  replaces the `{{PLACEHOLDERS}}` below by plain string substitution —
+  replaces the `{{PLACEHOLDERS}}` below by plain string substitution -
   nothing else. Designers can open this file directly in a browser (with
   placeholders left literal) to iterate on CSS without running the xtask.
 
   Constraints:
    - Do not fetch anything from the network.
-   - Do not use @media queries — viewport is fixed at 1280×640.
+   - Do not use @media queries - viewport is fixed at 1280x640.
    - Do not add a new placeholder without also teaching generate.mjs about
      it; the contract is intentionally narrow.
 -->
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>{{REPO_FULL_NAME}} — social preview</title>
+    <title>{{REPO_FULL_NAME}} - social preview</title>
     <style>
       @font-face {
         font-family: "DejaVu Sans Mono";
@@ -187,7 +187,7 @@
       (function () {
         // JSON.parse handles both valid payloads and the designer
         // fallback path (template opened directly with the literal
-        // {{LANGUAGES_JSON}} placeholder) — the latter throws and we
+        // {{LANGUAGES_JSON}} placeholder) - the latter throws and we
         // silently leave the bar empty. A stringly-typed guard like
         // `raw === "{{LANGUAGES_JSON}}"` would itself be substituted by
         // generate.mjs, corrupting this script's syntax.

--- a/templates/social-preview.html
+++ b/templates/social-preview.html
@@ -19,7 +19,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>{{REPO_FULL_NAME}} - social preview</title>
+    <title>{{REPO_FULL_NAME}} — social preview</title>
     <style>
       @font-face {
         font-family: "DejaVu Sans Mono";

--- a/xtask/social-preview/README.md
+++ b/xtask/social-preview/README.md
@@ -8,19 +8,19 @@ pinned `mcr.microsoft.com/playwright:<tag>` Docker image.
 
 ## What's in here
 
-- `generate.mjs` — Node ESM entry point. Reads
+- `generate.mjs` - Node ESM entry point. Reads
   `templates/social-preview.html`, fetches GitHub repo + language data,
   renders the card via Playwright + Chromium, and writes PNG to
   `$OUT_PATH` (supplied by the Rust xtask).
-- `package.json` / `package-lock.json` — pin `@playwright/test` to the
+- `package.json` / `package-lock.json` - pin `@playwright/test` to the
   numeric part of the Playwright Docker tag. **Both are committed.**
-- `node_modules/` — gitignored, populated on first invocation.
+- `node_modules/` - gitignored, populated on first invocation.
 
 The generated PNG is written to `target/social-preview/social-preview.png`
-by default — under Cargo's build-artifact directory, which is already
+by default - under Cargo's build-artifact directory, which is already
 `.gitignore`d. Override with `--out <PATH>`.
 
-Language → colour mappings are fetched from
+Language -> colour mappings are fetched from
 [ozh/github-colors][ozh-colors] at runtime (a JSON mirror of
 github-linguist's `languages.yml`), so no colour snapshot lives in this
 repository. Unknown languages fall back to `#cccccc` with a warning.
@@ -55,11 +55,11 @@ GitHub has no API for social preview uploads. To publish a new card:
 
 1. Run `cargo xtask generate-social-preview`.
 2. Open the repository's
-   **Settings → General → Social preview**.
-3. Choose **Edit → Upload an image** and pick
+   **Settings -> General -> Social preview**.
+3. Choose **Edit -> Upload an image** and pick
    `target/social-preview/social-preview.png`.
 
-## Version coupling: Playwright ⇄ Docker tag
+## Version coupling: Playwright <-> Docker tag
 
 The `@playwright/test` version in `package.json` **must** match the
 numeric portion of the Docker image tag pinned in
@@ -73,8 +73,8 @@ together in the same commit. The current pinning is:
 
 ## Template authoring
 
-`templates/social-preview.html` is self-contained — no network fetches,
-no `@media` queries, a single viewport of 1280×640. Designers can open
+`templates/social-preview.html` is self-contained - no network fetches,
+no `@media` queries, a single viewport of 1280x640. Designers can open
 the file directly in a browser to iterate on CSS.
 
 The only placeholders the generator substitutes are the ones listed in

--- a/xtask/social-preview/generate.mjs
+++ b/xtask/social-preview/generate.mjs
@@ -8,21 +8,21 @@
 // container path (for example, under `/workspace/...`).
 //
 // Inputs (environment):
-//   OUT_PATH      — output path for the PNG inside the container
+//   OUT_PATH      - output path for the PNG inside the container
 //                   filesystem (required, set by the Rust xtask; may be
 //                   absolute).
-//   GITHUB_TOKEN  — optional; enables authenticated GitHub API requests.
-//   GITHUB_OWNER  — defaults to "whme".
-//   GITHUB_REPO   — defaults to "csshw".
+//   GITHUB_TOKEN  - optional; enables authenticated GitHub API requests.
+//   GITHUB_OWNER  - defaults to "whme".
+//   GITHUB_REPO   - defaults to "csshw".
 //
 // Outputs:
-//   A 2560×1280 PNG (2× scale for sharp rendering) written to OUT_PATH.
+//   A 2560x1280 PNG (2x scale for sharp rendering) written to OUT_PATH.
 //
 // Design goals:
-//   - Fail loudly on any network, file, or Playwright error — no silent
+//   - Fail loudly on any network, file, or Playwright error - no silent
 //     fallbacks. Unknown language colors are the one exception (warn +
 //     grey fallback). Missing language icons fall back to colored swatches.
-//   - No HTTP libraries — use Node's built-in `fetch`. Per run we make
+//   - No HTTP libraries - use Node's built-in `fetch`. Per run we make
 //     up to three + N outbound calls: GitHub repo metadata, GitHub
 //     language bytes, (on cache miss) the linguist colour map from
 //     ozh/github-colors, and up to N language icon fetches from
@@ -52,9 +52,9 @@ const LINGUIST_COLORS_URL =
 const UNKNOWN_LANGUAGE_COLOR = "#cccccc";
 const OTHER_BUCKET_COLOR = "#ededed";
 const VIEWPORT = { width: 1280, height: 640 };
-// Layout is designed at 1280×640 CSS pixels (GitHub's recommended social
-// preview size) but rendered at 2× device scale for sharper output,
-// producing a 2560×1280 PNG (see https://docs.github.com/en/repositories/
+// Layout is designed at 1280x640 CSS pixels (GitHub's recommended social
+// preview size) but rendered at 2x device scale for sharper output,
+// producing a 2560x1280 PNG (see https://docs.github.com/en/repositories/
 // managing-your-repositorys-settings-and-features/customizing-your-
 // repository/customizing-your-repositorys-social-media-preview).
 const DEVICE_SCALE_FACTOR = 2;
@@ -67,7 +67,7 @@ const ICON_CACHE_DIR = "target/social-preview/icon-cache";
 
 // Maps GitHub linguist language names to Simple Icons slugs.
 // Only languages that have a matching Simple Icons entry need an entry
-// here — missing languages gracefully fall back to a colored swatch.
+// here - missing languages gracefully fall back to a colored swatch.
 const LANGUAGE_ICON_SLUGS = {
   Rust: "rust",
   JavaScript: "javascript",
@@ -179,7 +179,7 @@ function buildLanguages(bytesByLang, colorsByLang) {
       e.pct = Math.round(e.pct * scale * 10) / 10;
     });
   }
-  // Drop entries that rounded to zero — they contribute no visible
+  // Drop entries that rounded to zero - they contribute no visible
   // segment and just clutter the legend.
   return result.filter((e) => e.pct > 0);
 }
@@ -195,7 +195,7 @@ async function dataUri(path, mime) {
  * string on success, or `null` on any failure.
  *
  * The CDN URL pattern `https://cdn.simpleicons.org/{slug}/{hex}` returns
- * the icon SVG with all paths filled in the requested colour — no
+ * the icon SVG with all paths filled in the requested colour - no
  * client-side tinting needed.
  */
 async function fetchLanguageIcon(slug, hexColor) {
@@ -213,7 +213,7 @@ async function fetchLanguageIcon(slug, hexColor) {
     const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
     if (!res.ok) {
       console.warn(
-        `Icon fetch for "${slug}" returned ${res.status} — falling back to swatch.`,
+        `Icon fetch for "${slug}" returned ${res.status} - falling back to swatch.`,
       );
       return null;
     }
@@ -222,7 +222,7 @@ async function fetchLanguageIcon(slug, hexColor) {
     await writeFile(cacheFile, svg);
     return `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
   } catch (err) {
-    console.warn(`Icon fetch for "${slug}" failed: ${err.message} — falling back to swatch.`);
+    console.warn(`Icon fetch for "${slug}" failed: ${err.message} - falling back to swatch.`);
     return null;
   }
 }
@@ -250,7 +250,7 @@ async function populateLanguageIcons(langEntries) {
  * ozh/github-colors and persists a flat `{ "<Language>": "#rrggbb" }`
  * JSON file for future runs. That repo publishes entries in the form
  * `{ "<Language>": { "color": "#rrggbb", "url": "..." } }` with
- * `color: null` for languages linguist does not assign a hue to — those
+ * `color: null` for languages linguist does not assign a hue to - those
  * are dropped so `buildLanguages` falls back to the unknown-language
  * colour instead of crashing. Delete the cache file to force a refresh.
  */

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -1,8 +1,8 @@
 //! Local coverage report generation.
 //!
-//! The nightly toolchain is required because `#[coverage(off)]` — used to
+//! The nightly toolchain is required because `#[coverage(off)]` - used to
 //! exclude untestable code such as Windows API wrappers and production I/O
-//! implementations from coverage — relies on the `coverage_attribute` feature,
+//! implementations from coverage - relies on the `coverage_attribute` feature,
 //! which is only available on nightly Rust. Without it the `cfg(coverage_nightly)`
 //! guards would not activate, causing those impls to be counted as missed lines
 //! and distorting the report.

--- a/xtask/src/inject_agent_token.rs
+++ b/xtask/src/inject_agent_token.rs
@@ -1,7 +1,7 @@
 //! Paseo agent GitHub auth injection.
 //!
 //! A paseo-spawned agent would otherwise inherit the user's full `gh`
-//! login — including classic scopes like `repo` that allow deleting
+//! login - including classic scopes like `repo` that allow deleting
 //! repositories or force-pushing to `main`. This module is the
 //! counterpart of that risk: on worktree creation, it writes a
 //! per-worktree `.claude/settings.local.json` whose `env` map carries
@@ -11,7 +11,7 @@
 //! scoped PAT while the contributor's own `gh` session outside paseo
 //! is unaffected.
 //!
-//! The token source is `<source-checkout>/.paseo/gh-token` — a
+//! The token source is `<source-checkout>/.paseo/gh-token` - a
 //! gitignored file the contributor creates once per clone. The
 //! source checkout path is taken from the `PASEO_SOURCE_CHECKOUT_PATH`
 //! environment variable paseo sets when running setup steps; if that
@@ -21,8 +21,8 @@
 //!
 //! If the token file is missing the subcommand is a silent no-op
 //! (with an informational log line). If it contains anything other
-//! than a fine-grained PAT — e.g. a classic `ghp_…` or OAuth `gho_…`
-//! token — the subcommand aborts, since those token types grant far
+//! than a fine-grained PAT - e.g. a classic `ghp_...` or OAuth `gho_...`
+//! token - the subcommand aborts, since those token types grant far
 //! more than the least-privilege goal allows.
 
 use std::path::{Path, PathBuf};
@@ -31,7 +31,7 @@ use anyhow::{bail, Context, Result};
 
 /// Expected prefix for a fine-grained personal access token. Classic
 /// tokens (`ghp_`) and OAuth tokens (`gho_`) are rejected to preserve
-/// the least-privilege property — classic tokens cannot be restricted
+/// the least-privilege property - classic tokens cannot be restricted
 /// to specific repositories or to a subset of repository permissions.
 const FINE_GRAINED_PREFIX: &str = "github_pat_";
 
@@ -169,7 +169,7 @@ fn build_settings_body(token: &str) -> String {
 /// PAT alphabet `[A-Za-z0-9_]`.
 ///
 /// Enforcing this invariant is what lets [`build_settings_body`]
-/// embed the token directly into a JSON template without escaping —
+/// embed the token directly into a JSON template without escaping -
 /// none of the characters in this alphabet need JSON escaping, so a
 /// token that passes this check cannot break out of its string
 /// literal nor inject additional keys.
@@ -192,8 +192,8 @@ fn is_fine_grained_pat_alphabet(token: &str) -> bool {
 /// Resolve the source checkout directory.
 ///
 /// Paseo passes `PASEO_SOURCE_CHECKOUT_PATH` into `worktree.setup`
-/// subprocesses. When the variable is missing — for example when the
-/// subcommand is invoked manually — fall back to the current
+/// subprocesses. When the variable is missing - for example when the
+/// subcommand is invoked manually - fall back to the current
 /// directory so running it from the repo root behaves intuitively.
 ///
 /// # Arguments
@@ -259,7 +259,7 @@ pub fn inject_agent_token<S: InjectAgentTokenSystem>(system: &S) -> Result<()> {
     }
     if !token.starts_with(FINE_GRAINED_PREFIX) {
         bail!(
-            "{} must contain a fine-grained PAT (prefix `{}`); classic `ghp_…` and OAuth `gho_…` tokens are not accepted because they cannot be scoped tightly enough. See CONTRIBUTING.md.",
+            "{} must contain a fine-grained PAT (prefix `{}`); classic `ghp_...` and OAuth `gho_...` tokens are not accepted because they cannot be scoped tightly enough. See CONTRIBUTING.md.",
             token_file.display(),
             FINE_GRAINED_PREFIX
         );

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-//! xtask — developer automation tasks for csshw.
+//! xtask -- developer automation tasks for csshw.
 //!
 //! Invoke via `cargo xtask <subcommand>`.
 //! See each subcommand's module for details.
@@ -11,6 +11,7 @@ mod inject_agent_token;
 mod readme;
 mod release;
 mod social_preview;
+mod typography;
 
 use std::path::PathBuf;
 
@@ -61,6 +62,9 @@ enum Command {
     /// agents act with a least-privilege token instead of the user's
     /// full `gh` login. A no-op when `.paseo/gh-token` is absent.
     InjectAgentToken,
+    /// Scan tracked text files for forbidden decorative Unicode
+    /// punctuation and fail with a list of offending locations.
+    CheckTypography,
 }
 
 fn main() -> Result<()> {
@@ -93,6 +97,9 @@ fn main() -> Result<()> {
         }
         Command::InjectAgentToken => {
             inject_agent_token::inject_agent_token(&inject_agent_token::RealSystem)?;
+        }
+        Command::CheckTypography => {
+            typography::check_typography(&typography::RealSystem)?;
         }
     }
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-//! xtask -- developer automation tasks for csshw.
+//! xtask - developer automation tasks for csshw.
 //!
 //! Invoke via `cargo xtask <subcommand>`.
 //! See each subcommand's module for details.

--- a/xtask/src/readme.rs
+++ b/xtask/src/readme.rs
@@ -229,7 +229,7 @@ pub fn update_readme_help<S: ReadmeSystem>(system: &S) -> Result<bool> {
         return Ok(false);
     }
 
-    println!("WARNING - README.md help section is outdated — fixing it.");
+    println!("WARNING - README.md help section is outdated - fixing it.");
     let new_readme = replace_readme_help_section(&readme, &actual_help)?;
     system.write_readme(&new_readme)?;
     println!("INFO - README.md help section has been updated with current --help output.");

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -368,7 +368,7 @@ impl ReleaseSystem for RealSystem {
 
 /// Determine the suggested next version and release type from the current branch.
 ///
-/// `main` → minor bump; `*-maintenance` → patch bump.
+/// `main` -> minor bump; `*-maintenance` -> patch bump.
 ///
 /// # Arguments
 ///
@@ -467,7 +467,7 @@ pub fn set_cargo_toml_version(cargo_toml_content: &str, new_version: &str) -> Re
 pub fn prepare_release<S: ReleaseSystem>(system: &S) -> Result<()> {
     let status = system.git_status_porcelain()?;
     if !status.trim().is_empty() {
-        bail!("git working directory is not clean — commit or stash changes first:\n{status}");
+        bail!("git working directory is not clean - commit or stash changes first:\n{status}");
     }
 
     let current_branch = system.git_current_branch()?;
@@ -497,7 +497,7 @@ pub fn prepare_release<S: ReleaseSystem>(system: &S) -> Result<()> {
             }
             let custom: Version = custom_str
                 .parse()
-                .context("invalid version format — use semantic versioning (e.g. 1.2.3)")?;
+                .context("invalid version format - use semantic versioning (e.g. 1.2.3)")?;
             let release_type = determine_release_type(&current_version, &custom);
             (custom, release_type)
         } else if answer.is_empty()
@@ -506,7 +506,7 @@ pub fn prepare_release<S: ReleaseSystem>(system: &S) -> Result<()> {
         {
             (suggested_version, suggested_type)
         } else {
-            bail!("invalid input — please enter Y or n");
+            bail!("invalid input - please enter Y or n");
         };
 
     let target_branch = if current_branch == "main" {
@@ -581,7 +581,7 @@ pub fn create_release_tag<S: ReleaseSystem>(system: &S) -> Result<()> {
     if !current_branch.ends_with("-maintenance") {
         bail!(
             "must be on a maintenance branch to create a release tag \
-             (current branch: {current_branch}) — run `cargo xtask prepare-release` first"
+             (current branch: {current_branch}) - run `cargo xtask prepare-release` first"
         );
     }
 
@@ -617,7 +617,7 @@ pub fn create_release_tag<S: ReleaseSystem>(system: &S) -> Result<()> {
 
     let behind = system.git_rev_list_count_behind(&current_branch)?;
     if behind > 0 {
-        bail!("local branch is {behind} commit(s) behind remote — run `git pull` first");
+        bail!("local branch is {behind} commit(s) behind remote - run `git pull` first");
     }
 
     let answer = system.prompt_user(&format!(

--- a/xtask/src/social_preview.rs
+++ b/xtask/src/social_preview.rs
@@ -1,7 +1,7 @@
 //! Social preview image generation.
 //!
 //! Orchestrates `docker run` against the pinned Playwright image to render
-//! `templates/social-preview.html` into a 1280×640 PNG with live data
+//! `templates/social-preview.html` into a 1280x640 PNG with live data
 //! fetched from the GitHub API. The Rust side is a thin shell: all HTTP,
 //! template substitution, and screenshotting live in
 //! `xtask/social-preview/generate.mjs`, which runs inside the container.
@@ -272,7 +272,7 @@ fn normalise_path(path: &Path) -> PathBuf {
 /// Render a `docker` argument list as a single shell-quoted string, purely
 /// for diagnostic logging. Arguments containing whitespace or shell
 /// metacharacters are wrapped in single quotes; inner single quotes are
-/// escaped as `'\''`. This is never re-parsed — it's only printed to
+/// escaped as `'\''`. This is never re-parsed - it's only printed to
 /// stdout so a user can copy-paste the exact invocation.
 fn shell_quote_args(args: &[String]) -> String {
     args.iter()
@@ -346,7 +346,7 @@ fn build_docker_args(workspace_root: &Path, container_out: &str, has_token: bool
     // The install runs in a subshell so it does not alter the CWD of the
     // subsequent `node` invocation. `generate.mjs` resolves its inputs
     // (template, logo, font, linguist colors) as workspace-relative paths,
-    // so it must run from `/workspace` — not from
+    // so it must run from `/workspace` - not from
     // `/workspace/xtask/social-preview`.
     args.push(
         "( cd xtask/social-preview && { [ -d node_modules ] || npm ci; } ) && node xtask/social-preview/generate.mjs"
@@ -382,7 +382,7 @@ pub fn generate_social_preview<S: SocialPreviewSystem>(
     let workspace_root = system.workspace_root()?;
     let (host_out, relative_out) = resolve_out_paths(&workspace_root, out)?;
     system.print_info(&format!(
-        "Generating social preview → {}",
+        "Generating social preview -> {}",
         host_out.display()
     ));
     system.check_docker_ready()?;

--- a/xtask/src/tests/test_inject_agent_token.rs
+++ b/xtask/src/tests/test_inject_agent_token.rs
@@ -187,7 +187,7 @@ fn test_classic_token_is_rejected() {
 
 #[test]
 fn test_oauth_token_is_rejected() {
-    // Arrange — OAuth tokens (`gho_…`) take the same rejection path as
+    // Arrange - OAuth tokens (`gho_...`) take the same rejection path as
     // classic tokens; the wording must remain accurate for both.
     let (mut mock, _source, _cwd) =
         make_mock_with_layout("C:\\src", "C:\\worktree", Some("C:\\src"));
@@ -210,7 +210,7 @@ fn test_oauth_token_is_rejected() {
 
 #[test]
 fn test_token_with_invalid_characters_is_rejected() {
-    // Arrange — passes the `github_pat_` prefix check but contains
+    // Arrange - passes the `github_pat_` prefix check but contains
     // characters outside `[A-Za-z0-9_]`, which would break the JSON
     // template if embedded directly. Must be rejected before the
     // template is built.

--- a/xtask/src/tests/test_social_preview.rs
+++ b/xtask/src/tests/test_social_preview.rs
@@ -227,7 +227,7 @@ fn test_generate_rejects_parent_escape_in_out_path() {
     mock.expect_ensure_parent_dir().never();
     mock.expect_run_docker().never();
 
-    // Act — relative `..` that escapes the workspace resolves outside
+    // Act - relative `..` that escapes the workspace resolves outside
     // `workspace_root` and is rejected.
     let result =
         generate_social_preview(&mock, Some(PathBuf::from("../outside/preview.png")), None);
@@ -244,7 +244,7 @@ fn test_generate_accepts_dotdot_that_stays_inside_workspace() {
     let captured = Arc::new(Mutex::new(DockerCall::default()));
     capture_docker(&mut mock, captured.clone());
 
-    // Act — `sub/../preview.png` normalises to `preview.png` under the
+    // Act - `sub/../preview.png` normalises to `preview.png` under the
     // workspace root, so the path is accepted.
     let result = generate_social_preview(&mock, Some(PathBuf::from("sub/../preview.png")), None);
 
@@ -269,7 +269,7 @@ fn test_generate_rejects_absolute_path_outside_workspace() {
     mock.expect_ensure_parent_dir().never();
     mock.expect_run_docker().never();
 
-    // Act — an absolute path whose root does not share a prefix with
+    // Act - an absolute path whose root does not share a prefix with
     // `workspace_root` cannot be reached from inside the container and
     // is rejected. The particular path shape differs by platform but
     // the branch under test is the same.

--- a/xtask/src/tests/test_typography.rs
+++ b/xtask/src/tests/test_typography.rs
@@ -96,6 +96,12 @@ fn test_should_scan_includes_pre_commit_hook() {
 }
 
 #[test]
+fn test_should_scan_includes_javascript() {
+    assert!(should_scan("xtask/social-preview/generate.mjs"));
+    assert!(should_scan("scripts/foo.js"));
+}
+
+#[test]
 fn test_should_scan_excludes_cargo_lock() {
     assert!(!should_scan("Cargo.lock"));
 }

--- a/xtask/src/tests/test_typography.rs
+++ b/xtask/src/tests/test_typography.rs
@@ -1,0 +1,290 @@
+//! Tests for the typography module.
+
+use std::path::Path;
+
+use anyhow::Result;
+use mockall::mock;
+
+use crate::typography::{
+    check_typography, is_blocklisted, scan_bytes, should_scan, TypographySystem, Violation,
+};
+
+mock! {
+    TypographySystemMock {}
+    impl TypographySystem for TypographySystemMock {
+        fn list_tracked_files(&self) -> Result<Vec<String>>;
+        fn file_size(&self, path: &Path) -> Result<u64>;
+        fn read_file(&self, path: &Path) -> Result<Vec<u8>>;
+        fn log(&self, msg: &str);
+    }
+}
+
+#[test]
+fn test_is_blocklisted_flags_em_dash() {
+    // Arrange / Act / Assert
+    assert!(is_blocklisted('\u{2014}'));
+}
+
+#[test]
+fn test_is_blocklisted_flags_en_dash() {
+    assert!(is_blocklisted('\u{2013}'));
+}
+
+#[test]
+fn test_is_blocklisted_flags_smart_quotes() {
+    assert!(is_blocklisted('\u{2018}'));
+    assert!(is_blocklisted('\u{2019}'));
+    assert!(is_blocklisted('\u{201C}'));
+    assert!(is_blocklisted('\u{201D}'));
+}
+
+#[test]
+fn test_is_blocklisted_flags_ellipsis() {
+    assert!(is_blocklisted('\u{2026}'));
+}
+
+#[test]
+fn test_is_blocklisted_flags_arrows() {
+    assert!(is_blocklisted('\u{2190}'));
+    assert!(is_blocklisted('\u{2192}'));
+    assert!(is_blocklisted('\u{21FF}'));
+}
+
+#[test]
+fn test_is_blocklisted_flags_nbsp() {
+    assert!(is_blocklisted('\u{00A0}'));
+}
+
+#[test]
+fn test_is_blocklisted_allows_ascii() {
+    for c in 0u32..=0x7F {
+        let c = char::from_u32(c).unwrap();
+        assert!(!is_blocklisted(c), "ASCII {c:?} flagged");
+    }
+}
+
+#[test]
+fn test_is_blocklisted_allows_emoji() {
+    // Robot, check mark, cross mark, magnifier (used in CI workflow logs).
+    assert!(!is_blocklisted('\u{1F916}'));
+    assert!(!is_blocklisted('\u{2705}'));
+    assert!(!is_blocklisted('\u{274C}'));
+    assert!(!is_blocklisted('\u{1F50D}'));
+}
+
+#[test]
+fn test_should_scan_includes_rust_files() {
+    assert!(should_scan("src/main.rs"));
+    assert!(should_scan("xtask/src/typography.rs"));
+}
+
+#[test]
+fn test_should_scan_includes_markdown() {
+    assert!(should_scan("AGENTS.md"));
+    assert!(should_scan("docs/guide.md"));
+}
+
+#[test]
+fn test_should_scan_includes_workflow_yaml() {
+    assert!(should_scan(".github/workflows/_shared-ci.yml"));
+    assert!(should_scan("config.yaml"));
+}
+
+#[test]
+fn test_should_scan_includes_pre_commit_hook() {
+    assert!(should_scan(".githooks/pre-commit"));
+}
+
+#[test]
+fn test_should_scan_excludes_cargo_lock() {
+    assert!(!should_scan("Cargo.lock"));
+}
+
+#[test]
+fn test_should_scan_excludes_unknown_extensions() {
+    assert!(!should_scan("logo.png"));
+    assert!(!should_scan("binary.exe"));
+    assert!(!should_scan("README"));
+}
+
+#[test]
+fn test_scan_bytes_clean_ascii_returns_empty() {
+    // Arrange
+    let bytes = b"// Plain ASCII\nfn main() {}\n";
+
+    // Act
+    let (violations, non_utf8) = scan_bytes("src/main.rs", bytes);
+
+    // Assert
+    assert!(violations.is_empty());
+    assert!(!non_utf8);
+}
+
+#[test]
+fn test_scan_bytes_emoji_not_flagged() {
+    // Arrange
+    let bytes = "println!(\"\u{1F916} done\");\n".as_bytes();
+
+    // Act
+    let (violations, non_utf8) = scan_bytes("src/main.rs", bytes);
+
+    // Assert
+    assert!(violations.is_empty());
+    assert!(!non_utf8);
+}
+
+#[test]
+fn test_scan_bytes_crlf_not_flagged() {
+    // Arrange
+    let bytes = b"// line one\r\n// line two\r\n";
+
+    // Act
+    let (violations, non_utf8) = scan_bytes("src/main.rs", bytes);
+
+    // Assert
+    assert!(violations.is_empty());
+    assert!(!non_utf8);
+}
+
+#[test]
+fn test_scan_bytes_em_dash_reported_with_position() {
+    // Arrange: em-dash on line 2, after "ab".
+    let bytes = "fn main() {}\nab\u{2014}cd\n".as_bytes();
+
+    // Act
+    let (violations, non_utf8) = scan_bytes("src/main.rs", bytes);
+
+    // Assert
+    assert!(!non_utf8);
+    assert_eq!(
+        violations,
+        vec![Violation {
+            path: "src/main.rs".to_owned(),
+            line: 2,
+            column: 3,
+            character: '\u{2014}',
+        }]
+    );
+}
+
+#[test]
+fn test_scan_bytes_arrow_reported() {
+    // Arrange: rightwards arrow at start of line 1.
+    let bytes = "\u{2192} foo".as_bytes();
+
+    // Act
+    let (violations, non_utf8) = scan_bytes("src/lib.rs", bytes);
+
+    // Assert
+    assert!(!non_utf8);
+    assert_eq!(violations.len(), 1);
+    assert_eq!(violations[0].character, '\u{2192}');
+    assert_eq!(violations[0].line, 1);
+    assert_eq!(violations[0].column, 1);
+}
+
+#[test]
+fn test_scan_bytes_multiple_violations_reported() {
+    // Arrange
+    let bytes = "// \u{2014}\u{2026}\n".as_bytes();
+
+    // Act
+    let (violations, non_utf8) = scan_bytes("a.md", bytes);
+
+    // Assert
+    assert!(!non_utf8);
+    assert_eq!(violations.len(), 2);
+    assert_eq!(violations[0].character, '\u{2014}');
+    assert_eq!(violations[0].column, 4);
+    assert_eq!(violations[1].character, '\u{2026}');
+    assert_eq!(violations[1].column, 5);
+}
+
+#[test]
+fn test_scan_bytes_invalid_utf8_flagged() {
+    // Arrange: lone continuation byte.
+    let bytes: &[u8] = &[0x66, 0x6F, 0x80, 0x6F];
+
+    // Act
+    let (violations, non_utf8) = scan_bytes("bin", bytes);
+
+    // Assert
+    assert!(violations.is_empty());
+    assert!(non_utf8);
+}
+
+#[test]
+fn test_check_typography_passes_when_all_clean() {
+    // Arrange
+    let mut mock = MockTypographySystemMock::new();
+    mock.expect_list_tracked_files()
+        .returning(|| Ok(vec!["src/main.rs".to_owned(), "Cargo.lock".to_owned()]));
+    mock.expect_file_size()
+        .withf(|p: &Path| p == Path::new("src/main.rs"))
+        .returning(|_| Ok(20));
+    mock.expect_read_file()
+        .withf(|p: &Path| p == Path::new("src/main.rs"))
+        .returning(|_| Ok(b"fn main() {}\n".to_vec()));
+    // Cargo.lock must NOT be read because it is in ALLOWED_PATHS.
+
+    // Act
+    let result = check_typography(&mock);
+
+    // Assert
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_check_typography_fails_on_em_dash() {
+    // Arrange
+    let mut mock = MockTypographySystemMock::new();
+    mock.expect_list_tracked_files()
+        .returning(|| Ok(vec!["AGENTS.md".to_owned()]));
+    mock.expect_file_size().returning(|_| Ok(20));
+    mock.expect_read_file()
+        .returning(|_| Ok("hello \u{2014} world\n".as_bytes().to_vec()));
+
+    // Act
+    let result = check_typography(&mock);
+
+    // Assert
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("forbidden"), "unexpected error: {msg}");
+}
+
+#[test]
+fn test_check_typography_skips_oversized_file() {
+    // Arrange: a tracked file larger than the cap should be skipped
+    // with a warning rather than blocking the run.
+    let mut mock = MockTypographySystemMock::new();
+    mock.expect_list_tracked_files()
+        .returning(|| Ok(vec!["huge.md".to_owned()]));
+    mock.expect_file_size().returning(|_| Ok(10 * 1024 * 1024));
+    mock.expect_log().returning(|_| ());
+    // read_file must NOT be called for an oversized file.
+
+    // Act
+    let result = check_typography(&mock);
+
+    // Assert
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_check_typography_skips_non_utf8_file() {
+    // Arrange
+    let mut mock = MockTypographySystemMock::new();
+    mock.expect_list_tracked_files()
+        .returning(|| Ok(vec!["weird.md".to_owned()]));
+    mock.expect_file_size().returning(|_| Ok(4));
+    mock.expect_read_file()
+        .returning(|_| Ok(vec![0x66, 0x6F, 0x80, 0x6F]));
+    mock.expect_log().returning(|_| ());
+
+    // Act
+    let result = check_typography(&mock);
+
+    // Assert
+    assert!(result.is_ok());
+}

--- a/xtask/src/tests/test_typography.rs
+++ b/xtask/src/tests/test_typography.rs
@@ -101,6 +101,21 @@ fn test_should_scan_excludes_cargo_lock() {
 }
 
 #[test]
+fn test_should_scan_excludes_news_fragment_workflow() {
+    assert!(!should_scan(".github/workflows/news-fragment-check.yml"));
+}
+
+#[test]
+fn test_should_scan_excludes_github_pages_template() {
+    assert!(!should_scan("templates/github-pages-index.html"));
+}
+
+#[test]
+fn test_should_scan_excludes_social_preview_template() {
+    assert!(!should_scan("templates/social-preview.html"));
+}
+
+#[test]
 fn test_should_scan_excludes_unknown_extensions() {
     assert!(!should_scan("logo.png"));
     assert!(!should_scan("binary.exe"));

--- a/xtask/src/typography.rs
+++ b/xtask/src/typography.rs
@@ -25,7 +25,7 @@ use anyhow::{bail, Context, Result};
 /// All matching is done in lowercase. Files with no extension are
 /// scanned only when their path matches [`SCAN_EXTRA_PATHS`].
 const SCAN_EXTENSIONS: &[&str] = &[
-    "rs", "md", "toml", "yml", "yaml", "json", "html", "txt", "cfg", "sh", "ps1",
+    "rs", "md", "toml", "yml", "yaml", "json", "html", "txt", "cfg", "sh", "ps1", "js", "mjs",
 ];
 
 /// Tracked paths without a recognised extension that should still be

--- a/xtask/src/typography.rs
+++ b/xtask/src/typography.rs
@@ -1,0 +1,332 @@
+//! Typography linter that blocks decorative or "smart" Unicode
+//! punctuation from sneaking into the repository.
+//!
+//! Agents tend to introduce em-dashes, en-dashes, smart quotes,
+//! ellipsis, arrows, and similar non-ASCII glyphs in comments and
+//! prose. They look similar to their ASCII equivalents but are not
+//! what a Windows developer types and not what `cargo fmt` produces.
+//!
+//! [`check_typography`] enumerates tracked text files via
+//! `git ls-files`, scans each for a curated blocklist of code points,
+//! prints any violations as `path:line:col U+XXXX 'glyph'`, and
+//! returns an error when at least one violation is found so the
+//! pre-commit hook and CI both abort.
+//!
+//! Performance: the scan runs inside the pre-commit hook, so the
+//! hot path reads bytes, exits early on pure-ASCII input, and only
+//! decodes UTF-8 for files that actually contain non-ASCII bytes.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+/// File extensions whose contents are scanned.
+///
+/// All matching is done in lowercase. Files with no extension are
+/// scanned only when their path matches [`SCAN_EXTRA_PATHS`].
+const SCAN_EXTENSIONS: &[&str] = &[
+    "rs", "md", "toml", "yml", "yaml", "json", "html", "txt", "cfg", "sh", "ps1",
+];
+
+/// Tracked paths without a recognised extension that should still be
+/// scanned (shell scripts, hooks, etc.). Compared against the
+/// `git ls-files` output verbatim (forward slashes).
+const SCAN_EXTRA_PATHS: &[&str] = &[".githooks/pre-commit"];
+
+/// Tracked paths that are explicitly excluded from scanning. Used for
+/// generated artefacts such as `Cargo.lock` and for files (such as
+/// the `CHANGELOG.md`) that may legitimately preserve historical
+/// typography from prior releases.
+///
+/// Keep this list short -- the goal is to fix offending content, not
+/// to allowlist around it. Compared against the `git ls-files` output
+/// verbatim (forward slashes).
+const ALLOWED_PATHS: &[&str] = &["Cargo.lock"];
+
+/// Hard cap on file size accepted by the scanner. Anything larger is
+/// skipped with a warning -- the repo has nothing close to this size,
+/// and a pathological large file should not block a commit.
+const MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// All side-effecting operations performed by the typography scanner.
+///
+/// Implement with mocks in tests to achieve zero filesystem and
+/// process side-effects.
+pub trait TypographySystem {
+    /// Return the list of tracked files reported by `git ls-files`.
+    ///
+    /// Paths are returned with forward slashes (the format `git`
+    /// emits on every platform).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `git` process cannot be started or
+    /// exits non-zero.
+    fn list_tracked_files(&self) -> Result<Vec<String>>;
+
+    /// Return the size in bytes of the file at `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be stat-ed.
+    fn file_size(&self, path: &Path) -> Result<u64>;
+
+    /// Read the full contents of the file at `path` as raw bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read.
+    fn read_file(&self, path: &Path) -> Result<Vec<u8>>;
+
+    /// Emit a message to the user (informational or warning).
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - Message to display.
+    fn log(&self, msg: &str);
+}
+
+/// Production implementation of [`TypographySystem`].
+pub struct RealSystem;
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+impl TypographySystem for RealSystem {
+    fn list_tracked_files(&self) -> Result<Vec<String>> {
+        let output = std::process::Command::new("git")
+            .args(["ls-files"])
+            .output()
+            .context("failed to run `git ls-files`")?;
+        if !output.status.success() {
+            bail!(
+                "`git ls-files` exited non-zero: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let stdout =
+            String::from_utf8(output.stdout).context("`git ls-files` produced non-UTF-8 output")?;
+        Ok(stdout
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(|line| line.to_owned())
+            .collect())
+    }
+
+    fn file_size(&self, path: &Path) -> Result<u64> {
+        let meta = std::fs::metadata(path)
+            .with_context(|| format!("failed to stat {}", path.display()))?;
+        Ok(meta.len())
+    }
+
+    fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
+        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))
+    }
+
+    fn log(&self, msg: &str) {
+        eprintln!("{msg}");
+    }
+}
+
+/// A single offending code point found in a scanned file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    /// Repository-relative path with forward slashes.
+    pub path: String,
+    /// 1-based line number of the offending character.
+    pub line: u32,
+    /// 1-based column (counted in `char`s, not bytes) of the offending
+    /// character.
+    pub column: u32,
+    /// The offending Unicode scalar value.
+    pub character: char,
+}
+
+/// Return `true` when `c` should be flagged by the scanner.
+///
+/// The blocklist is hand-curated to cover the decorative glyphs that
+/// LLMs habitually substitute for ASCII punctuation. Emoji and other
+/// non-ASCII characters are deliberately not included.
+///
+/// # Arguments
+///
+/// * `c` - Character to test.
+///
+/// # Returns
+///
+/// `true` when `c` is on the blocklist, `false` otherwise.
+pub fn is_blocklisted(c: char) -> bool {
+    let cp = c as u32;
+    matches!(
+        cp,
+        // Non-breaking and middle-dot, multiplication, division.
+        0x00A0 | 0x00B7 | 0x00D7 | 0x00F7
+        // Exotic spaces.
+        | 0x2000..=0x200B
+        | 0x202F | 0x205F | 0x3000
+        // Hyphens, en/em-dashes, horizontal bar, minus sign.
+        | 0x2010..=0x2015 | 0x2212
+        // Smart single and double quotes.
+        | 0x2018..=0x201F
+        // Bullet, ellipsis.
+        | 0x2022 | 0x2026
+        // Arrows block in its entirety.
+        | 0x2190..=0x21FF
+        // Math comparison glyphs.
+        | 0x2248 | 0x2260 | 0x2264 | 0x2265
+    )
+}
+
+/// Decide whether `path` should be scanned.
+///
+/// A file is scanned when:
+///
+/// 1. it is not in [`ALLOWED_PATHS`], and
+/// 2. its lowercase extension is in [`SCAN_EXTENSIONS`], or its path
+///    appears verbatim in [`SCAN_EXTRA_PATHS`].
+///
+/// # Arguments
+///
+/// * `path` - Forward-slash relative path as emitted by
+///   `git ls-files`.
+///
+/// # Returns
+///
+/// `true` when the file should be scanned, `false` otherwise.
+pub fn should_scan(path: &str) -> bool {
+    if ALLOWED_PATHS.contains(&path) {
+        return false;
+    }
+    if SCAN_EXTRA_PATHS.contains(&path) {
+        return true;
+    }
+    let Some(dot) = path.rfind('.') else {
+        return false;
+    };
+    let ext = &path[dot + 1..];
+    SCAN_EXTENSIONS
+        .iter()
+        .any(|allowed| allowed.eq_ignore_ascii_case(ext))
+}
+
+/// Scan a single file's contents and return any violations.
+///
+/// Pure function -- no I/O. Files that are pure ASCII return early
+/// before allocating or decoding UTF-8, which keeps the common case
+/// (almost every `.rs` file in this repo) cheap.
+///
+/// Files that are not valid UTF-8 are reported via the returned
+/// `non_utf8` flag and produce no violations; the caller decides
+/// whether to surface that as a warning.
+///
+/// # Arguments
+///
+/// * `path` - Display path used when constructing violations.
+/// * `bytes` - Raw file contents.
+///
+/// # Returns
+///
+/// `(violations, non_utf8)` where `non_utf8` is `true` if the file
+/// could not be decoded as UTF-8.
+pub fn scan_bytes(path: &str, bytes: &[u8]) -> (Vec<Violation>, bool) {
+    // Fast path: pure ASCII -> nothing to flag.
+    if bytes.iter().all(|&b| b < 0x80) {
+        return (Vec::new(), false);
+    }
+
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return (Vec::new(), true);
+    };
+
+    let mut violations = Vec::new();
+    let mut line: u32 = 1;
+    let mut column: u32 = 1;
+    for c in text.chars() {
+        if c == '\n' {
+            line += 1;
+            column = 1;
+            continue;
+        }
+        if c == '\r' {
+            // CRLF: do not advance the column. The following '\n' resets it.
+            continue;
+        }
+        if is_blocklisted(c) {
+            violations.push(Violation {
+                path: path.to_owned(),
+                line,
+                column,
+                character: c,
+            });
+        }
+        column += 1;
+    }
+    (violations, false)
+}
+
+/// Scan every tracked text file and report violations.
+///
+/// Reads the file list via `git ls-files`, filters it through
+/// [`should_scan`], and runs [`scan_bytes`] on each remaining file.
+/// Violations are printed to stderr as
+/// `path:line:col U+XXXX 'glyph'`.
+///
+/// # Arguments
+///
+/// * `system` - Injected I/O provider.
+///
+/// # Returns
+///
+/// `Ok(())` when no violations are found.
+///
+/// # Errors
+///
+/// Returns an error when at least one violation is found, or when an
+/// I/O operation fails. Files that are too large or not valid UTF-8
+/// are skipped with a warning and do not fail the run.
+pub fn check_typography<S: TypographySystem>(system: &S) -> Result<()> {
+    let files = system.list_tracked_files()?;
+    let mut violations: Vec<Violation> = Vec::new();
+    for rel in files {
+        if !should_scan(&rel) {
+            continue;
+        }
+        let path = PathBuf::from(&rel);
+        let size = system.file_size(&path)?;
+        if size > MAX_FILE_BYTES {
+            system.log(&format!(
+                "WARNING - skipping {rel}: {size} bytes exceeds {MAX_FILE_BYTES} byte cap"
+            ));
+            continue;
+        }
+        let bytes = system.read_file(&path)?;
+        let (mut found, non_utf8) = scan_bytes(&rel, &bytes);
+        if non_utf8 {
+            system.log(&format!("WARNING - skipping {rel}: not valid UTF-8"));
+            continue;
+        }
+        violations.append(&mut found);
+    }
+
+    if violations.is_empty() {
+        println!("INFO - check-typography: no forbidden Unicode found.");
+        return Ok(());
+    }
+
+    eprintln!(
+        "ERROR - check-typography: found {} forbidden Unicode character(s).",
+        violations.len()
+    );
+    eprintln!("        Replace them with their ASCII equivalents (em/en-dashes -> '-',");
+    eprintln!("        smart quotes -> ' or \", ellipsis -> ..., arrows -> -> / <-, etc.).");
+    eprintln!();
+    for v in &violations {
+        eprintln!(
+            "{}:{}:{} U+{:04X} {:?}",
+            v.path, v.line, v.column, v.character as u32, v.character
+        );
+    }
+    bail!("found {} forbidden Unicode character(s)", violations.len())
+}
+
+#[cfg(test)]
+#[path = "tests/test_typography.rs"]
+mod tests;

--- a/xtask/src/typography.rs
+++ b/xtask/src/typography.rs
@@ -33,15 +33,24 @@ const SCAN_EXTENSIONS: &[&str] = &[
 /// `git ls-files` output verbatim (forward slashes).
 const SCAN_EXTRA_PATHS: &[&str] = &[".githooks/pre-commit"];
 
-/// Tracked paths that are explicitly excluded from scanning. Used for
-/// generated artefacts such as `Cargo.lock` and for files (such as
-/// the `CHANGELOG.md`) that may legitimately preserve historical
-/// typography from prior releases.
+/// Tracked paths that are explicitly excluded from scanning. Used for:
+///
+/// - generated artefacts such as `Cargo.lock`,
+/// - files (such as the `CHANGELOG.md`) that may legitimately preserve
+///   historical typography from prior releases,
+/// - templates and workflow snippets whose non-ASCII content is
+///   intentional and rendered to users (e.g. social-preview titles,
+///   GitHub Pages footers, PR-comment heredocs).
 ///
 /// Keep this list short -- the goal is to fix offending content, not
 /// to allowlist around it. Compared against the `git ls-files` output
 /// verbatim (forward slashes).
-const ALLOWED_PATHS: &[&str] = &["Cargo.lock"];
+const ALLOWED_PATHS: &[&str] = &[
+    "Cargo.lock",
+    ".github/workflows/news-fragment-check.yml",
+    "templates/github-pages-index.html",
+    "templates/social-preview.html",
+];
 
 /// Hard cap on file size accepted by the scanner. Anything larger is
 /// skipped with a warning -- the repo has nothing close to this size,


### PR DESCRIPTION
Agents have been silently introducing decorative Unicode (em-dashes,
en-dashes, smart quotes, ellipsis, arrows, NBSP, etc.) into comments,
docstrings, and prose. These glyphs look like their ASCII equivalents,
slip past review, and are not what a Windows developer types.

Add a new `cargo xtask check-typography` subcommand that scans every
tracked text file for a curated blocklist of code points and reports
violations as `path:line:col U+XXXX 'glyph'`. The scanner uses a
pure-ASCII fast path so the pre-commit hook stays well under 200 ms
on this repo. Wire it into `.githooks/pre-commit` and a new CI job
modeled on `check-readme-help`.

Add an explicit `## ASCII-Only Punctuation` section to `AGENTS.md`
(placed before Code Standards) so agents see the rule early, and
sweep 17 existing files to replace offending characters with their
ASCII equivalents (em/en-dash -> `-`, smart quotes -> `'`/`"`,
ellipsis -> `...`, arrows -> `->`/`<-`, etc.).

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
