### PR TITLE
control mode: make [t]oggle enabled a true per-client toggle

### DIFF
--- a/news/184.bugfix.md
+++ b/news/184.bugfix.md
@@ -1,4 +1,0 @@
-The `[t]oggle enabled` control-mode option is now a true toggle: every
-press flips each client's enabled state independently, so disabled
-clients re-enable on the next press instead of staying disabled
-forever. This matches the behavior of csshX's equivalent action.

--- a/news/184.bugfix.md
+++ b/news/184.bugfix.md
@@ -1,0 +1,4 @@
+The `[t]oggle enabled` control-mode option is now a true toggle: every
+press flips each client's enabled state independently, so disabled
+clients re-enable on the next press instead of staying disabled
+forever. This matches the behavior of csshX's equivalent action.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -189,9 +189,8 @@ impl std::ops::Deref for Clients {
 /// Flips each client's [`PipeServerState`] independently, so every
 /// `Enabled` client becomes `Disabled` and vice versa.
 ///
-/// Mirrors the per-window toggle implemented by csshX's master-menu `t`
-/// action. Calling this twice in a row restores the original state of
-/// every client.
+/// Calling this twice in a row restores the original state of every
+/// client.
 ///
 /// # Arguments
 ///

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -186,6 +186,27 @@ impl std::ops::Deref for Clients {
     }
 }
 
+/// Flips each client's [`PipeServerState`] independently, so every
+/// `Enabled` client becomes `Disabled` and vice versa.
+///
+/// Mirrors the per-window toggle implemented by csshX's master-menu `t`
+/// action. Calling this twice in a row restores the original state of
+/// every client.
+///
+/// # Arguments
+///
+/// * `clients` - The collection of clients whose pipe-server states should
+///   be flipped.
+fn toggle_pipe_server_states(clients: &Clients) {
+    for client in clients.iter() {
+        let mut state = client.pipe_server_state.lock().unwrap();
+        *state = match *state {
+            PipeServerState::Enabled => PipeServerState::Disabled,
+            PipeServerState::Disabled => PipeServerState::Enabled,
+        };
+    }
+}
+
 /// Consumes the collection and yields its clients in insertion order.
 ///
 /// Used when merging a freshly launched [`Clients`] batch into an existing
@@ -528,12 +549,7 @@ impl<'a> Daemon<'a> {
                     // TODO: Select windows
                 }
                 (VK_T, 0) => {
-                    for client in clients.lock().unwrap().iter() {
-                        let mut state = client.pipe_server_state.lock().unwrap();
-                        if *state == PipeServerState::Enabled {
-                            *state = PipeServerState::Disabled;
-                        }
-                    }
+                    toggle_pipe_server_states(&clients.lock().unwrap());
                     self.quit_control_mode(windows_api);
                 }
                 (VK_N, 0) => {

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -13,8 +13,8 @@ mod daemon_test {
 
     use crate::{
         daemon::{
-            named_pipe_server_routine, resolve_cluster_tags, Client, Clients, HWNDWrapper,
-            PipeServerState,
+            named_pipe_server_routine, resolve_cluster_tags, toggle_pipe_server_states, Client,
+            Clients, HWNDWrapper, PipeServerState,
         },
         protocol::{
             serialization::serialize_pid, FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH,
@@ -614,5 +614,62 @@ mod daemon_test {
         let hostnames_after_retain: Vec<&str> =
             clients.iter().map(|c| return c.hostname.as_str()).collect();
         assert_eq!(hostnames_after_retain, vec!["host-a", "host-c"]);
+    }
+
+    /// Builds a [`Client`] with the given PID and initial [`PipeServerState`].
+    fn make_client_with_state(pid: u32, state: PipeServerState) -> Client {
+        return Client {
+            hostname: format!("host-{pid}"),
+            window_handle: HWND(std::ptr::null_mut()),
+            process_handle: HANDLE::default(),
+            process_id: pid,
+            pipe_server_state: Arc::new(Mutex::new(state)),
+        };
+    }
+
+    /// Verifies that [`toggle_pipe_server_states`] flips each client's
+    /// [`PipeServerState`] independently and is its own inverse over two
+    /// invocations.
+    #[test]
+    fn test_toggle_pipe_server_states_flips_each_client_independently() {
+        let mut clients = Clients::new();
+        clients.push(make_client_with_state(1, PipeServerState::Enabled));
+        clients.push(make_client_with_state(2, PipeServerState::Disabled));
+        clients.push(make_client_with_state(3, PipeServerState::Enabled));
+        clients.push(make_client_with_state(4, PipeServerState::Disabled));
+
+        let snapshot = |c: &Clients| -> Vec<PipeServerState> {
+            return c
+                .iter()
+                .map(|client| return *client.pipe_server_state.lock().unwrap())
+                .collect();
+        };
+
+        let initial = snapshot(&clients);
+        assert_eq!(
+            initial,
+            vec![
+                PipeServerState::Enabled,
+                PipeServerState::Disabled,
+                PipeServerState::Enabled,
+                PipeServerState::Disabled,
+            ]
+        );
+
+        // First press of `t`: every client flips.
+        toggle_pipe_server_states(&clients);
+        assert_eq!(
+            snapshot(&clients),
+            vec![
+                PipeServerState::Disabled,
+                PipeServerState::Enabled,
+                PipeServerState::Disabled,
+                PipeServerState::Enabled,
+            ]
+        );
+
+        // Second press of `t`: every client flips back to its initial state.
+        toggle_pipe_server_states(&clients);
+        assert_eq!(snapshot(&clients), initial);
     }
 }


### PR DESCRIPTION
Previously the `[t]oggle enabled` action only flipped clients from
`Enabled` to `Disabled` and never the reverse, so the label promised
a toggle but the implementation was one-way disable. This contradicts
csshX, which csshw's master-menu wording is modeled on - csshX flips
each slave's `disabled` flag independently on every press, and
clusterssh's `Toggle Active` host menu does the same per host.

With this change, every press of `t` flips each client's
`PipeServerState` independently: `Enabled` becomes `Disabled` and
`Disabled` becomes `Enabled`. The toggle is its own inverse over two
presses. Extracted the loop body into a free `toggle_pipe_server_states`
helper so the new unit test can drive it directly without spinning up
the full daemon harness.

GitHub: #184
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
