### PR TITLE
docs: track .paseo directory and surface gh-token setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 /res/csshw.ico
 /xtask/social-preview/node_modules/
 
-# Per-contributor paseo-agent fine-grained PAT (never commit)
-/.paseo/gh-token
+# Per-contributor paseo state — track only the explanatory README,
+# never the gh-token or any other ad-hoc contents.
+/.paseo/*
+!/.paseo/README.md
 # Claude Code per-worktree local settings (contains the injected GH_TOKEN)
 /.claude/settings.local.json

--- a/.paseo/README.md
+++ b/.paseo/README.md
@@ -1,0 +1,22 @@
+# `.paseo/` - per-contributor paseo state
+
+This directory holds per-contributor state used by
+[paseo](https://paseo.dev) when it spawns AI coding agents on this
+repository. It is intentionally checked in (with this README only) so
+the directory exists in fresh clones - every other file here is
+gitignored.
+
+## `gh-token`
+
+A fine-grained GitHub Personal Access Token, used to scope the
+`gh` CLI of paseo-spawned AI agents down to least-privilege.
+
+`cargo xtask inject-agent-token` reads this file at worktree
+creation time (wired up via `paseo.json`'s `worktree.setup`) and
+injects the token as `GH_TOKEN` into the agent's environment via
+`.claude/settings.local.json`.
+
+The full setup procedure (how to mint the token, which scopes to
+grant, how to rotate it) lives in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) under
+"AI agent GitHub auth (optional)".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,33 @@ Unsure where to begin contributing to csshW? Here are some suggestions:
    cargo install cargo-make
    ```
 
+### AI agent GitHub auth (optional)
+
+If you use [paseo](https://paseo.dev) to spawn AI coding agents on this
+repository, those agents inherit your full `gh` CLI login by default -
+typically a classic `repo` scope, which can delete the repository or
+force-push to `main`. You can scope an agent down by providing a
+**fine-grained** Personal Access Token:
+
+1. Generate a fine-grained PAT at
+   <https://github.com/settings/personal-access-tokens/new> with
+   `Contents`, `Pull requests`, and `Issues` set to *Read and write*
+   (and only those - leave everything else at *No access*). Restrict it
+   to your fork of `csshw`. Set a short expiration.
+2. Save the full token (including the `github_pat_` prefix) to
+   `.paseo/gh-token` in your source checkout (not in a worktree). The
+   `.paseo/` directory is checked into the repository so the file
+   itself is gitignored.
+
+`cargo xtask inject-agent-token` is wired into `paseo.json`'s
+`worktree.setup` and will write the token into the worktree's
+`.claude/settings.local.json` at creation time, where Claude Code
+injects it as `GH_TOKEN` for the agent process. If the file is absent
+the step is a no-op; classic `ghp_...` or OAuth `gho_...` tokens are
+rejected. To rotate, overwrite `.paseo/gh-token` in the source
+checkout and either re-run `cargo xtask inject-agent-token` from there
+or recreate the worktree.
+
 ### Development Workflow
 
 csshW uses cargo aliases and [cargo make](https://github.com/sagiegurari/cargo-make) for development automation. Key commands:
@@ -79,32 +106,6 @@ csshW uses pre-commit git hooks to enforce code quality. These are automatically
 - Update README help output if needed
 - Run documentation tests
 - Run all tests
-
-### AI agent GitHub auth (optional)
-
-If you use [paseo](https://paseo.dev) to spawn AI coding agents on this
-repository, those agents inherit your full `gh` CLI login by default -
-typically a classic `repo` scope, which can delete the repository or
-force-push to `main`. You can scope an agent down by providing a
-**fine-grained** Personal Access Token:
-
-1. Generate a fine-grained PAT at
-   <https://github.com/settings/personal-access-tokens/new> with
-   `Contents`, `Pull requests`, and `Issues` set to *Read and write*
-   (and only those - leave everything else at *No access*). Restrict it
-   to your fork of `csshw`. Set a short expiration.
-2. Save the full token (including the `github_pat_` prefix) to
-   `.paseo/gh-token` in your source checkout (not in a worktree). The
-   file is gitignored.
-
-`cargo xtask inject-agent-token` is wired into `paseo.json`'s
-`worktree.setup` and will write the token into the worktree's
-`.claude/settings.local.json` at creation time, where Claude Code
-injects it as `GH_TOKEN` for the agent process. If the file is absent
-the step is a no-op; classic `ghp_...` or OAuth `gho_...` tokens are
-rejected. To rotate, overwrite `.paseo/gh-token` in the source
-checkout and either re-run `cargo xtask inject-agent-token` from there
-or recreate the worktree.
 
 ### For Small Changes
 


### PR DESCRIPTION
Previously the .paseo/ directory did not exist on a fresh checkout
because its only intended file (.paseo/gh-token) was gitignored. A
contributor wanting to scope their paseo-spawned AI agent with a
fine-grained PAT had to create the directory by hand, with no
mention of the workflow in the dev environment setup steps.

With this change:

- A new .paseo/README.md documents the directory's purpose, so the
  directory is checked in and present on every clone. The token file
  (and any other ad-hoc contents) stays gitignored via a
  deny-by-default rule (/.paseo/* + !/.paseo/README.md).
- The existing "AI agent GitHub auth (optional)" subsection of
  CONTRIBUTING.md is moved up to sit directly under "Development
  Environment Setup", making it discoverable when contributors first
  configure the project. The note about gitignoring is reworded to
  reflect that the directory itself is now tracked.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
