### PR TITLE
daemon: note input/state ordering race in pipe-server gate

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1137,6 +1137,12 @@ async fn named_pipe_server_routine(
         // Copy the state out so the mutex guard does not span the `.await`
         // below - `MutexGuard` is not `Send` and would prevent the routine
         // from being spawned on a multi-threaded runtime.
+        //
+        // Note: state and input travel on independent channels, so this gate
+        // uses state-at-consume-time rather than state-at-emit-time. Very
+        // unlikely to matter in practice - the control-mode chord drains the
+        // in-flight window before the toggle lands. See
+        // https://github.com/whme/csshw/issues/186.
         let state = *pipe_server_state.lock().unwrap();
         match state {
             PipeServerState::Enabled => {}


### PR DESCRIPTION
The per-client pipe-server gate reads `pipe_server_state` after
pulling each input record from the broadcast, so the gate decides
on state-at-consume-time rather than state-at-emit-time. The race
is real at the code level but practically unobservable: control
mode swallows input, and the multi-key chord required to toggle
costs hundreds of milliseconds while in-flight records drain in
microseconds on healthy clients.

Document the race in-source so a future developer touching the
loop is not surprised, and so the bug can be re-evaluated cheaply
if conditions change (e.g. client-side buffering or batching).
This commit only adds a comment - no behavior change.

GitHub: #186
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
