### PR TITLE
client: propagate and visualize disabled state

### DIFF
--- a/news/181.feature.md
+++ b/news/181.feature.md
@@ -1,0 +1,4 @@
+Disabled clients now repaint their console window with a muted dark-grey
+background and revert to their original colors when re-enabled, giving an
+immediate visual confirmation that the daemon's `[t]oggle enabled` and
+`e[n]able all` control-mode bindings landed on the right window.

--- a/news/189.bugfix.md
+++ b/news/189.bugfix.md
@@ -1,0 +1,5 @@
+Fix a Windows 10 visual glitch where re-enabling a client left the bottom
+row and rightmost column displaying the dim "disabled" palette until the
+user clicked the affected cells. The console buffer was already restored
+to the original attributes; only the visible window needed an explicit
+redraw on the legacy conhost.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 
 use crate::utils::config::ClientConfig;
-use crate::utils::windows::{get_console_title, set_console_color, WindowsApi};
+use crate::utils::windows::{get_console_title, try_set_console_color, WindowsApi};
 use ssh2_config::{ParseRule, SshConfig};
 use tokio::net::windows::named_pipe::NamedPipeClient;
 use tokio::process::{Child, Command};
@@ -82,6 +82,11 @@ const DISABLED_CONSOLE_ATTRIBUTES: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARAC
 /// at startup failed, in which case we degrade gracefully and leave the
 /// console untouched.
 ///
+/// Disabled-state visuals are best-effort: a transient console API failure
+/// during the recolor is logged and swallowed rather than panicking the
+/// client, since the visual cue is non-critical and the daemon-driven
+/// state machine remains correct regardless of the repaint outcome.
+///
 /// # Arguments
 ///
 /// * `api`             - The Windows API implementation to use.
@@ -106,7 +111,12 @@ fn apply_state_visuals(
         ClientState::Active => original,
         ClientState::Disabled => DISABLED_CONSOLE_ATTRIBUTES,
     };
-    set_console_color(api, attrs);
+    if let Err(err) = try_set_console_color(api, attrs) {
+        warn!(
+            "Failed to repaint console for state transition {:?} -> {:?}: {}",
+            prev, next, err
+        );
+    }
 }
 
 /// Write the given [INPUT_RECORD_0] to the console input buffer using the provided API.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,20 +12,23 @@ use std::time::Duration;
 use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 
 use crate::utils::config::ClientConfig;
-use crate::utils::windows::{get_console_title, WindowsApi};
+use crate::utils::windows::{get_console_title, set_console_color, WindowsApi};
 use ssh2_config::{ParseRule, SshConfig};
 use tokio::net::windows::named_pipe::NamedPipeClient;
 use tokio::process::{Child, Command};
+use tokio::sync::watch;
 use tokio::{io::Interest, net::windows::named_pipe::ClientOptions};
 use windows::Win32::System::Console::{
-    INPUT_RECORD, INPUT_RECORD_0, KEY_EVENT, KEY_EVENT_RECORD, LEFT_ALT_PRESSED, RIGHT_ALT_PRESSED,
-    SHIFT_PRESSED,
+    BACKGROUND_INTENSITY, CONSOLE_CHARACTER_ATTRIBUTES, FOREGROUND_BLUE, FOREGROUND_GREEN,
+    FOREGROUND_RED, INPUT_RECORD, INPUT_RECORD_0, KEY_EVENT, KEY_EVENT_RECORD, LEFT_ALT_PRESSED,
+    RIGHT_ALT_PRESSED, SHIFT_PRESSED,
 };
 
 use crate::{
     protocol::{
         deserialization::parse_daemon_to_client_messages, serialization::serialize_pid,
-        DaemonToClientMessage, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+        ClientState, DaemonToClientMessage, SERIALIZED_INPUT_RECORD_0_LENGTH,
+        SERIALIZED_PID_LENGTH,
     },
     utils::constants::{PIPE_NAME, PKG_NAME},
 };
@@ -56,6 +59,54 @@ enum ReadWriteResult {
     Err,
     /// The pipe was closed.
     Disconnect,
+}
+
+/// Console attributes applied while the client is in
+/// [`ClientState::Disabled`].
+///
+/// The default-grey foreground (red+green+blue, no intensity) on a
+/// `BACKGROUND_INTENSITY`-only background paints the window as light text on
+/// a muted dark-grey background - a clear "this client is greyed out" cue
+/// that mirrors the daemon's existing reuse of `set_console_color` while
+/// staying visually distinct from the daemon's bright-red palette.
+const DISABLED_CONSOLE_ATTRIBUTES: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARACTER_ATTRIBUTES(
+    FOREGROUND_RED.0 | FOREGROUND_GREEN.0 | FOREGROUND_BLUE.0 | BACKGROUND_INTENSITY.0,
+);
+
+/// Repaint the console to reflect a [`ClientState`] transition.
+///
+/// Called from the visuals task whenever the watch channel observes a new
+/// state. Does nothing when `prev == next` (the watch channel notifies on
+/// every send, including no-op replays) and also does nothing when
+/// `original_attrs` is `None` - that signals the initial buffer-info read
+/// at startup failed, in which case we degrade gracefully and leave the
+/// console untouched.
+///
+/// # Arguments
+///
+/// * `api`             - The Windows API implementation to use.
+/// * `prev`            - State applied on the previous invocation.
+/// * `next`            - State just observed on the watch channel.
+/// * `original_attrs`  - Console attributes captured at startup. Used to
+///                       restore the pristine appearance when transitioning
+///                       back to [`ClientState::Active`].
+fn apply_state_visuals(
+    api: &dyn WindowsApi,
+    prev: ClientState,
+    next: ClientState,
+    original_attrs: Option<CONSOLE_CHARACTER_ATTRIBUTES>,
+) {
+    if prev == next {
+        return;
+    }
+    let Some(original) = original_attrs else {
+        return;
+    };
+    let attrs = match next {
+        ClientState::Active => original,
+        ClientState::Disabled => DISABLED_CONSOLE_ATTRIBUTES,
+    };
+    set_console_color(api, attrs);
 }
 
 /// Write the given [INPUT_RECORD_0] to the console input buffer using the provided API.
@@ -191,9 +242,12 @@ async fn launch_ssh_process(
 ///
 /// Input records are written to the console input buffer using the provided API
 /// and their key-event payloads are returned via `ReadWriteResult::Success` so
-/// the caller can detect the Alt+Shift+C close combination. Keep-alive frames
-/// are ignored. Partial trailing frames are returned as `remainder` for the
-/// next call to prepend.
+/// the caller can detect the Alt+Shift+C close combination. State-change frames
+/// are forwarded via [`watch::Sender::send_replace`] on `state_tx`, making the
+/// authoritative [`ClientState`] visible to every watch subscriber (currently
+/// the visuals task in [`main`]) without coupling this loop to any
+/// state-dependent rendering. Keep-alive frames are ignored. Partial trailing
+/// frames are returned as `remainder` for the next call to prepend.
 ///
 /// # Arguments
 ///
@@ -202,6 +256,9 @@ async fn launch_ssh_process(
 ///                           the named pipe created by the daemon.
 /// * `internal_buffer`     - Vector containing the unconsumed bytes (possibly an
 ///                           incomplete trailing frame) from a previous call.
+/// * `state_tx`            - Watch sender used to broadcast every
+///                           [`DaemonToClientMessage::StateChange`] payload as
+///                           the client's authoritative [`ClientState`].
 /// # Returns
 ///
 /// A `ReadWriteResult` indicating whether we were able to read from the named pipe and write the available INPUT_RECORDs
@@ -212,6 +269,7 @@ async fn read_write_loop(
     api: &dyn WindowsApi,
     named_pipe_client: &NamedPipeClient,
     internal_buffer: &mut Vec<u8>,
+    state_tx: &watch::Sender<ClientState>,
 ) -> ReadWriteResult {
     let mut buf: [u8; SERIALIZED_INPUT_RECORD_0_LENGTH * 10] =
         [0; SERIALIZED_INPUT_RECORD_0_LENGTH * 10];
@@ -231,6 +289,9 @@ async fn read_write_loop(
                     DaemonToClientMessage::InputRecord(input_record) => {
                         write_console_input(api, input_record);
                         key_event_records.push(unsafe { input_record.KeyEvent });
+                    }
+                    DaemonToClientMessage::StateChange(state) => {
+                        state_tx.send_replace(state);
                     }
                     DaemonToClientMessage::KeepAlive => {}
                 }
@@ -336,9 +397,12 @@ async fn send_pid_handshake(named_pipe_client: &NamedPipeClient) {
 ///
 /// # Arguments
 ///
-/// * `api` - The Windows API implementation to use.
-/// * `child` - Handle to the running SSH process.
-async fn run(api: &dyn WindowsApi, child: &mut Child) {
+/// * `api`         - The Windows API implementation to use.
+/// * `child`       - Handle to the running SSH process.
+/// * `state_tx`    - Watch sender used by [`read_write_loop`] to broadcast the
+///                   client's authoritative [`ClientState`] to subscribers
+///                   such as the visuals task in [`main`].
+async fn run(api: &dyn WindowsApi, child: &mut Child, state_tx: &watch::Sender<ClientState>) {
     // Many clients trying to open the pipe at the same time can cause
     // a file not found error, so keep trying until we managed to open it
     let named_pipe_client: NamedPipeClient = loop {
@@ -366,7 +430,7 @@ async fn run(api: &dyn WindowsApi, child: &mut Child) {
                 panic!("Named client pipe is not ready to be read",)
             });
 
-        match read_write_loop(api, &named_pipe_client, &mut internal_buffer).await {
+        match read_write_loop(api, &named_pipe_client, &mut internal_buffer, state_tx).await {
             ReadWriteResult::Success {
                 remainder,
                 key_event_records,
@@ -440,6 +504,27 @@ pub async fn main(
     cli_port: Option<u16>,
     config: &ClientConfig,
 ) {
+    // Capture the console's original attributes before anything (title task,
+    // SSH child) gets a chance to write output. This snapshot is what the
+    // visuals task reverts to on a `Disabled -> Active` transition.
+    let original_attrs: Option<CONSOLE_CHARACTER_ATTRIBUTES> = match api
+        .get_console_screen_buffer_info()
+    {
+        Ok(info) => Some(info.wAttributes),
+        Err(err) => {
+            warn!(
+                "Failed to capture original console attributes; disabled-state visuals will be skipped: {}",
+                err
+            );
+            None
+        }
+    };
+
+    // Watch channel that carries the authoritative `ClientState` from the
+    // pipe-reading loop ([`read_write_loop`]) to the visuals task below.
+    // Mirrors the daemon-side channel pattern introduced in PR #181.
+    let (state_tx, state_rx) = watch::channel(ClientState::Active);
+
     let (host, inline_port) =
         host.rsplit_once(':')
             .map_or((host.as_str(), None), |(host, port)| {
@@ -484,15 +569,39 @@ pub async fn main(
     };
     let child_task = async {
         let mut child = launch_ssh_process(&resolved_username, host, port, config).await;
-        run(api, &mut child).await;
+        run(api, &mut child, &state_tx).await;
         return child;
     };
 
-    // Use tokio::select to run both tasks concurrently
+    // Visuals task: subscribes to the state watch channel and repaints the
+    // console whenever the daemon flips this client between Active and
+    // Disabled. Decoupling the redraw from `read_write_loop` keeps named-pipe
+    // I/O off the critical path of the (potentially slow) per-row
+    // `fill_console_output_attribute` calls inside `set_console_color`.
+    let visuals_task = {
+        let mut state_rx = state_rx;
+        async move {
+            let mut prev = *state_rx.borrow_and_update();
+            while state_rx.changed().await.is_ok() {
+                let next = *state_rx.borrow_and_update();
+                apply_state_visuals(api, prev, next, original_attrs);
+                prev = next;
+            }
+        }
+    };
+
+    // Use tokio::select to run all tasks concurrently. The title and visuals
+    // tasks are infinite by construction: as long as `state_tx` lives in this
+    // scope the watch channel stays open, so `visuals_task` cannot fall out
+    // of its loop. If either ever does complete, that is a logic bug, not a
+    // shutdown path.
     let child = tokio::select! {
         child = child_task => child,
         _ = title_task => {
             panic!("Title task should never complete");
+        }
+        _ = visuals_task => {
+            panic!("Visuals task should never complete");
         }
     };
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 
 use crate::utils::config::ClientConfig;
-use crate::utils::windows::{get_console_title, try_set_console_color, WindowsApi};
+use crate::utils::windows::{get_console_title, set_console_color, WindowsApi};
 use ssh2_config::{ParseRule, SshConfig};
 use tokio::net::windows::named_pipe::NamedPipeClient;
 use tokio::process::{Child, Command};
@@ -82,11 +82,6 @@ const DISABLED_CONSOLE_ATTRIBUTES: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARAC
 /// at startup failed, in which case we degrade gracefully and leave the
 /// console untouched.
 ///
-/// Disabled-state visuals are best-effort: a transient console API failure
-/// during the recolor is logged and swallowed rather than panicking the
-/// client, since the visual cue is non-critical and the daemon-driven
-/// state machine remains correct regardless of the repaint outcome.
-///
 /// # Arguments
 ///
 /// * `api`             - The Windows API implementation to use.
@@ -111,12 +106,7 @@ fn apply_state_visuals(
         ClientState::Active => original,
         ClientState::Disabled => DISABLED_CONSOLE_ATTRIBUTES,
     };
-    if let Err(err) = try_set_console_color(api, attrs) {
-        warn!(
-            "Failed to repaint console for state transition {:?} -> {:?}: {}",
-            prev, next, err
-        );
-    }
+    set_console_color(api, attrs);
 }
 
 /// Write the given [INPUT_RECORD_0] to the console input buffer using the provided API.
@@ -530,9 +520,6 @@ pub async fn main(
         }
     };
 
-    // Watch channel that carries the authoritative `ClientState` from the
-    // pipe-reading loop ([`read_write_loop`]) to the visuals task below.
-    // Mirrors the daemon-side channel pattern introduced in PR #181.
     let (state_tx, state_rx) = watch::channel(ClientState::Active);
 
     let (host, inline_port) =

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1045,51 +1045,26 @@ fn launch_client_console<W: WindowsApi>(
     );
 }
 
-/// Wait for the named pipe server to connect, correlate the client by
-/// its process id, then multiplex broadcast input records, [`ClientState`]
-/// updates, and idle keep-alives onto the named pipe.
+/// Correlate the connecting client by PID, then multiplex input records,
+/// [`ClientState`] updates, and keep-alives onto the named pipe.
 ///
-/// Correlation: after [`NamedPipeServer::connect`] resolves, the client is
-/// expected to write its 4 byte little-endian process id into the pipe. The
-/// routine looks up the [`Client`] with that PID in the daemon's `clients`
-/// collection; if it is not found, the routine logs an error and terminates
-/// the daemon - an unknown PID indicates broken daemon bookkeeping and is
-/// unrecoverable.
+/// The post-subscribe initial-state push is intentional: `state_rx.changed`
+/// only fires on transitions observed *after* `subscribe`, so a state set
+/// in the brief window between [`Client`] construction and `subscribe`
+/// would otherwise leave the client on its default until the next
+/// transition.
 ///
-/// Right after `subscribe`, the routine writes one
-/// [`TAG_STATE_CHANGE`] frame carrying the current authoritative
-/// [`ClientState`] so the client converges immediately even if the
-/// daemon called [`Daemon::set_client_state`] before the client
-/// connected; without this push the freshly-subscribed receiver would
-/// not observe the pre-existing value via `changed`.
+/// The `select!` is biased toward `recv` so the keep-alive tick never
+/// preempts active input traffic; the [`ClientState::Disabled`] arm
+/// therefore probes the pipe itself, otherwise sustained input would
+/// hide a disconnect.
 ///
-/// Multiplexing: a biased [`tokio::select`] polls three branches per
-/// iteration in order - (a) the broadcast `receiver` for input records,
-/// (b) `state_rx.changed` for [`ClientState`] updates pushed by the
-/// daemon, (c) a 5 ms timer that emits a keep-alive frame so dead pipes
-/// are detected even when the daemon has nothing to send. The biased
-/// ordering ensures the keep-alive branch only fires when neither input
-/// nor state-change is ready, so it cannot interrupt active traffic.
-/// Input records are gated on the current [`ClientState`] read via
-/// `*state_rx.borrow()`: [`ClientState::Active`] forwards the record,
-/// [`ClientState::Disabled`] drops it and yields so the daemon does not
-/// tight-loop while the client is suppressed.
+/// # Errors and termination
 ///
-/// If any write to the pipe fails the pipe is considered closed and the
-/// routine ends. If the [`watch::Sender`] is dropped (i.e. the daemon
-/// removed the client from its bookkeeping) the routine likewise ends.
-///
-/// # Arguments
-///
-/// * `server`   - The named pipe server.
-/// * `receiver` - Broadcast receiver of serialized input records.
-/// * `clients`  - Tracked clients, used for PID correlation and to
-///                obtain the [`watch::Sender`] for this server.
-///
-/// # Panics
-///
-/// Panics if the connecting client sends a PID that is not present in
-/// `clients`.
+/// An unknown PID exits the process (production) or panics (tests) -
+/// the daemon's bookkeeping is broken and recovery is not possible.
+/// A failed pipe write or a dropped [`watch::Sender`] ends the routine
+/// cleanly.
 async fn named_pipe_server_routine(
     server: NamedPipeServer,
     receiver: &mut Receiver<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>,
@@ -1119,14 +1094,7 @@ async fn named_pipe_server_routine(
         }
     };
 
-    // Push the current authoritative state immediately so the client
-    // converges right after the PID handshake. `state_rx.changed()`
-    // only fires on transitions observed *after* `subscribe`, so a
-    // state set before this point (e.g. via `Daemon::set_client_state`
-    // during the brief window between `Client` construction and
-    // `subscribe`) would otherwise leave the client stuck on its
-    // default `ClientState::Active` even though the daemon already
-    // gates forwarding on the new value.
+    // Initial state push - see fn docs.
     let initial_state = *state_rx.borrow_and_update();
     let initial_frame: [u8; FRAMED_STATE_CHANGE_LENGTH] =
         [TAG_STATE_CHANGE, serialize_client_state(initial_state)];
@@ -1163,10 +1131,7 @@ async fn named_pipe_server_routine(
                         panic!("Failed to receive data from the Receiver");
                     }
                 };
-                // Gate forwarding on the current state. The match is exhaustive
-                // so the compiler will flag this site when new variants are
-                // added. Copy the value out before any `.await` so the
-                // `watch::Ref` (not `Send`) does not span the await.
+                // Copy out before any `.await` - `watch::Ref` is not `Send`.
                 let current_state = *state_rx.borrow();
                 match current_state {
                     ClientState::Active => {}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -15,9 +15,11 @@ use std::{thread, time};
 
 use crate::get_console_window_handle;
 use crate::protocol::{
-    deserialization::deserialize_pid, serialization::serialize_input_record_0, ClientState,
-    FRAMED_INPUT_RECORD_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
-    TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+    deserialization::deserialize_pid,
+    serialization::{serialize_client_state, serialize_input_record_0},
+    ClientState, FRAMED_INPUT_RECORD_LENGTH, FRAMED_STATE_CHANGE_LENGTH,
+    SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+    TAG_STATE_CHANGE,
 };
 use crate::utils::config::{Cluster, DaemonConfig};
 use crate::utils::debug::StringRepr;
@@ -42,7 +44,6 @@ use tokio::{
         watch,
     },
     task::JoinHandle,
-    time::MissedTickBehavior,
 };
 use windows::Win32::System::Console::{
     CONSOLE_CHARACTER_ATTRIBUTES, INPUT_RECORD_0, LEFT_CTRL_PRESSED, RIGHT_CTRL_PRESSED,
@@ -82,9 +83,11 @@ struct Client {
     process_id: u32,
     /// Authoritative source for this client's [`ClientState`].
     ///
-    /// The daemon writes through this sender; the pipe-server task clones
-    /// it after PID correlation and reads via `borrow()` to gate input
-    /// forwarding.
+    /// The daemon broadcasts new state values through the [`watch::Sender`];
+    /// the assigned pipe-server task subscribes upon successful PID
+    /// correlation and forwards every change to the client over the named
+    /// pipe. [`watch::Sender`] is itself [`Clone`], so cloning a [`Client`]
+    /// produces another sender that drives the same channel.
     state_tx: watch::Sender<ClientState>,
 }
 
@@ -755,18 +758,26 @@ impl<'a> Daemon<'a> {
 
     /// Push a new [`ClientState`] for the client identified by `pid`.
     ///
-    /// No-op if no client matches `pid`.
+    /// Looks the client up by PID and broadcasts the new state through its
+    /// [`watch::Sender`]. The pipe-server task subscribed to that sender
+    /// observes the change and forwards a [`crate::protocol::TAG_STATE_CHANGE`]
+    /// frame to the client over the named pipe. Called from the
+    /// control-mode handlers for `[t]oggle enabled` and `e[n]able all` via
+    /// [`Daemon::update_client_states`].
     ///
     /// # Arguments
     ///
     /// * `clients` - The daemon's tracked clients.
     /// * `pid`     - Process id of the client whose state should change.
-    /// * `state`   - The new state to record.
+    /// * `state`   - The new state to broadcast.
     fn set_client_state(&self, clients: &Clients, pid: u32, state: ClientState) {
         if let Some(client) = clients.get_by_pid(pid) {
-            // `send_replace` keeps the stored value authoritative even
-            // with no subscribers; `send` would `Err` and leave it
-            // untouched. The pipe-server task only reads via `borrow()`.
+            // `send_replace` always updates the stored value (unlike `send`,
+            // which returns `Err` and leaves the value untouched when there
+            // are no active receivers). This matters during the brief window
+            // between [`Client`] construction and the pipe-server task's
+            // `subscribe()`: any state change pushed in that window must
+            // still be visible to the next subscriber via `borrow`.
             client.state_tx.send_replace(state);
         }
     }
@@ -911,8 +922,10 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
                 len_hosts + index_offset,
                 aspect_ratio_adjustment,
             );
-            // Held on the [`Client`] to keep the channel alive; the
-            // pipe-server task clones the sender after PID correlation.
+            // The receiver is dropped immediately; pipe-server tasks acquire
+            // their own receivers via `state_tx.subscribe()` after PID
+            // correlation. Holding the sender on the [`Client`] keeps the
+            // channel alive for the lifetime of the client.
             let (state_tx, _state_rx) = watch::channel(ClientState::Active);
             return (
                 index,
@@ -1032,16 +1045,39 @@ fn launch_client_console<W: WindowsApi>(
     );
 }
 
-/// Connect, correlate the connecting client by PID, then forward
-/// broadcast input records to the named pipe and emit periodic
-/// keep-alives during idle periods.
+/// Wait for the named pipe server to connect, correlate the client by
+/// its process id, then multiplex broadcast input records, [`ClientState`]
+/// updates, and idle keep-alives onto the named pipe.
 ///
-/// A biased [`tokio::select!`] polls the `receiver` first and falls back
-/// to a periodic keep-alive tick when no input is ready. Input records
-/// are gated on the current [`ClientState`]: [`ClientState::Active`]
-/// forwards the record, [`ClientState::Disabled`] drops it - and probes
-/// the pipe so a disabled client cannot hide a disconnect under
-/// sustained input. Any failed write terminates the routine.
+/// Correlation: after [`NamedPipeServer::connect`] resolves, the client is
+/// expected to write its 4 byte little-endian process id into the pipe. The
+/// routine looks up the [`Client`] with that PID in the daemon's `clients`
+/// collection; if it is not found, the routine logs an error and terminates
+/// the daemon - an unknown PID indicates broken daemon bookkeeping and is
+/// unrecoverable.
+///
+/// Right after `subscribe`, the routine writes one
+/// [`TAG_STATE_CHANGE`] frame carrying the current authoritative
+/// [`ClientState`] so the client converges immediately even if the
+/// daemon called [`Daemon::set_client_state`] before the client
+/// connected; without this push the freshly-subscribed receiver would
+/// not observe the pre-existing value via `changed`.
+///
+/// Multiplexing: a biased [`tokio::select`] polls three branches per
+/// iteration in order - (a) the broadcast `receiver` for input records,
+/// (b) `state_rx.changed` for [`ClientState`] updates pushed by the
+/// daemon, (c) a 5 ms timer that emits a keep-alive frame so dead pipes
+/// are detected even when the daemon has nothing to send. The biased
+/// ordering ensures the keep-alive branch only fires when neither input
+/// nor state-change is ready, so it cannot interrupt active traffic.
+/// Input records are gated on the current [`ClientState`] read via
+/// `*state_rx.borrow()`: [`ClientState::Active`] forwards the record,
+/// [`ClientState::Disabled`] drops it and yields so the daemon does not
+/// tight-loop while the client is suppressed.
+///
+/// If any write to the pipe fails the pipe is considered closed and the
+/// routine ends. If the [`watch::Sender`] is dropped (i.e. the daemon
+/// removed the client from its bookkeeping) the routine likewise ends.
 ///
 /// # Arguments
 ///
@@ -1067,8 +1103,8 @@ async fn named_pipe_server_routine(
 
     // Correlate the connecting client by reading its 4 byte PID.
     let pid = read_client_pid(&server).await;
-    let state_tx = match clients.lock().unwrap().get_by_pid(pid) {
-        Some(client) => client.state_tx.clone(),
+    let mut state_rx = match clients.lock().unwrap().get_by_pid(pid) {
+        Some(client) => client.state_tx.subscribe(),
         None => {
             error!(
                 "Named pipe server received unknown PID {} - daemon bookkeeping broken",
@@ -1083,8 +1119,20 @@ async fn named_pipe_server_routine(
         }
     };
 
-    let mut keepalive = tokio::time::interval(Duration::from_millis(5));
-    keepalive.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    // Push the current authoritative state immediately so the client
+    // converges right after the PID handshake. `state_rx.changed()`
+    // only fires on transitions observed *after* `subscribe`, so a
+    // state set before this point (e.g. via `Daemon::set_client_state`
+    // during the brief window between `Client` construction and
+    // `subscribe`) would otherwise leave the client stuck on its
+    // default `ClientState::Active` even though the daemon already
+    // gates forwarding on the new value.
+    let initial_state = *state_rx.borrow_and_update();
+    let initial_frame: [u8; FRAMED_STATE_CHANGE_LENGTH] =
+        [TAG_STATE_CHANGE, serialize_client_state(initial_state)];
+    if !write_framed_message(&server, &initial_frame).await {
+        return;
+    }
 
     loop {
         tokio::select! {
@@ -1115,9 +1163,11 @@ async fn named_pipe_server_routine(
                         panic!("Failed to receive data from the Receiver");
                     }
                 };
-                // Copy the value out before any `.await` so the `watch::Ref`
-                // (which is not `Send`) does not span the await.
-                let current_state = *state_tx.borrow();
+                // Gate forwarding on the current state. The match is exhaustive
+                // so the compiler will flag this site when new variants are
+                // added. Copy the value out before any `.await` so the
+                // `watch::Ref` (not `Send`) does not span the await.
+                let current_state = *state_rx.borrow();
                 match current_state {
                     ClientState::Active => {}
                     ClientState::Disabled => {
@@ -1138,8 +1188,25 @@ async fn named_pipe_server_routine(
                     return;
                 }
             }
-            _ = keepalive.tick() => {
-                if !probe_pipe_alive(&server) {
+            changed_result = state_rx.changed() => {
+                // Sender dropped - the daemon has removed this client from its
+                // bookkeeping, so there is nothing left to forward.
+                if changed_result.is_err() {
+                    debug!(
+                        "Client state sender dropped, stopping named pipe server routine ({:?})",
+                        server
+                    );
+                    return;
+                }
+                let state = *state_rx.borrow_and_update();
+                let frame: [u8; FRAMED_STATE_CHANGE_LENGTH] =
+                    [TAG_STATE_CHANGE, serialize_client_state(state)];
+                if !write_framed_message(&server, &frame).await {
+                    return;
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(5)) => {
+                if !write_framed_message(&server, &[TAG_KEEP_ALIVE]).await {
                     return;
                 }
             }

--- a/src/protocol/deserialization.rs
+++ b/src/protocol/deserialization.rs
@@ -4,8 +4,8 @@ use windows::Win32::{
 };
 
 use crate::protocol::{
-    DaemonToClientMessage, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
-    TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+    ClientState, DaemonToClientMessage, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+    TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
 };
 
 /// Deserialize a [KEY_EVENT_RECORD_0] from a u8 slice using custom binary format.
@@ -61,6 +61,31 @@ pub fn deserialize_pid(bytes: &[u8; SERIALIZED_PID_LENGTH]) -> u32 {
     return u32::from_le_bytes(*bytes);
 }
 
+/// Deserialize a single byte into a [`ClientState`] variant.
+///
+/// # Arguments
+///
+/// * `byte` - The single payload byte of a [`crate::protocol::TAG_STATE_CHANGE`]
+///            frame, equal to a [`ClientState`]'s `#[repr(u8)]` discriminant.
+///
+/// # Returns
+///
+/// The decoded [`ClientState`].
+///
+/// # Panics
+///
+/// Panics if `byte` does not match a known [`ClientState`] discriminant. An
+/// unknown value indicates either a protocol-version mismatch between the
+/// daemon and client or corruption on the pipe - both unrecoverable, matching
+/// the codebase's "broken bookkeeping -> panic" convention.
+pub fn deserialize_client_state(byte: u8) -> ClientState {
+    match byte {
+        x if x == ClientState::Active as u8 => return ClientState::Active,
+        x if x == ClientState::Disabled as u8 => return ClientState::Disabled,
+        other => panic!("Unknown ClientState byte: 0x{other:02X}"),
+    }
+}
+
 /// Parse as many complete [`DaemonToClientMessage`]s as possible from `buffer`.
 ///
 /// The parser walks `buffer` from the start, decoding one tag-prefixed frame
@@ -102,6 +127,16 @@ pub fn parse_daemon_to_client_messages(buffer: &[u8]) -> (Vec<DaemonToClientMess
                 let record = deserialize_input_record_0(&buffer[payload_start..payload_end]);
                 messages.push(DaemonToClientMessage::InputRecord(record));
                 pos = payload_end;
+            }
+            TAG_STATE_CHANGE => {
+                let payload_index = pos + 1;
+                if buffer.len() <= payload_index {
+                    // Trailing partial frame; stop and return it as remainder.
+                    break;
+                }
+                let state = deserialize_client_state(buffer[payload_index]);
+                messages.push(DaemonToClientMessage::StateChange(state));
+                pos = payload_index + 1;
             }
             TAG_KEEP_ALIVE => {
                 messages.push(DaemonToClientMessage::KeepAlive);

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -36,7 +36,11 @@ pub const SERIALIZED_PID_LENGTH: usize = 4;
 /// by [`crate::protocol::serialization::serialize_input_record_0`].
 pub const TAG_INPUT_RECORD: u8 = 0x00;
 
-/// Tag byte reserved for client state-change messages.
+/// Tag byte identifying a client state-change message on the daemon-to-client
+/// pipe.
+///
+/// The tag byte is followed by the single-byte payload produced by
+/// [`crate::protocol::serialization::serialize_client_state`].
 pub const TAG_STATE_CHANGE: u8 = 0x01;
 
 /// Tag byte identifying a zero-payload keep-alive message on the
@@ -53,34 +57,45 @@ pub const FRAMED_INPUT_RECORD_LENGTH: usize = 1 + SERIALIZED_INPUT_RECORD_0_LENG
 /// Length on the wire of a framed keep-alive message: just the tag byte.
 pub const FRAMED_KEEP_ALIVE_LENGTH: usize = 1;
 
+/// Length on the wire of a framed state-change message: the tag byte plus
+/// a single-byte [`ClientState`] payload.
+pub const FRAMED_STATE_CHANGE_LENGTH: usize = 2;
+
 /// Runtime state of a single client.
 ///
-/// Authoritative state value tracked per client by the daemon. The daemon
-/// consults this value to gate input forwarding for each client. Hosted in
-/// the protocol module ahead of the wire-format follow-up that will push
-/// transitions to the client over the named pipe.
+/// Authoritative state value tracked per client by the daemon and pushed to
+/// the corresponding client over the named pipe. Both ends consult this
+/// value: the daemon to gate input forwarding, the client to know its own
+/// state inside its main loop.
 ///
-/// `#[repr(u8)]` so the enum can round-trip through a single byte once the
-/// wire format is added.
+/// `#[repr(u8)]` so the enum round-trips through
+/// [`crate::protocol::serialization::serialize_client_state`] /
+/// [`crate::protocol::deserialization::deserialize_client_state`] using a
+/// single byte.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClientState {
     /// Client receives and replays all input records broadcast by the
     /// daemon.
     Active = 0,
-    /// Daemon suppresses input forwarding for this client.
+    /// Daemon suppresses input forwarding for this client. The client is
+    /// informed via [`TAG_STATE_CHANGE`] so it can render itself
+    /// accordingly.
     Disabled = 1,
 }
 
 /// Daemon-to-client message variants exchanged over the named pipe.
 ///
 /// Each variant maps to a distinct tag byte at the start of the wire
-/// representation; see [`TAG_INPUT_RECORD`] and [`TAG_KEEP_ALIVE`].
+/// representation; see [`TAG_INPUT_RECORD`], [`TAG_STATE_CHANGE`] and
+/// [`TAG_KEEP_ALIVE`].
 #[derive(Clone, Copy)]
 pub enum DaemonToClientMessage {
     /// Carries an [`INPUT_RECORD_0`] (`KeyEvent`) to be replayed to the
     /// client's console input buffer.
     InputRecord(INPUT_RECORD_0),
+    /// Carries the new [`ClientState`] the daemon assigned to this client.
+    StateChange(ClientState),
     /// Empty payload sent on idle by the daemon's pipe server to detect a
     /// closed client pipe.
     KeepAlive,

--- a/src/protocol/serialization.rs
+++ b/src/protocol/serialization.rs
@@ -1,8 +1,9 @@
 use windows::Win32::System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0};
 
 use crate::protocol::{
-    DaemonToClientMessage, FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH,
-    SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+    ClientState, DaemonToClientMessage, FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH,
+    FRAMED_STATE_CHANGE_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
+    TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
 };
 
 /// Serialize a [KEY_EVENT_RECORD_0] into a `Vec<u8>` using custom binary format.
@@ -53,6 +54,20 @@ pub fn serialize_pid(pid: u32) -> [u8; SERIALIZED_PID_LENGTH] {
     return pid.to_le_bytes();
 }
 
+/// Serialize a [`ClientState`] into its single-byte wire representation.
+///
+/// # Arguments
+///
+/// * `state` - The client state to serialize.
+///
+/// # Returns
+///
+/// The state's `#[repr(u8)]` discriminant, used as the payload of a tagged
+/// [`crate::protocol::TAG_STATE_CHANGE`] frame.
+pub fn serialize_client_state(state: ClientState) -> u8 {
+    return state as u8;
+}
+
 /// Serialize a [`DaemonToClientMessage`] into its tagged-envelope wire
 /// representation.
 ///
@@ -73,6 +88,12 @@ pub fn serialize_daemon_to_client_message(msg: &DaemonToClientMessage) -> Vec<u8
             let mut buf = Vec::with_capacity(FRAMED_INPUT_RECORD_LENGTH);
             buf.push(TAG_INPUT_RECORD);
             buf.extend_from_slice(&serialize_input_record_0(record));
+            return buf;
+        }
+        DaemonToClientMessage::StateChange(state) => {
+            let mut buf = Vec::with_capacity(FRAMED_STATE_CHANGE_LENGTH);
+            buf.push(TAG_STATE_CHANGE);
+            buf.push(serialize_client_state(*state));
             return buf;
         }
         DaemonToClientMessage::KeepAlive => {

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -731,6 +731,28 @@ fn test_apply_state_visuals_no_op_when_state_unchanged() {
 }
 
 #[test]
+fn test_apply_state_visuals_swallows_api_error() {
+    // A transient console-API failure during the recolor must not panic the
+    // client - the visual cue is best-effort, and the daemon-driven state
+    // machine remains correct regardless of the repaint outcome.
+    let original = CONSOLE_CHARACTER_ATTRIBUTES(0x07);
+
+    let mut mock_api = MockWindowsApi::new();
+    mock_api
+        .expect_set_console_text_attribute()
+        .with(mockall::predicate::eq(DISABLED_CONSOLE_ATTRIBUTES))
+        .times(1)
+        .returning(|_| return Err(windows::core::Error::from_win32()));
+
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Active,
+        ClientState::Disabled,
+        Some(original),
+    );
+}
+
+#[test]
 fn test_apply_state_visuals_skipped_when_original_attrs_unavailable() {
     // When startup failed to capture the original attributes we degrade
     // gracefully and leave the console untouched even on a real

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -731,28 +731,6 @@ fn test_apply_state_visuals_no_op_when_state_unchanged() {
 }
 
 #[test]
-fn test_apply_state_visuals_swallows_api_error() {
-    // A transient console-API failure during the recolor must not panic the
-    // client - the visual cue is best-effort, and the daemon-driven state
-    // machine remains correct regardless of the repaint outcome.
-    let original = CONSOLE_CHARACTER_ATTRIBUTES(0x07);
-
-    let mut mock_api = MockWindowsApi::new();
-    mock_api
-        .expect_set_console_text_attribute()
-        .with(mockall::predicate::eq(DISABLED_CONSOLE_ATTRIBUTES))
-        .times(1)
-        .returning(|_| return Err(windows::core::Error::from_win32()));
-
-    apply_state_visuals(
-        &mock_api,
-        ClientState::Active,
-        ClientState::Disabled,
-        Some(original),
-    );
-}
-
-#[test]
 fn test_apply_state_visuals_skipped_when_original_attrs_unavailable() {
     // When startup failed to capture the original attributes we degrade
     // gracefully and leave the console untouched even on a real

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -10,11 +10,16 @@ use windows::Win32::System::Console::{
 use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 
 use crate::client::{
-    build_ssh_arguments, is_alt_shift_c_combination, resolve_username, send_pid_handshake,
-    write_console_input,
+    apply_state_visuals, build_ssh_arguments, is_alt_shift_c_combination, read_write_loop,
+    resolve_username, send_pid_handshake, write_console_input, ReadWriteResult,
+    DISABLED_CONSOLE_ATTRIBUTES,
 };
+use crate::protocol::serialization::{serialize_client_state, serialize_input_record_0};
+use crate::protocol::{ClientState, TAG_INPUT_RECORD, TAG_STATE_CHANGE};
 use crate::utils::config::ClientConfig;
 use crate::utils::windows::MockWindowsApi;
+use tokio::sync::watch;
+use windows::Win32::System::Console::{CONSOLE_CHARACTER_ATTRIBUTES, CONSOLE_SCREEN_BUFFER_INFO};
 
 // Test constants - consistent dummy values used throughout tests
 const TEST_USERNAME: &str = "testuser";
@@ -486,6 +491,254 @@ fn test_write_console_input() {
         // Execute the function under test
         write_console_input(&mock_api, test_input_record);
     }
+}
+
+#[tokio::test]
+async fn test_read_write_loop_dispatches_state_change_and_input_record(
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io;
+    use tokio::net::windows::named_pipe::{ClientOptions, PipeMode, ServerOptions};
+    use windows::Win32::System::Console::INPUT_RECORD_0;
+
+    // Use a per-test unique pipe name so parallel test runs don't collide
+    // on the global PIPE_NAME.
+    let pipe_name = format!(
+        r"\\.\pipe\csshw-test-read-write-loop-{}",
+        std::process::id()
+    );
+    let server = ServerOptions::new()
+        .access_inbound(true)
+        .access_outbound(true)
+        .pipe_mode(PipeMode::Message)
+        .create(&pipe_name)?;
+    let client = ClientOptions::new().open(&pipe_name)?;
+    server.connect().await?;
+
+    // Build a StateChange frame followed by an InputRecord frame so the
+    // test exercises both the state-update dispatch and the input-forwarding
+    // regression path in a single call.
+    let input_record = INPUT_RECORD_0 {
+        KeyEvent: KEY_EVENT_RECORD {
+            bKeyDown: true.into(),
+            wRepeatCount: 1,
+            wVirtualKeyCode: VK_C.0,
+            wVirtualScanCode: 0,
+            uChar: KEY_EVENT_RECORD_0 {
+                UnicodeChar: b'c' as u16,
+            },
+            dwControlKeyState: 0,
+        },
+    };
+    let mut payload: Vec<u8> = Vec::new();
+    payload.push(TAG_STATE_CHANGE);
+    payload.push(serialize_client_state(ClientState::Active));
+    payload.push(TAG_INPUT_RECORD);
+    payload.extend_from_slice(&serialize_input_record_0(&input_record));
+
+    // Push the framed bytes onto the pipe so the client side can consume
+    // them via [`read_write_loop`].
+    let mut written = 0usize;
+    while written < payload.len() {
+        server.writable().await?;
+        match server.try_write(&payload[written..]) {
+            Ok(0) => return Err("pipe closed before write completed".into()),
+            Ok(n) => written += n,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    // The mock API must observe exactly one [`write_console_input`] call -
+    // proves the input-forwarding path still runs after the state-change
+    // dispatch.
+    let mut mock_api = MockWindowsApi::new();
+    mock_api
+        .expect_write_console_input()
+        .times(1)
+        .returning(|_, number_written| {
+            *number_written = 1;
+            return Ok(());
+        });
+
+    let mut internal_buffer: Vec<u8> = Vec::new();
+    // Initialize the watch channel with the *opposite* state so that a
+    // successful dispatch is visible as a value change, not a same-value
+    // replay.
+    let (state_tx, state_rx) = watch::channel(ClientState::Disabled);
+    // Wait until the client side has bytes available.
+    client.readable().await?;
+    let result = read_write_loop(&mock_api, &client, &mut internal_buffer, &state_tx).await;
+
+    match result {
+        ReadWriteResult::Success {
+            remainder,
+            key_event_records,
+        } => {
+            assert!(remainder.is_empty());
+            assert_eq!(key_event_records.len(), 1);
+            assert_eq!(key_event_records[0].wVirtualKeyCode, VK_C.0);
+        }
+        _ => panic!("expected ReadWriteResult::Success"),
+    }
+    // The state byte applied through the StateChange frame must be reflected
+    // in the watch channel handed back to the caller.
+    assert_eq!(*state_rx.borrow(), ClientState::Active);
+    return Ok(());
+}
+
+#[tokio::test]
+async fn test_read_write_loop_dispatches_disabled_state_change(
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io;
+    use tokio::net::windows::named_pipe::{ClientOptions, PipeMode, ServerOptions};
+
+    let pipe_name = format!(
+        r"\\.\pipe\csshw-test-read-write-loop-disabled-{}",
+        std::process::id()
+    );
+    let server = ServerOptions::new()
+        .access_inbound(true)
+        .access_outbound(true)
+        .pipe_mode(PipeMode::Message)
+        .create(&pipe_name)?;
+    let client = ClientOptions::new().open(&pipe_name)?;
+    server.connect().await?;
+
+    // A lone StateChange(Disabled) frame - no input records this time, so
+    // the API must not see any `write_console_input` calls.
+    let payload: Vec<u8> = vec![
+        TAG_STATE_CHANGE,
+        serialize_client_state(ClientState::Disabled),
+    ];
+
+    let mut written = 0usize;
+    while written < payload.len() {
+        server.writable().await?;
+        match server.try_write(&payload[written..]) {
+            Ok(0) => return Err("pipe closed before write completed".into()),
+            Ok(n) => written += n,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    let mock_api = MockWindowsApi::new();
+    let mut internal_buffer: Vec<u8> = Vec::new();
+    let (state_tx, state_rx) = watch::channel(ClientState::Active);
+
+    client.readable().await?;
+    let result = read_write_loop(&mock_api, &client, &mut internal_buffer, &state_tx).await;
+
+    match result {
+        ReadWriteResult::Success {
+            remainder,
+            key_event_records,
+        } => {
+            assert!(remainder.is_empty());
+            assert!(key_event_records.is_empty());
+        }
+        _ => panic!("expected ReadWriteResult::Success"),
+    }
+    assert_eq!(*state_rx.borrow(), ClientState::Disabled);
+    return Ok(());
+}
+
+/// Helper: build a `CONSOLE_SCREEN_BUFFER_INFO` with the buffer size used
+/// for the `apply_state_visuals` tests below.
+fn buffer_info(rows: i16) -> CONSOLE_SCREEN_BUFFER_INFO {
+    let mut info = CONSOLE_SCREEN_BUFFER_INFO::default();
+    info.dwSize.X = 80;
+    info.dwSize.Y = rows;
+    return info;
+}
+
+#[test]
+fn test_apply_state_visuals_active_to_disabled_repaints_with_disabled_palette() {
+    let original = CONSOLE_CHARACTER_ATTRIBUTES(0x07);
+    let rows: i16 = 25;
+
+    let mut mock_api = MockWindowsApi::new();
+    mock_api
+        .expect_set_console_text_attribute()
+        .with(mockall::predicate::eq(DISABLED_CONSOLE_ATTRIBUTES))
+        .times(1)
+        .returning(|_| return Ok(()));
+    mock_api
+        .expect_get_console_screen_buffer_info()
+        .times(1)
+        .return_const(Ok(buffer_info(rows)));
+    mock_api
+        .expect_fill_console_output_attribute()
+        .times(rows as usize)
+        .returning(|_, _, _| return Ok(80));
+
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Active,
+        ClientState::Disabled,
+        Some(original),
+    );
+}
+
+#[test]
+fn test_apply_state_visuals_disabled_to_active_restores_original_attrs() {
+    let original = CONSOLE_CHARACTER_ATTRIBUTES(0x5A);
+    let rows: i16 = 30;
+
+    let mut mock_api = MockWindowsApi::new();
+    mock_api
+        .expect_set_console_text_attribute()
+        .with(mockall::predicate::eq(original))
+        .times(1)
+        .returning(|_| return Ok(()));
+    mock_api
+        .expect_get_console_screen_buffer_info()
+        .times(1)
+        .return_const(Ok(buffer_info(rows)));
+    mock_api
+        .expect_fill_console_output_attribute()
+        .times(rows as usize)
+        .returning(|_, _, _| return Ok(80));
+
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Disabled,
+        ClientState::Active,
+        Some(original),
+    );
+}
+
+#[test]
+fn test_apply_state_visuals_no_op_when_state_unchanged() {
+    let original = CONSOLE_CHARACTER_ATTRIBUTES(0x07);
+
+    // No expectations set: any call to the API would cause the mockall
+    // strict-mock to fail, proving the no-transition branch is silent.
+    let mock_api = MockWindowsApi::new();
+
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Active,
+        ClientState::Active,
+        Some(original),
+    );
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Disabled,
+        ClientState::Disabled,
+        Some(original),
+    );
+}
+
+#[test]
+fn test_apply_state_visuals_skipped_when_original_attrs_unavailable() {
+    // When startup failed to capture the original attributes we degrade
+    // gracefully and leave the console untouched even on a real
+    // transition.
+    let mock_api = MockWindowsApi::new();
+
+    apply_state_visuals(&mock_api, ClientState::Active, ClientState::Disabled, None);
+    apply_state_visuals(&mock_api, ClientState::Disabled, ClientState::Active, None);
 }
 
 #[tokio::test]

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -671,6 +671,10 @@ fn test_apply_state_visuals_active_to_disabled_repaints_with_disabled_palette() 
         .expect_fill_console_output_attribute()
         .times(rows as usize)
         .returning(|_, _, _| return Ok(80));
+    // Win11 reports build >= 22000, so the post-fill invalidate is gated off.
+    mock_api
+        .expect_get_os_version()
+        .returning(|| return "10.0.22000".to_string());
 
     apply_state_visuals(
         &mock_api,
@@ -699,6 +703,9 @@ fn test_apply_state_visuals_disabled_to_active_restores_original_attrs() {
         .expect_fill_console_output_attribute()
         .times(rows as usize)
         .returning(|_, _, _| return Ok(80));
+    mock_api
+        .expect_get_os_version()
+        .returning(|| return "10.0.22000".to_string());
 
     apply_state_visuals(
         &mock_api,

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -15,8 +15,8 @@ mod daemon_test {
         daemon::{named_pipe_server_routine, resolve_cluster_tags, Client, Clients, HWNDWrapper},
         protocol::{
             serialization::serialize_pid, ClientState, FRAMED_INPUT_RECORD_LENGTH,
-            FRAMED_KEEP_ALIVE_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH,
-            TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+            FRAMED_KEEP_ALIVE_LENGTH, FRAMED_STATE_CHANGE_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH,
+            SERIALIZED_PID_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
         },
         utils::{config::Cluster, constants::PIPE_NAME},
     };
@@ -169,6 +169,14 @@ mod daemon_test {
                         assert_eq!([2; SERIALIZED_INPUT_RECORD_0_LENGTH], buf[1..]);
                         successful_iterations += 1;
                     }
+                    TAG_STATE_CHANGE => {
+                        // Initial state push emitted right after the routine
+                        // subscribes; the default state is `Active`. Drain it
+                        // and keep reading so the rest of the assertions still
+                        // observe the input-record and keep-alive frames.
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
+                    }
                     other => panic!("Unexpected tag byte 0x{other:02X}"),
                 },
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
@@ -187,6 +195,195 @@ mod daemon_test {
         // Drop the client, closing the pipe.
         drop(named_pipe_client);
         // We expect the routine to exit gracefully.
+        future.await?;
+        return Ok(());
+    }
+
+    #[tokio::test]
+    async fn test_named_pipe_server_routine_forwards_state_change(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_PID: u32 = 66666;
+        // Use a per-test unique pipe name so parallel test runs don't collide
+        // on the global PIPE_NAME.
+        let pipe_name = format!(r"\\.\pipe\csshw-test-state-change-{}", std::process::id());
+        let (_sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
+            SERIALIZED_INPUT_RECORD_0_LENGTH,
+        );
+        let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
+            .access_outbound(true)
+            .pipe_mode(PipeMode::Message)
+            .create(&pipe_name)?;
+        let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
+        let clients = make_clients_with_pid(TEST_PID);
+        // Grab the watch sender so we can later trigger a state change push.
+        let state_tx = clients
+            .lock()
+            .unwrap()
+            .get_by_pid(TEST_PID)
+            .unwrap()
+            .state_tx
+            .clone();
+        send_pid(&named_pipe_client, TEST_PID).await?;
+        let future = tokio::spawn(async move {
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
+        });
+        // The routine emits the current authoritative state right after
+        // subscribing, so the very first frame on the pipe must be the
+        // initial `TAG_STATE_CHANGE(Active)` push. Receiving it also
+        // proves the subscribe has happened and any subsequent
+        // `state_tx.send` will be observed.
+        loop {
+            named_pipe_client.readable().await?;
+            let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+            match named_pipe_client.try_read(&mut buf) {
+                Ok(0) => return Err("pipe closed before initial state push".into()),
+                Ok(n) => match buf[0] {
+                    TAG_STATE_CHANGE => {
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
+                        break;
+                    }
+                    other => {
+                        panic!("Expected initial TAG_STATE_CHANGE, got tag byte 0x{other:02X}")
+                    }
+                },
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        // Push a real state transition through the watch sender; the routine
+        // must write a tagged state-change frame to the pipe.
+        state_tx.send(ClientState::Disabled)?;
+        let mut state_change_seen = false;
+        loop {
+            named_pipe_client.readable().await?;
+            let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+            match named_pipe_client.try_read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => match buf[0] {
+                    TAG_STATE_CHANGE => {
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Disabled as u8);
+                        state_change_seen = true;
+                        break;
+                    }
+                    TAG_KEEP_ALIVE => {
+                        assert_eq!(FRAMED_KEEP_ALIVE_LENGTH, n);
+                        // Keep-alives may interleave with the state change; keep waiting.
+                    }
+                    other => panic!("Unexpected tag byte 0x{other:02X}"),
+                },
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        assert!(state_change_seen);
+        drop(named_pipe_client);
+        future.await?;
+        return Ok(());
+    }
+
+    /// Verifies that the pipe server routine emits a `TAG_STATE_CHANGE`
+    /// frame carrying the current authoritative state immediately after
+    /// the PID handshake, even when no transition fires after subscribe.
+    ///
+    /// `Daemon::set_client_state` may run in the brief window between
+    /// `Client` construction and the routine's `state_tx.subscribe()`
+    /// call. In that case `state_rx.changed()` would never fire for the
+    /// pre-existing value, leaving the client stuck on its default
+    /// `ClientState::Active` even though the daemon already gates
+    /// forwarding on the new value. The fix - and what this test
+    /// asserts - is that the routine pushes the snapshot from
+    /// `state_rx.borrow_and_update()` as its very first frame.
+    #[tokio::test]
+    async fn test_named_pipe_server_routine_sends_initial_state_after_subscribe(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_PID: u32 = 88888;
+        // Use a per-test unique pipe name so parallel test runs don't collide
+        // on the global PIPE_NAME.
+        let pipe_name = format!(r"\\.\pipe\csshw-test-initial-state-{}", std::process::id());
+        let (_sender, mut receiver) = broadcast::channel::<[u8; SERIALIZED_INPUT_RECORD_0_LENGTH]>(
+            SERIALIZED_INPUT_RECORD_0_LENGTH,
+        );
+        let named_pipe_server = ServerOptions::new()
+            .access_inbound(true)
+            .access_outbound(true)
+            .pipe_mode(PipeMode::Message)
+            .create(&pipe_name)?;
+        let named_pipe_client = ClientOptions::new().open(&pipe_name)?;
+        let (clients, state_tx) = make_clients_with_pid_and_state(TEST_PID);
+
+        // Pre-disable BEFORE the routine subscribes. `send_replace`
+        // updates the stored value even when there are no receivers,
+        // which is exactly the production race this test guards against:
+        // `Daemon::set_client_state` mutating the watch before the
+        // pipe-server task has had a chance to call `subscribe`. A
+        // regular `send` would error with no receivers.
+        state_tx.send_replace(ClientState::Disabled);
+
+        send_pid(&named_pipe_client, TEST_PID).await?;
+        let future = tokio::spawn(async move {
+            named_pipe_server_routine(named_pipe_server, &mut receiver, clients).await;
+        });
+
+        // The very first non-keep-alive frame on the pipe must be the
+        // initial `TAG_STATE_CHANGE(Disabled)` push. Keep-alive frames
+        // may legally interleave because the routine spawns its keep-
+        // alive timer through the same select; tolerate them but reject
+        // any other tag.
+        let read_result: Result<Result<(), Box<dyn std::error::Error>>, _> =
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    named_pipe_client.readable().await?;
+                    let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
+                    match named_pipe_client.try_read(&mut buf) {
+                        Ok(0) => {
+                            return Err("pipe closed before initial state frame arrived".into());
+                        }
+                        Ok(n) => match buf[0] {
+                            TAG_STATE_CHANGE => {
+                                assert_eq!(
+                                    FRAMED_STATE_CHANGE_LENGTH, n,
+                                    "State-change frame must be exactly two bytes"
+                                );
+                                assert_eq!(
+                                    buf[1],
+                                    ClientState::Disabled as u8,
+                                    "Initial state push must reflect the value set before subscribe"
+                                );
+                                return Ok(());
+                            }
+                            TAG_KEEP_ALIVE => {
+                                // The initial state push happens before the
+                                // select loop, so a keep-alive arriving first
+                                // would mean the routine skipped the push.
+                                return Err("received keep-alive before initial state frame".into());
+                            }
+                            TAG_INPUT_RECORD => {
+                                return Err(
+                                    "received input record before initial state frame".into()
+                                );
+                            }
+                            other => {
+                                return Err(format!("Unexpected tag byte 0x{other:02X}").into());
+                            }
+                        },
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                        Err(e) => return Err(e.into()),
+                    }
+                }
+            })
+            .await;
+        match read_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                return Err("timed out waiting for initial state frame after subscribe".into());
+            }
+        }
+
+        drop(named_pipe_client);
         future.await?;
         return Ok(());
     }
@@ -235,6 +432,12 @@ mod daemon_test {
                         assert_eq!(FRAMED_INPUT_RECORD_LENGTH, n);
                         assert_eq!([2; SERIALIZED_INPUT_RECORD_0_LENGTH], buf[1..]);
                         break;
+                    }
+                    TAG_STATE_CHANGE => {
+                        // Initial state push emitted right after subscribe.
+                        // Drain it and continue reading.
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
                     }
                     other => panic!("Unexpected tag byte 0x{other:02X}"),
                 },
@@ -313,12 +516,13 @@ mod daemon_test {
     }
 
     /// Construct a [`Clients`] collection holding a single [`Client`] whose
-    /// `process_id` equals `pid`, returning both the collection and a clone
-    /// of the [`watch::Sender<ClientState>`] so the caller can mutate it.
+    /// `process_id` equals `pid`, returning both the collection and the
+    /// shared [`watch::Sender`] handle so the caller can drive [`ClientState`]
+    /// transitions.
     fn make_clients_with_pid_and_state(
         pid: u32,
     ) -> (Arc<Mutex<Clients>>, watch::Sender<ClientState>) {
-        let (state_tx, _state_rx) = watch::channel(ClientState::Active);
+        let state_tx = watch::channel(ClientState::Active).0;
         let mut clients = Clients::new();
         clients.push(Client {
             hostname: format!("test-host-{pid}"),
@@ -333,7 +537,9 @@ mod daemon_test {
     /// Verifies that when a client's [`ClientState`] is set to
     /// [`ClientState::Disabled`], the pipe server routine consumes
     /// broadcast messages but does not forward them through the pipe.
-    /// Only keep-alive packets should arrive on the client side.
+    /// Only keep-alive packets (and the [`TAG_STATE_CHANGE`] frame
+    /// announcing the transition itself) should arrive on the client
+    /// side.
     #[tokio::test]
     async fn test_named_pipe_server_routine_disabled() -> Result<(), Box<dyn std::error::Error>> {
         const TEST_PID: u32 = 66666;
@@ -376,6 +582,14 @@ mod daemon_test {
                         got_data = true;
                         break;
                     }
+                    TAG_STATE_CHANGE => {
+                        // Initial state push emitted right after subscribe.
+                        // The default state is `Active`. Drain it and keep
+                        // reading so the assertion still observes the
+                        // input-record frame.
+                        assert_eq!(FRAMED_STATE_CHANGE_LENGTH, n);
+                        assert_eq!(buf[1], ClientState::Active as u8);
+                    }
                     other => panic!("Unexpected tag byte 0x{other:02X}"),
                 },
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
@@ -384,8 +598,9 @@ mod daemon_test {
         }
         assert!(got_data);
 
-        // Disable the client.
-        state_tx.send_replace(ClientState::Disabled);
+        // Disable the client. The routine emits a `TAG_STATE_CHANGE`
+        // frame as soon as it observes this transition.
+        state_tx.send(ClientState::Disabled).unwrap();
 
         // Send more data - it must NOT arrive at the client.
         const SENDS: usize = 5;
@@ -393,19 +608,21 @@ mod daemon_test {
             sender.send([3; SERIALIZED_INPUT_RECORD_0_LENGTH])?;
         }
 
-        // The disabled branch writes one keep-alive frame per consumed
-        // broadcast record, so we expect at least `SENDS` keep-alive
-        // frames to arrive. Read exactly that many and assert each is
-        // a `TAG_KEEP_ALIVE` byte - any `TAG_INPUT_RECORD` frame would
-        // be a leak of broadcast data and must fail the test.
+        // While disabled, the only frames that may arrive are the
+        // single `TAG_STATE_CHANGE(Disabled)` announcement and any
+        // number of `TAG_KEEP_ALIVE` frames. We require at least
+        // `SENDS` keep-alive frames to confirm the routine keeps
+        // running while suppressed; any `TAG_INPUT_RECORD` would be
+        // a leak of broadcast data and must fail the test.
         //
         // The whole loop is bounded by a `tokio::time::timeout` so a
         // regression that stops keep-alive emission surfaces as a
         // deterministic assertion instead of a hung test.
         let read_result: Result<Result<(), Box<dyn std::error::Error>>, _> =
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
-                let mut received = 0;
-                while received < SENDS {
+                let mut received_keep_alive = 0;
+                let mut saw_state_change = false;
+                while received_keep_alive < SENDS || !saw_state_change {
                     named_pipe_client.readable().await?;
                     let mut buf = [0u8; FRAMED_INPUT_RECORD_LENGTH];
                     match named_pipe_client.try_read(&mut buf) {
@@ -420,7 +637,20 @@ mod daemon_test {
                                     FRAMED_KEEP_ALIVE_LENGTH, n,
                                     "Keep-alive frame must be exactly one byte"
                                 );
-                                received += 1;
+                                received_keep_alive += 1;
+                            }
+                            TAG_STATE_CHANGE => {
+                                assert!(!saw_state_change, "Disabled transition was announced more than once");
+                                assert_eq!(
+                                    FRAMED_STATE_CHANGE_LENGTH, n,
+                                    "State-change frame must be exactly two bytes"
+                                );
+                                assert_eq!(
+                                    buf[1],
+                                    ClientState::Disabled as u8,
+                                    "State-change announcement must carry Disabled"
+                                );
+                                saw_state_change = true;
                             }
                             TAG_INPUT_RECORD => panic!(
                                 "Received input-record frame after disabling - broadcast data leaked through"
@@ -431,6 +661,7 @@ mod daemon_test {
                         Err(e) => return Err(e.into()),
                     }
                 }
+                assert!(saw_state_change, "Disabled transition must be announced");
                 return Ok(());
             })
             .await;
@@ -452,15 +683,15 @@ mod daemon_test {
 
     /// Verifies that when the broadcast receiver falls behind the
     /// channel's bounded buffer, the pipe server routine handles the
-    /// resulting [`tokio::sync::broadcast::error::TryRecvError::Lagged`]
+    /// resulting [`tokio::sync::broadcast::error::RecvError::Lagged`]
     /// without panicking. This is a regression guard for the previous
     /// behaviour where any `Lagged` error propagated to the catch-all
     /// `Err(err)` arm and crashed the routine.
     ///
     /// The test deliberately disables the client so the routine
     /// throttles its consumption rate, then bursts more records than
-    /// the channel capacity through the sender so the first
-    /// `try_recv` is guaranteed to observe `Lagged`.
+    /// the channel capacity through the sender so the next `recv`
+    /// is guaranteed to observe `Lagged`.
     #[tokio::test]
     async fn test_named_pipe_server_routine_lagged() -> Result<(), Box<dyn std::error::Error>> {
         const TEST_PID: u32 = 77777;
@@ -480,7 +711,12 @@ mod daemon_test {
         let (clients, state_tx) = make_clients_with_pid_and_state(TEST_PID);
 
         // Disable up front so the routine throttles consumption and
-        // cannot drain the broadcast buffer before we overflow it.
+        // cannot drain the broadcast buffer before we overflow it. Use
+        // `send_replace` because the routine has not yet subscribed to
+        // the watch channel, so a regular `send` would error with no
+        // receivers; `send_replace` updates the stored value either
+        // way and the routine reads it through `borrow_and_update` on
+        // its first iteration.
         state_tx.send_replace(ClientState::Disabled);
 
         // Overflow the bounded broadcast buffer before the routine
@@ -517,6 +753,16 @@ mod daemon_test {
                                     "Keep-alive frame must be exactly one byte"
                                 );
                                 return Ok(());
+                            }
+                            TAG_STATE_CHANGE => {
+                                // The initial Disabled transition may surface
+                                // here; drain it and continue reading so the
+                                // test still observes a keep-alive frame.
+                                assert_eq!(
+                                    FRAMED_STATE_CHANGE_LENGTH, n,
+                                    "State-change frame must be exactly two bytes"
+                                );
+                                continue;
                             }
                             TAG_INPUT_RECORD => panic!(
                                 "Received input-record frame while disabled - broadcast data leaked through after Lagged"
@@ -621,19 +867,18 @@ mod daemon_test {
 
     /// Builds a [`Client`] with the given PID and initial [`ClientState`].
     fn make_client_with_state(pid: u32, state: ClientState) -> Client {
-        let (state_tx, _state_rx) = watch::channel(state);
         return Client {
             hostname: format!("host-{pid}"),
             window_handle: HWND(std::ptr::null_mut()),
             process_handle: HANDLE::default(),
             process_id: pid,
-            state_tx,
+            state_tx: watch::channel(state).0,
         };
     }
 
-    /// Verifies that the per-client toggle (snapshot then flip via
-    /// `send_replace`) flips each client's [`ClientState`] independently
-    /// and is its own inverse over two invocations.
+    /// Verifies that the `[t]oggle enabled` control-mode handler flips each
+    /// client's [`ClientState`] independently and is its own inverse over
+    /// two invocations.
     ///
     /// Mirrors the snapshot-then-flip logic in
     /// [`crate::daemon::Daemon::handle_control_mode`]'s `VK_T` arm so the
@@ -678,7 +923,7 @@ mod daemon_test {
                 .collect();
             // `send_replace` succeeds even when no task has subscribed;
             // tests don't spin up the pipe-server routine that would
-            // normally observe the value via `borrow()`.
+            // normally hold the receiver.
             for (client, flipped) in c.iter().zip(flips) {
                 client.state_tx.send_replace(flipped);
             }

--- a/src/tests/protocol/test_mod.rs
+++ b/src/tests/protocol/test_mod.rs
@@ -141,13 +141,84 @@ mod deserialization_test {
     }
 }
 
+mod client_state_test {
+    use crate::protocol::deserialization::deserialize_client_state;
+    use crate::protocol::serialization::serialize_client_state;
+    use crate::protocol::ClientState;
+
+    /// Round-trip list of every [`ClientState`] variant through the
+    /// byte-level serializer / deserializer.
+    const ALL_VARIANTS: &[ClientState] = &[ClientState::Active, ClientState::Disabled];
+
+    /// Maps each [`ClientState`] variant to a unique single-bit mask.
+    ///
+    /// The exhaustive `match` (no wildcard) forces an update on any new
+    /// variant, where the developer must allocate a fresh bit. The bit
+    /// allocations are then OR-ed together to form the canonical
+    /// [`EXPECTED_VARIANTS_MASK`].
+    const fn variant_bit(state: ClientState) -> u32 {
+        match state {
+            ClientState::Active => return 1 << 0,
+            ClientState::Disabled => return 1 << 1,
+        }
+    }
+
+    /// Bitmask of every known [`ClientState`] variant. Adding a variant
+    /// requires extending [`variant_bit`] AND OR-ing the new bit in here.
+    const EXPECTED_VARIANTS_MASK: u32 =
+        variant_bit(ClientState::Active) | variant_bit(ClientState::Disabled);
+
+    /// Compile-time guard: [`ALL_VARIANTS`] must list every [`ClientState`]
+    /// variant. Adding a variant fails to compile in [`variant_bit`] until
+    /// a fresh bit is allocated and OR-ed into [`EXPECTED_VARIANTS_MASK`];
+    /// once both are updated, the const evaluation below panics unless
+    /// [`ALL_VARIANTS`] was also extended to include the new variant.
+    const _: () = {
+        let mut seen: u32 = 0;
+        let mut i = 0;
+        while i < ALL_VARIANTS.len() {
+            seen |= variant_bit(ALL_VARIANTS[i]);
+            i += 1;
+        }
+        assert!(
+            seen == EXPECTED_VARIANTS_MASK,
+            "ALL_VARIANTS does not cover every ClientState variant",
+        );
+    };
+
+    #[test]
+    fn test_client_state_round_trip_all_variants() {
+        for &state in ALL_VARIANTS {
+            let byte = serialize_client_state(state);
+            assert_eq!(deserialize_client_state(byte), state);
+        }
+    }
+
+    #[test]
+    fn test_serialize_client_state_active_byte() {
+        assert_eq!(serialize_client_state(ClientState::Active), 0u8);
+    }
+
+    #[test]
+    fn test_serialize_client_state_disabled_byte() {
+        assert_eq!(serialize_client_state(ClientState::Disabled), 1u8);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unknown ClientState byte")]
+    fn test_deserialize_client_state_unknown_panics() {
+        let _ = deserialize_client_state(0xAB);
+    }
+}
+
 mod framed_message_test {
     use super::deserialization_test::Equality;
     use super::*;
     use crate::protocol::{
         deserialization::parse_daemon_to_client_messages,
-        serialization::serialize_daemon_to_client_message, DaemonToClientMessage,
-        FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE,
+        serialization::serialize_daemon_to_client_message, ClientState, DaemonToClientMessage,
+        FRAMED_INPUT_RECORD_LENGTH, FRAMED_KEEP_ALIVE_LENGTH, FRAMED_STATE_CHANGE_LENGTH,
+        TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
     };
 
     fn unwrap_input_record(msg: &DaemonToClientMessage) -> INPUT_RECORD_0 {
@@ -186,6 +257,30 @@ mod framed_message_test {
         assert!(remainder.is_empty());
         assert_eq!(messages.len(), 1);
         assert!(unwrap_input_record(&messages[0]).equals(EXPECTED_INPUT_RECORD_0));
+    }
+
+    #[test]
+    fn test_serialize_state_change_envelope() {
+        let bytes = serialize_daemon_to_client_message(&DaemonToClientMessage::StateChange(
+            ClientState::Active,
+        ));
+        assert_eq!(bytes.len(), FRAMED_STATE_CHANGE_LENGTH);
+        assert_eq!(bytes[0], TAG_STATE_CHANGE);
+        assert_eq!(bytes[1], ClientState::Active as u8);
+    }
+
+    #[test]
+    fn test_parse_state_change_round_trip() {
+        let bytes = serialize_daemon_to_client_message(&DaemonToClientMessage::StateChange(
+            ClientState::Active,
+        ));
+        let (messages, remainder) = parse_daemon_to_client_messages(&bytes);
+        assert!(remainder.is_empty());
+        assert_eq!(messages.len(), 1);
+        match messages[0] {
+            DaemonToClientMessage::StateChange(state) => assert_eq!(state, ClientState::Active),
+            _ => panic!("expected StateChange variant"),
+        }
     }
 
     #[test]

--- a/src/tests/utils/test_windows.rs
+++ b/src/tests/utils/test_windows.rs
@@ -194,6 +194,113 @@ mod console_color_test {
             .times(25)
             .returning(|_, _, _| return Ok(80));
 
+        // Default to Win11 so the post-fill invalidate is gated off; the
+        // dedicated tests below cover both gate branches.
+        mock_api
+            .expect_get_os_version()
+            .returning(|| return "10.0.22000".to_string());
+
+        set_console_color(&mock_api, test_color);
+    }
+
+    /// Tests that on Windows 10 the post-fill console invalidate is
+    /// issued exactly once, working around the legacy conhost leaving
+    /// the trailing row and column stale after a bulk attribute fill.
+    #[test]
+    fn test_set_console_color_invalidates_on_windows_10() {
+        let mut mock_api = MockWindowsApi::new();
+        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
+
+        let mut buffer_info = CONSOLE_SCREEN_BUFFER_INFO::default();
+        buffer_info.dwSize.X = 80;
+        buffer_info.dwSize.Y = 25;
+
+        mock_api
+            .expect_set_console_text_attribute()
+            .times(1)
+            .returning(|_| return Ok(()));
+        mock_api
+            .expect_get_console_screen_buffer_info()
+            .times(1)
+            .return_const(Ok(buffer_info));
+        mock_api
+            .expect_fill_console_output_attribute()
+            .times(25)
+            .returning(|_, _, _| return Ok(80));
+        mock_api
+            .expect_get_os_version()
+            .returning(|| return "10.0.19045".to_string());
+        mock_api
+            .expect_invalidate_console_window()
+            .times(1)
+            .returning(|| return Ok(()));
+
+        set_console_color(&mock_api, test_color);
+    }
+
+    /// Tests that on Windows 11 the post-fill console invalidate is not
+    /// issued - the modern terminal repaints on its own.
+    #[test]
+    fn test_set_console_color_skips_invalidate_on_windows_11() {
+        let mut mock_api = MockWindowsApi::new();
+        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
+
+        let mut buffer_info = CONSOLE_SCREEN_BUFFER_INFO::default();
+        buffer_info.dwSize.X = 80;
+        buffer_info.dwSize.Y = 25;
+
+        mock_api
+            .expect_set_console_text_attribute()
+            .times(1)
+            .returning(|_| return Ok(()));
+        mock_api
+            .expect_get_console_screen_buffer_info()
+            .times(1)
+            .return_const(Ok(buffer_info));
+        mock_api
+            .expect_fill_console_output_attribute()
+            .times(25)
+            .returning(|_, _, _| return Ok(80));
+        mock_api
+            .expect_get_os_version()
+            .returning(|| return "10.0.22631".to_string());
+        mock_api.expect_invalidate_console_window().times(0);
+
+        set_console_color(&mock_api, test_color);
+    }
+
+    /// Tests that a failing invalidate on Windows 10 is logged and does
+    /// not propagate - a stale visual is recoverable; panicking would
+    /// kill the SSH session for a non-critical visual cue.
+    #[test]
+    fn test_set_console_color_swallows_invalidate_error_on_windows_10() {
+        let mut mock_api = MockWindowsApi::new();
+        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
+
+        let mut buffer_info = CONSOLE_SCREEN_BUFFER_INFO::default();
+        buffer_info.dwSize.X = 80;
+        buffer_info.dwSize.Y = 25;
+
+        mock_api
+            .expect_set_console_text_attribute()
+            .times(1)
+            .returning(|_| return Ok(()));
+        mock_api
+            .expect_get_console_screen_buffer_info()
+            .times(1)
+            .return_const(Ok(buffer_info));
+        mock_api
+            .expect_fill_console_output_attribute()
+            .times(25)
+            .returning(|_, _, _| return Ok(80));
+        mock_api
+            .expect_get_os_version()
+            .returning(|| return "10.0.19045".to_string());
+        mock_api
+            .expect_invalidate_console_window()
+            .times(1)
+            .returning(|| return Err(windows::core::Error::from_win32()));
+
         set_console_color(&mock_api, test_color);
     }
 

--- a/src/tests/utils/test_windows.rs
+++ b/src/tests/utils/test_windows.rs
@@ -5,7 +5,7 @@
 
 use crate::utils::windows::{
     clear_screen, is_windows_10, read_console_input, read_keyboard_input, set_console_border_color,
-    set_console_color, utf16_buffer_to_string, MockWindowsApi, KEY_EVENT,
+    set_console_color, try_set_console_color, utf16_buffer_to_string, MockWindowsApi, KEY_EVENT,
 };
 use windows::Win32::Foundation::COLORREF;
 use windows::Win32::System::Console::{
@@ -218,6 +218,51 @@ mod console_color_test {
             result.is_err(),
             "Should panic when set_console_text_attribute fails"
         );
+    }
+
+    /// Tests that the fallible variant returns the underlying API error
+    /// instead of panicking, so best-effort callers can log and continue.
+    #[test]
+    fn test_try_set_console_color_returns_error() {
+        let mut mock_api = MockWindowsApi::new();
+        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
+
+        mock_api
+            .expect_set_console_text_attribute()
+            .with(mockall::predicate::eq(test_color))
+            .times(1)
+            .returning(|_| return Err(windows::core::Error::from_win32()));
+
+        let result = try_set_console_color(&mock_api, test_color);
+        assert!(result.is_err());
+    }
+
+    /// Tests that the fallible variant succeeds and repaints every row when
+    /// all underlying API calls succeed.
+    #[test]
+    fn test_try_set_console_color_success() {
+        let mut mock_api = MockWindowsApi::new();
+        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
+
+        let mut buffer_info = CONSOLE_SCREEN_BUFFER_INFO::default();
+        buffer_info.dwSize.X = 80;
+        buffer_info.dwSize.Y = 25;
+
+        mock_api
+            .expect_set_console_text_attribute()
+            .with(mockall::predicate::eq(test_color))
+            .times(1)
+            .returning(|_| return Ok(()));
+        mock_api
+            .expect_get_console_screen_buffer_info()
+            .times(1)
+            .return_const(Ok(buffer_info));
+        mock_api
+            .expect_fill_console_output_attribute()
+            .times(25)
+            .returning(|_, _, _| return Ok(80));
+
+        assert!(try_set_console_color(&mock_api, test_color).is_ok());
     }
 }
 

--- a/src/tests/utils/test_windows.rs
+++ b/src/tests/utils/test_windows.rs
@@ -5,7 +5,7 @@
 
 use crate::utils::windows::{
     clear_screen, is_windows_10, read_console_input, read_keyboard_input, set_console_border_color,
-    set_console_color, try_set_console_color, utf16_buffer_to_string, MockWindowsApi, KEY_EVENT,
+    set_console_color, utf16_buffer_to_string, MockWindowsApi, KEY_EVENT,
 };
 use windows::Win32::Foundation::COLORREF;
 use windows::Win32::System::Console::{
@@ -218,51 +218,6 @@ mod console_color_test {
             result.is_err(),
             "Should panic when set_console_text_attribute fails"
         );
-    }
-
-    /// Tests that the fallible variant returns the underlying API error
-    /// instead of panicking, so best-effort callers can log and continue.
-    #[test]
-    fn test_try_set_console_color_returns_error() {
-        let mut mock_api = MockWindowsApi::new();
-        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
-
-        mock_api
-            .expect_set_console_text_attribute()
-            .with(mockall::predicate::eq(test_color))
-            .times(1)
-            .returning(|_| return Err(windows::core::Error::from_win32()));
-
-        let result = try_set_console_color(&mock_api, test_color);
-        assert!(result.is_err());
-    }
-
-    /// Tests that the fallible variant succeeds and repaints every row when
-    /// all underlying API calls succeed.
-    #[test]
-    fn test_try_set_console_color_success() {
-        let mut mock_api = MockWindowsApi::new();
-        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
-
-        let mut buffer_info = CONSOLE_SCREEN_BUFFER_INFO::default();
-        buffer_info.dwSize.X = 80;
-        buffer_info.dwSize.Y = 25;
-
-        mock_api
-            .expect_set_console_text_attribute()
-            .with(mockall::predicate::eq(test_color))
-            .times(1)
-            .returning(|_| return Ok(()));
-        mock_api
-            .expect_get_console_screen_buffer_info()
-            .times(1)
-            .return_const(Ok(buffer_info));
-        mock_api
-            .expect_fill_console_output_attribute()
-            .times(25)
-            .returning(|_, _, _| return Ok(80));
-
-        assert!(try_set_console_color(&mock_api, test_color).is_ok());
     }
 }
 

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -10,7 +10,7 @@
     rustdoc::private_intra_doc_links
 )]
 
-use log::error;
+use log::{error, warn};
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStrExt;
 use std::{mem, ptr};
@@ -18,6 +18,7 @@ use std::{mem, ptr};
 use windows::core::{HSTRING, PCWSTR};
 use windows::Win32::Foundation::{BOOL, COLORREF, FALSE, HANDLE, HWND, LPARAM, TRUE};
 use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_BORDER_COLOR};
+use windows::Win32::Graphics::Gdi::InvalidateRect;
 use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
 use windows::Win32::System::Console::{
     FillConsoleOutputAttribute, GetConsoleProcessList, GetConsoleScreenBufferInfo,
@@ -201,6 +202,17 @@ pub trait WindowsApi: Send + Sync {
     ///
     /// Result indicating success or failure of the operation
     fn set_console_border_color(&self, color: &COLORREF) -> windows::core::Result<()>;
+
+    /// Marks the entire console window client area as needing a redraw.
+    ///
+    /// Used to nudge the legacy Win10 conhost into repainting from its
+    /// own buffer state after bulk attribute changes that the renderer
+    /// otherwise leaves stale on the trailing row/column.
+    ///
+    /// # Returns
+    ///
+    /// Result indicating success or failure of the operation
+    fn invalidate_console_window(&self) -> windows::core::Result<()>;
 
     /// Writes input records to the console input buffer.
     ///
@@ -629,6 +641,14 @@ impl WindowsApi for DefaultWindowsApi {
         };
     }
 
+    fn invalidate_console_window(&self) -> windows::core::Result<()> {
+        let succeeded = unsafe { InvalidateRect(Some(GetConsoleWindow()), None, false) };
+        if succeeded.as_bool() {
+            return Ok(());
+        }
+        return Err(windows::core::Error::from_win32());
+    }
+
     fn write_console_input(
         &self,
         buffer: &[INPUT_RECORD],
@@ -910,6 +930,15 @@ pub fn set_console_color(api: &dyn WindowsApi, color: CONSOLE_CHARACTER_ATTRIBUT
             COORD { X: 0, Y: y },
         )
         .unwrap();
+    }
+    // Win10 conhost leaves the bottom row + rightmost column stale after a
+    // bulk attribute fill until something forces a redraw (the user
+    // double-clicking is one such trigger). Win11+ Terminal repaints on
+    // its own.
+    if is_windows_10(api) {
+        if let Err(err) = api.invalidate_console_window() {
+            warn!("Failed to invalidate console window after recolor: {}", err);
+        }
     }
 }
 

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -886,52 +886,6 @@ pub fn build_command_line(application: &str, args: &[String]) -> Vec<u16> {
 
 /// Sets the back- and foreground color of the current console window using the provided API.
 ///
-/// Returns the first error encountered without unwinding, leaving partial
-/// repaints visible to the caller. Use this from best-effort paths (e.g.
-/// transient state-transition recolors) where a Windows API hiccup must
-/// not panic the process; for startup-critical recolors, prefer
-/// [`set_console_color`], which unwraps on failure.
-///
-/// # Arguments
-///
-/// * `api` - The Windows API implementation to use.
-/// * `color` - The color value describing the back- and foreground color.
-///
-/// # Returns
-///
-/// `Ok(())` on success, or the first underlying [`windows::core::Error`]
-/// returned by the console API.
-///
-/// # Examples
-///
-/// ```no_run
-/// use csshw_lib::utils::windows::{try_set_console_color, DefaultWindowsApi};
-/// use windows::Win32::System::Console::CONSOLE_CHARACTER_ATTRIBUTES;
-///
-/// let api = DefaultWindowsApi;
-/// let _ = try_set_console_color(&api, CONSOLE_CHARACTER_ATTRIBUTES(0x0F));
-/// ```
-pub fn try_set_console_color(
-    api: &dyn WindowsApi,
-    color: CONSOLE_CHARACTER_ATTRIBUTES,
-) -> windows::core::Result<()> {
-    api.set_console_text_attribute(color)?;
-    let buffer_info = api.get_console_screen_buffer_info()?;
-    for y in 0..buffer_info.dwSize.Y {
-        api.fill_console_output_attribute(
-            color.0,
-            buffer_info.dwSize.X.try_into().unwrap(),
-            COORD { X: 0, Y: y },
-        )?;
-    }
-    return Ok(());
-}
-
-/// Sets the back- and foreground color of the current console window using the provided API.
-///
-/// Panics on any underlying console API failure. For best-effort recolors
-/// that must not propagate a panic, use [`try_set_console_color`].
-///
 /// # Arguments
 ///
 /// * `api` - The Windows API implementation to use.
@@ -947,7 +901,16 @@ pub fn try_set_console_color(
 /// set_console_color(&api, CONSOLE_CHARACTER_ATTRIBUTES(0x0F));
 /// ```
 pub fn set_console_color(api: &dyn WindowsApi, color: CONSOLE_CHARACTER_ATTRIBUTES) {
-    try_set_console_color(api, color).unwrap();
+    api.set_console_text_attribute(color).unwrap();
+    let buffer_info = api.get_console_screen_buffer_info().unwrap();
+    for y in 0..buffer_info.dwSize.Y {
+        api.fill_console_output_attribute(
+            color.0,
+            buffer_info.dwSize.X.try_into().unwrap(),
+            COORD { X: 0, Y: y },
+        )
+        .unwrap();
+    }
 }
 
 /// Empties the console screen output buffer of the current console window using the provided API.

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -886,6 +886,52 @@ pub fn build_command_line(application: &str, args: &[String]) -> Vec<u16> {
 
 /// Sets the back- and foreground color of the current console window using the provided API.
 ///
+/// Returns the first error encountered without unwinding, leaving partial
+/// repaints visible to the caller. Use this from best-effort paths (e.g.
+/// transient state-transition recolors) where a Windows API hiccup must
+/// not panic the process; for startup-critical recolors, prefer
+/// [`set_console_color`], which unwraps on failure.
+///
+/// # Arguments
+///
+/// * `api` - The Windows API implementation to use.
+/// * `color` - The color value describing the back- and foreground color.
+///
+/// # Returns
+///
+/// `Ok(())` on success, or the first underlying [`windows::core::Error`]
+/// returned by the console API.
+///
+/// # Examples
+///
+/// ```no_run
+/// use csshw_lib::utils::windows::{try_set_console_color, DefaultWindowsApi};
+/// use windows::Win32::System::Console::CONSOLE_CHARACTER_ATTRIBUTES;
+///
+/// let api = DefaultWindowsApi;
+/// let _ = try_set_console_color(&api, CONSOLE_CHARACTER_ATTRIBUTES(0x0F));
+/// ```
+pub fn try_set_console_color(
+    api: &dyn WindowsApi,
+    color: CONSOLE_CHARACTER_ATTRIBUTES,
+) -> windows::core::Result<()> {
+    api.set_console_text_attribute(color)?;
+    let buffer_info = api.get_console_screen_buffer_info()?;
+    for y in 0..buffer_info.dwSize.Y {
+        api.fill_console_output_attribute(
+            color.0,
+            buffer_info.dwSize.X.try_into().unwrap(),
+            COORD { X: 0, Y: y },
+        )?;
+    }
+    return Ok(());
+}
+
+/// Sets the back- and foreground color of the current console window using the provided API.
+///
+/// Panics on any underlying console API failure. For best-effort recolors
+/// that must not propagate a panic, use [`try_set_console_color`].
+///
 /// # Arguments
 ///
 /// * `api` - The Windows API implementation to use.
@@ -901,16 +947,7 @@ pub fn build_command_line(application: &str, args: &[String]) -> Vec<u16> {
 /// set_console_color(&api, CONSOLE_CHARACTER_ATTRIBUTES(0x0F));
 /// ```
 pub fn set_console_color(api: &dyn WindowsApi, color: CONSOLE_CHARACTER_ATTRIBUTES) {
-    api.set_console_text_attribute(color).unwrap();
-    let buffer_info = api.get_console_screen_buffer_info().unwrap();
-    for y in 0..buffer_info.dwSize.Y {
-        api.fill_console_output_attribute(
-            color.0,
-            buffer_info.dwSize.X.try_into().unwrap(),
-            COORD { X: 0, Y: y },
-        )
-        .unwrap();
-    }
+    try_set_console_color(api, color).unwrap();
 }
 
 /// Empties the console screen output buffer of the current console window using the provided API.


### PR DESCRIPTION
## Summary

Builds on top of #188 (the daemon refactor). Adds the wire format for client-state changes, has the daemon push transitions, and teaches the client to dim its console when disabled.

> **Stacked on #188.** This PR's base is `pr-a/daemon-state-refactor`. After #188 merges I'll rebase this onto `main`, which will collapse the diff to just the additive chunks below.

### What changes

- **Protocol.** Add `FRAMED_STATE_CHANGE_LENGTH = 2` and a `DaemonToClientMessage::StateChange(ClientState)` variant. New one-byte `serialize_client_state` / `deserialize_client_state` helpers in the serialization modules.
- **Daemon.** Subscribe to `state_tx` inside `named_pipe_server_routine`, add a third `tokio::select!` branch on `state_rx.changed()`, and push the post-subscribe initial frame so reconnecting clients catch up. State-change writes go through the existing `write_framed_message` helper from PR A.
- **Client.** Capture original console attributes at the top of `client::main`, recognize `TAG_STATE_CHANGE` in `read_write_loop`, forward to a `watch::Sender<ClientState>`, and spawn a `visuals_task` that calls `apply_state_visuals` to paint dim grey on `BACKGROUND_INTENSITY` while `Disabled` and restore captured attributes while `Active`. The initial buffer-info read is best effort; failure logs a warning and the visuals task no-ops.
- **Tests.** `ClientState` round-trip and variant-bitmask const-eval guard; `select!` state branch + initial-frame coverage in the daemon tests; `apply_state_visuals` and `read_write_loop` `Disabled`-payload coverage on the client side.
- **News.** `news/181.feature.md` describes the user-visible change.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo lint`
- [x] `cargo test` (151 lib + 12 doc tests pass)
- [x] `cargo xtask check-typography`
- [ ] Manual: launch a real cluster, focus the daemon, enter control mode. Press `[t]` on a focused client - that window dims to the muted palette while input forwarding is gated. Press `[n]` - all clients return to their original attributes and resume receiving input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)