### PR TITLE
xtask: add record-demo subcommand (v0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1254,35 @@ dependencies = [
  "libredox",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "registry"
@@ -2748,8 +2786,10 @@ dependencies = [
  "anyhow",
  "clap",
  "mockall",
+ "regex",
  "semver",
  "toml_edit 0.21.1",
+ "windows 0.59.0",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,20 @@ anyhow    = "1"
 clap      = { version = "4", features = ["derive"] }
 toml_edit = "0.21"
 semver    = "1.0"
+# Demo subcommand (record-demo): regex-based window matching.
+regex     = "1"
+
+# Demo subcommand: Windows input synthesis (SendInput) and window
+# enumeration. Pinned to the same major version csshw_lib uses
+# (Cargo.toml at the workspace root) so we share a compiled copy.
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.59.0"
+features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
+]
 
 [dev-dependencies]
 mockall = "0.13"

--- a/xtask/src/demo/config_override.rs
+++ b/xtask/src/demo/config_override.rs
@@ -1,0 +1,158 @@
+//! Generate a demo-only `csshw-config.toml` and per-host fake homes.
+//!
+//! csshw rebases its cwd to its own `exe_dir` at startup
+//! (`src/cli.rs:548`), so the demo flow copies `csshw.exe` into
+//! `<demo_root>/csshw.exe` and writes the config alongside it. With
+//! that layout, `[client]` overrides `program = "ssh"` to a local
+//! `cmd.exe` that opens a "fake host" - no real sshd, no mutation of
+//! the developer's real config.
+//!
+//! csshw's `username_host_placeholder` substitutes `<user>@<host>`
+//! into `[client] arguments`. To avoid pinning our directory layout
+//! to that exact format (and to handle the empty-username case
+//! gracefully), every host routes through a single
+//! `<demo_root>/dispatcher.bat` that strips the optional `<user>@`
+//! prefix and dispatches to the per-host `enter.bat`.
+//!
+//! Each host gets a `<demo_root>/fakehosts/<host>/enter.bat` that sets
+//! a readable prompt and `cd`s into a per-host home directory with a
+//! curated set of files. Differences between hosts are what makes the
+//! demo interesting (e.g. `secret.txt` only on `charlie`).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use super::DemoSystem;
+
+/// File contents shared by every fake host, keyed by relative path
+/// within the home directory. v0 is intentionally minimal.
+const SHARED_HOME_FILES: &[(&str, &str)] = &[(
+    "README.txt",
+    "csshw demo - shared file present on every host.\r\n",
+)];
+
+/// Files unique to a specific host, keyed by host name. The inner
+/// tuples are `(relative path, contents)`.
+const HOST_SPECIFIC_FILES: &[(&str, &[(&str, &str)])] =
+    &[("charlie", &[("secret.txt", "charlie-only payload\r\n")])];
+
+/// Result of [`generate`]: paths the caller passes back into the
+/// driver and (for `csshw_cwd`) into [`DemoSystem::spawn_csshw`].
+pub struct OverrideLayout {
+    /// Directory containing `csshw.exe`, `csshw-config.toml`, the
+    /// `dispatcher.bat`, and the `fakehosts/` subtree. csshw is
+    /// launched from here (cwd-rebased to here by csshw itself).
+    pub csshw_cwd: PathBuf,
+}
+
+/// Write the demo's csshw config, dispatcher, and per-host fake
+/// homes.
+///
+/// # Arguments
+///
+/// * `system` - file IO is delegated through [`DemoSystem`] so unit
+///   tests can mock it out.
+/// * `demo_root` - parent directory; the function writes
+///   `demo_root/csshw-config.toml`, `demo_root/dispatcher.bat`, and
+///   `demo_root/fakehosts/<host>/...`.
+/// * `hosts` - list of bare host names (no `user@` prefix).
+///
+/// # Returns
+///
+/// An [`OverrideLayout`] whose `csshw_cwd` is `demo_root`.
+pub fn generate<S: DemoSystem>(
+    system: &S,
+    demo_root: &Path,
+    hosts: &[&str],
+) -> Result<OverrideLayout> {
+    system.ensure_dir(demo_root)?;
+    let fakehosts = demo_root.join("fakehosts");
+    for host in hosts {
+        let home = fakehosts.join(host);
+        system.ensure_dir(&home)?;
+        for (rel, content) in SHARED_HOME_FILES {
+            system.write_file(&home.join(rel), content)?;
+        }
+        for (h, files) in HOST_SPECIFIC_FILES {
+            if h == host {
+                for (rel, content) in *files {
+                    system.write_file(&home.join(rel), content)?;
+                }
+            }
+        }
+        let bat = home.join("enter.bat");
+        system.write_file(&bat, &enter_bat(host, &home))?;
+    }
+    let dispatcher = demo_root.join("dispatcher.bat");
+    system.write_file(&dispatcher, dispatcher_bat())?;
+    let toml = render_toml(&dispatcher);
+    system.write_file(&demo_root.join("csshw-config.toml"), &toml)?;
+    Ok(OverrideLayout {
+        csshw_cwd: demo_root.to_path_buf(),
+    })
+}
+
+/// Build the per-host `enter.bat` that the dispatcher invokes.
+///
+/// `@echo off` keeps the output free of cmd-echo lines, then we set a
+/// readable prompt (`<host>-fake $$`) and `cd` into the host's home
+/// directory. The trailing `cls` clears the cmd-launch banner so the
+/// recording starts on a clean console.
+fn enter_bat(host: &str, home: &Path) -> String {
+    format!(
+        "@echo off\r\nset PROMPT=$_{host}@{host}-fake $$ \r\ncd /d \"{home}\"\r\ncls\r\n",
+        host = host,
+        home = home.display(),
+    )
+}
+
+/// Returns the static `dispatcher.bat` body.
+///
+/// The dispatcher is invoked by csshw with one argument: the
+/// substituted `{{USERNAME_AT_HOST}}`, which is either `user@host`
+/// (when csshw's username is set) or just `@host` (when it is not),
+/// or just `host` (when the host arg already includes the user
+/// prefix or no user is involved). The dispatcher normalises all
+/// three to the bare host so we can keep fakehost directories
+/// simply named (`alpha`, not `@alpha`).
+///
+/// Implementation note: we use cmd's `:*@=` substring substitution,
+/// not `for /f tokens=2 delims=@`. The `for /f` form skips leading
+/// delimiters - it parses `@alpha` as a single token (`alpha`), so
+/// `tokens=2` matches nothing and `HOST` keeps its initial
+/// `@alpha` value, leading to "the system cannot find the path
+/// specified" when `call` falls through to a non-existent
+/// `fakehosts\@alpha\enter.bat`. The substring form has no such
+/// quirk: it strips through the first `@` if present, otherwise
+/// leaves the value unchanged.
+fn dispatcher_bat() -> &'static str {
+    "@echo off\r\n\
+     setlocal enabledelayedexpansion\r\n\
+     set ARG=%~1\r\n\
+     set HOST=!ARG!\r\n\
+     if not \"!HOST:@=!\"==\"!HOST!\" set HOST=!HOST:*@=!\r\n\
+     call \"%~dp0fakehosts\\!HOST!\\enter.bat\"\r\n"
+}
+
+/// Build the TOML body that overrides `[client]` to spawn cmd.exe via
+/// the dispatcher. We leave `[daemon]` and `[clusters]` to csshw's
+/// own defaults (the demo passes hosts on the command line).
+fn render_toml(dispatcher: &Path) -> String {
+    // Backslashes are doubled because TOML basic strings interpret
+    // them as escapes. The dispatcher is the single entry point;
+    // csshw substitutes `{{USERNAME_AT_HOST}}` as its argument.
+    let dispatcher_str = dispatcher.display().to_string().replace('\\', "\\\\");
+    format!(
+        "# Auto-generated by `cargo xtask record-demo`. Do not commit.\n\
+         [client]\n\
+         ssh_config_path = \"\"\n\
+         program = \"cmd.exe\"\n\
+         arguments = [\"/k\", \"{dispatcher_str}\", \"{{{{USERNAME_AT_HOST}}}}\"]\n\
+         username_host_placeholder = \"{{{{USERNAME_AT_HOST}}}}\"\n",
+    )
+}
+
+#[cfg(test)]
+#[path = "../tests/test_demo_config_override.rs"]
+mod tests;

--- a/xtask/src/demo/driver.rs
+++ b/xtask/src/demo/driver.rs
@@ -50,17 +50,21 @@ pub fn run<S: DemoSystem>(
     let mut state = DriverState::new(raw_path, no_record);
     let mut deferred: Option<anyhow::Error> = None;
     for (i, step) in steps.iter().enumerate() {
-        if let Err(e) = run_step(system, &mut state, i, step) {
+        if let Err(e) = run_step(system, &mut state, i, step, out_gif) {
             deferred = Some(e);
             break;
         }
     }
-    // Best-effort cleanup if a capture was left running.
+    // Best-effort cleanup if a capture was left running. Mark
+    // `capturing` false up front so a failing `stop_recording` here
+    // can't be re-entered (e.g. by a future caller looping over
+    // `run`); the production `RealSystem::stop_recording` consumes
+    // the in-flight ffmpeg child handle, so a second call would error
+    // with "no active capture".
     if state.capturing {
+        state.capturing = false;
         if let Err(e) = system.stop_recording(&state.raw_path, out_gif) {
             system.print_debug(&format!("cleanup stop_recording failed: {e}"));
-        } else {
-            state.capturing = false;
         }
     }
     if let Some(e) = deferred {
@@ -100,6 +104,7 @@ fn run_step<S: DemoSystem>(
     state: &mut DriverState,
     index: usize,
     step: &Step,
+    out_gif: &Path,
 ) -> Result<()> {
     system.print_debug(&format!("step {index}: {step:?}"));
     match step {
@@ -135,10 +140,12 @@ fn run_step<S: DemoSystem>(
                 system.print_info(&format!("step {index}: StopCapture skipped (--no-record)"));
                 return Ok(());
             }
-            // The final GIF path is `raw_path` with `.gif` extension.
-            let gif_path = state.raw_path.with_extension("gif");
-            system.stop_recording(&state.raw_path, &gif_path)?;
+            // Mark the capture as stopped up front so a failing
+            // `stop_recording` cannot be retried by the cleanup path
+            // in `run` (which would double-consume the ffmpeg child
+            // and report "no active capture").
             state.capturing = false;
+            system.stop_recording(&state.raw_path, out_gif)?;
             Ok(())
         }
         Step::Marker(m) => {

--- a/xtask/src/demo/driver.rs
+++ b/xtask/src/demo/driver.rs
@@ -1,0 +1,220 @@
+//! Step-by-step interpreter for a built demo script.
+//!
+//! Takes a `&[Step]` plus a [`DemoSystem`] and walks the steps in order,
+//! delegating every side effect to the system trait. The driver has a
+//! tiny amount of internal state (where to write the raw capture file,
+//! how many `StartCapture` we've seen) so unit tests can assert
+//! capture pairing.
+//!
+//! # Errors
+//!
+//! Returns the first error encountered. Capture is best-effort cleaned
+//! up: if a [`Step::StartCapture`] succeeded and a later step fails,
+//! the driver still attempts [`DemoSystem::stop_recording`] before
+//! returning to avoid leaving an ffmpeg child orphaned. The cleanup
+//! error, if any, is logged via [`DemoSystem::print_debug`] and the
+//! original error is propagated.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use regex::Regex;
+
+use super::{dsl::Step, DemoSystem};
+
+/// Polling interval used by [`Step::WaitForWindow`] between
+/// `enum_windows` calls. Short enough to be responsive, long enough not
+/// to spin the CPU.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Run `steps` against `system`.
+///
+/// # Arguments
+///
+/// * `system` - implementation of [`DemoSystem`].
+/// * `steps` - the script's pre-validated steps.
+/// * `out_gif` - final GIF path; the raw `.mkv` is derived by replacing
+///   the extension with `.mkv` (so both files live alongside each
+///   other under `target/demo/`).
+/// * `no_record` - when true, [`Step::StartCapture`] /
+///   [`Step::StopCapture`] are logged and skipped. Useful for
+///   iterating on the script without spawning ffmpeg.
+pub fn run<S: DemoSystem>(
+    system: &S,
+    steps: &[Step],
+    out_gif: &Path,
+    no_record: bool,
+) -> Result<()> {
+    let raw_path = derive_raw_path(out_gif);
+    let mut state = DriverState::new(raw_path, no_record);
+    let mut deferred: Option<anyhow::Error> = None;
+    for (i, step) in steps.iter().enumerate() {
+        if let Err(e) = run_step(system, &mut state, i, step) {
+            deferred = Some(e);
+            break;
+        }
+    }
+    // Best-effort cleanup if a capture was left running.
+    if state.capturing {
+        if let Err(e) = system.stop_recording(&state.raw_path, out_gif) {
+            system.print_debug(&format!("cleanup stop_recording failed: {e}"));
+        } else {
+            state.capturing = false;
+        }
+    }
+    if let Some(e) = deferred {
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Driver-internal state.
+struct DriverState {
+    raw_path: PathBuf,
+    no_record: bool,
+    capturing: bool,
+}
+
+impl DriverState {
+    fn new(raw_path: PathBuf, no_record: bool) -> Self {
+        Self {
+            raw_path,
+            no_record,
+            capturing: false,
+        }
+    }
+}
+
+/// Replace the extension of `gif_path` with `.mkv` to get the raw
+/// capture path. If `gif_path` has no extension, append `.mkv`.
+fn derive_raw_path(gif_path: &Path) -> PathBuf {
+    let mut p = gif_path.to_path_buf();
+    p.set_extension("mkv");
+    p
+}
+
+/// Dispatch a single step.
+fn run_step<S: DemoSystem>(
+    system: &S,
+    state: &mut DriverState,
+    index: usize,
+    step: &Step,
+) -> Result<()> {
+    system.print_debug(&format!("step {index}: {step:?}"));
+    match step {
+        Step::WaitForWindow {
+            title_regex,
+            timeout,
+            stable_for,
+        } => wait_for_window(system, title_regex, *timeout, *stable_for)
+            .with_context(|| format!("step {index}: WaitForWindow {title_regex:?}")),
+        Step::Focus { title_regex } => focus(system, title_regex)
+            .with_context(|| format!("step {index}: Focus {title_regex:?}")),
+        Step::Type {
+            text,
+            per_char_delay,
+        } => {
+            type_text(system, text, *per_char_delay).with_context(|| format!("step {index}: Type"))
+        }
+        Step::Sleep(d) => {
+            system.sleep(*d);
+            Ok(())
+        }
+        Step::StartCapture => {
+            if state.no_record {
+                system.print_info(&format!("step {index}: StartCapture skipped (--no-record)"));
+                return Ok(());
+            }
+            system.start_recording(&state.raw_path)?;
+            state.capturing = true;
+            Ok(())
+        }
+        Step::StopCapture => {
+            if state.no_record {
+                system.print_info(&format!("step {index}: StopCapture skipped (--no-record)"));
+                return Ok(());
+            }
+            // The final GIF path is `raw_path` with `.gif` extension.
+            let gif_path = state.raw_path.with_extension("gif");
+            system.stop_recording(&state.raw_path, &gif_path)?;
+            state.capturing = false;
+            Ok(())
+        }
+        Step::Marker(m) => {
+            system.print_info(&format!("marker: {m}"));
+            Ok(())
+        }
+    }
+}
+
+/// Block until a window matching `title_regex` has been visible with
+/// the same rect for at least `stable_for`. Polls every
+/// [`POLL_INTERVAL`].
+fn wait_for_window<S: DemoSystem>(
+    system: &S,
+    title_regex: &str,
+    timeout: Duration,
+    stable_for: Duration,
+) -> Result<()> {
+    let re =
+        Regex::new(title_regex).with_context(|| format!("invalid title_regex {title_regex:?}"))?;
+    let deadline = Instant::now() + timeout;
+    let mut stable_since: Option<(u64, super::WindowRect, Instant)> = None;
+    loop {
+        let windows = system.enum_windows()?;
+        if let Some(w) = windows.into_iter().find(|w| re.is_match(&w.title)) {
+            match stable_since {
+                Some((hwnd, rect, since))
+                    if hwnd == w.hwnd && rect == w.rect && since.elapsed() >= stable_for =>
+                {
+                    return Ok(());
+                }
+                Some((hwnd, rect, _)) if hwnd == w.hwnd && rect == w.rect => {
+                    // Still stabilising; fall through to sleep.
+                }
+                _ => {
+                    stable_since = Some((w.hwnd, w.rect, Instant::now()));
+                }
+            }
+        } else {
+            stable_since = None;
+        }
+        if Instant::now() >= deadline {
+            bail!("no window matching {title_regex:?} stabilised within {timeout:?}");
+        }
+        system.sleep(POLL_INTERVAL);
+    }
+}
+
+/// Bring the first window matching `title_regex` to the foreground.
+fn focus<S: DemoSystem>(system: &S, title_regex: &str) -> Result<()> {
+    let re =
+        Regex::new(title_regex).with_context(|| format!("invalid title_regex {title_regex:?}"))?;
+    let windows = system.enum_windows()?;
+    let target = windows
+        .into_iter()
+        .find(|w| re.is_match(&w.title))
+        .ok_or_else(|| anyhow::anyhow!("no window matching {title_regex:?}"))?;
+    system.set_foreground(target.hwnd)
+}
+
+/// Type `text` one character at a time. Newlines (`\n`, `\r`) are sent
+/// as VK_RETURN so they actually submit a command in cmd.exe instead
+/// of inserting a literal control character.
+fn type_text<S: DemoSystem>(system: &S, text: &str, per_char_delay: Duration) -> Result<()> {
+    /// Windows `VK_RETURN` virtual-key code.
+    const VK_RETURN: u16 = 0x0D;
+    for c in text.chars() {
+        match c {
+            '\n' | '\r' => system.send_vk(VK_RETURN)?,
+            other => system.send_unicode_char(other)?,
+        }
+        system.sleep(per_char_delay);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "../tests/test_demo_driver.rs"]
+mod tests;

--- a/xtask/src/demo/dsl.rs
+++ b/xtask/src/demo/dsl.rs
@@ -1,0 +1,227 @@
+//! Typed "demo as code" DSL.
+//!
+//! A demo is a `Vec<Step>` produced by the [`Script`] builder. Each
+//! variant of [`Step`] is interpreted by [`crate::demo::driver`] in
+//! declaration order. The DSL is intentionally a closed enum so a typo
+//! in a script (an unknown step name, an invalid regex, an unbalanced
+//! `start_capture` / `stop_capture` pair) fails to compile or fails the
+//! `build` validation pass - never at recording time, after the
+//! developer has already burned a 30-second capture.
+//!
+//! See [`crate::demo::script::build_canonical_v0`] for the demo we ship.
+
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use regex::Regex;
+
+/// Default per-character delay for [`Step::Type`] when a script does not
+/// specify one. Slow enough that the recording is legible, fast enough
+/// that a multi-line `Type` step does not pad the GIF.
+pub const DEFAULT_PER_CHAR_DELAY: Duration = Duration::from_millis(50);
+
+/// Default timeout for [`Step::WaitForWindow`] when a script does not
+/// specify one. Generous: window creation includes csshw spawning a
+/// fresh `cmd.exe` per host plus its own daemon initialisation.
+pub const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default "stable for" window for [`Step::WaitForWindow`]. A window
+/// counts as ready only when its rect has been unchanged for this long;
+/// guards against typing into a freshly-spawned console that is still
+/// being repositioned by csshw's daemon-side layout.
+pub const DEFAULT_WAIT_STABLE_FOR: Duration = Duration::from_millis(500);
+
+/// A single deterministic action in the demo timeline.
+///
+/// Steps are interpreted top-down. None of them carry implicit side
+/// effects across step boundaries; the driver state machine does.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Step {
+    /// Block until a top-level window whose title matches `title_regex`
+    /// has been visible with a stable rect for `stable_for`. Fails if
+    /// no such window appears within `timeout`.
+    WaitForWindow {
+        /// Regex applied to each top-level window's title.
+        title_regex: String,
+        /// Hard deadline for the whole wait.
+        timeout: Duration,
+        /// How long the window's rect must be unchanged before the
+        /// step counts as satisfied. Guards against typing into a
+        /// console that csshw is still repositioning.
+        stable_for: Duration,
+    },
+    /// Bring the matching window to the foreground. The driver applies
+    /// the standard `AttachThreadInput + SetForegroundWindow` workaround
+    /// because Windows blocks `SetForegroundWindow` from background
+    /// processes.
+    Focus {
+        /// Regex applied to each top-level window's title.
+        title_regex: String,
+    },
+    /// Type `text` into the foreground window, one character at a time
+    /// via `SendInput(KEYEVENTF_UNICODE)`. Newlines are translated to
+    /// VK_RETURN so they actually submit a command in cmd.exe.
+    Type {
+        /// The literal text to type.
+        text: String,
+        /// Delay between successive characters.
+        per_char_delay: Duration,
+    },
+    /// Static pause. Use sparingly; prefer [`Step::WaitForWindow`].
+    Sleep(Duration),
+    /// Start ffmpeg's gdigrab capture. Must appear exactly once and
+    /// before [`Step::StopCapture`].
+    StartCapture,
+    /// Stop ffmpeg's gdigrab capture and run the post-encode pipeline
+    /// (frame extraction + gifski). Must appear exactly once and after
+    /// [`Step::StartCapture`].
+    StopCapture,
+    /// Free-form annotation emitted to the run trace. No side effects.
+    Marker(String),
+}
+
+/// Validation error returned by [`Script::build`].
+///
+/// The error carries a human-readable message describing the problem.
+/// We rely on `anyhow::Error` to bubble these up to `main.rs`.
+pub type ValidationError = anyhow::Error;
+
+/// Builder for a [`Vec<Step>`].
+///
+/// Methods take `&mut self` and return `&mut Self` so script files read
+/// top-to-bottom. Defaults for delays come from the `DEFAULT_*`
+/// constants in this module; the `*_with` variants accept an explicit
+/// override.
+pub struct Script {
+    name: String,
+    steps: Vec<Step>,
+}
+
+impl Script {
+    /// Start a new script with the given human-readable name.
+    ///
+    /// The name is included in the validation error messages so a
+    /// failing build pinpoints which script is broken.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            steps: Vec::new(),
+        }
+    }
+
+    /// Append a [`Step::WaitForWindow`] using the default timeout and
+    /// stability window.
+    pub fn wait_for(&mut self, title_regex: &str) -> &mut Self {
+        self.wait_for_with(title_regex, DEFAULT_WAIT_TIMEOUT, DEFAULT_WAIT_STABLE_FOR)
+    }
+
+    /// Append a [`Step::WaitForWindow`] with explicit timeouts.
+    pub fn wait_for_with(
+        &mut self,
+        title_regex: &str,
+        timeout: Duration,
+        stable_for: Duration,
+    ) -> &mut Self {
+        self.steps.push(Step::WaitForWindow {
+            title_regex: title_regex.to_string(),
+            timeout,
+            stable_for,
+        });
+        self
+    }
+
+    /// Append a [`Step::Focus`].
+    pub fn focus(&mut self, title_regex: &str) -> &mut Self {
+        self.steps.push(Step::Focus {
+            title_regex: title_regex.to_string(),
+        });
+        self
+    }
+
+    /// Append a [`Step::Type`] using the default per-character delay.
+    pub fn type_text(&mut self, text: &str) -> &mut Self {
+        self.type_text_with(text, DEFAULT_PER_CHAR_DELAY)
+    }
+
+    /// Append a [`Step::Type`] with an explicit per-character delay.
+    pub fn type_text_with(&mut self, text: &str, per_char_delay: Duration) -> &mut Self {
+        self.steps.push(Step::Type {
+            text: text.to_string(),
+            per_char_delay,
+        });
+        self
+    }
+
+    /// Append a [`Step::Sleep`] expressed in milliseconds.
+    pub fn sleep_ms(&mut self, ms: u64) -> &mut Self {
+        self.steps.push(Step::Sleep(Duration::from_millis(ms)));
+        self
+    }
+
+    /// Append [`Step::StartCapture`].
+    pub fn start_capture(&mut self) -> &mut Self {
+        self.steps.push(Step::StartCapture);
+        self
+    }
+
+    /// Append [`Step::StopCapture`].
+    pub fn stop_capture(&mut self) -> &mut Self {
+        self.steps.push(Step::StopCapture);
+        self
+    }
+
+    /// Append a [`Step::Marker`].
+    pub fn marker(&mut self, m: impl Into<String>) -> &mut Self {
+        self.steps.push(Step::Marker(m.into()));
+        self
+    }
+
+    /// Validate and finalise the script.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when:
+    /// - any `title_regex` is not a valid regex,
+    /// - `StartCapture` and `StopCapture` are not each present exactly
+    ///   once,
+    /// - `StopCapture` precedes `StartCapture`.
+    pub fn build(self) -> Result<Vec<Step>, ValidationError> {
+        let mut start_idx: Option<usize> = None;
+        let mut stop_idx: Option<usize> = None;
+        for (i, step) in self.steps.iter().enumerate() {
+            match step {
+                Step::WaitForWindow { title_regex, .. } | Step::Focus { title_regex } => {
+                    Regex::new(title_regex).map_err(|e| {
+                        anyhow!("step {i}: invalid title_regex {:?} - {e}", title_regex)
+                    })?;
+                }
+                Step::StartCapture => {
+                    if start_idx.is_some() {
+                        bail!("StartCapture appears more than once (second at step {i})");
+                    }
+                    start_idx = Some(i);
+                }
+                Step::StopCapture => {
+                    if stop_idx.is_some() {
+                        bail!("StopCapture appears more than once (second at step {i})");
+                    }
+                    stop_idx = Some(i);
+                }
+                _ => {}
+            }
+        }
+        match (start_idx, stop_idx) {
+            (None, _) => bail!("script {:?} is missing StartCapture", self.name),
+            (_, None) => bail!("script {:?} is missing StopCapture", self.name),
+            (Some(s), Some(t)) if t <= s => {
+                bail!("StopCapture (step {t}) precedes StartCapture (step {s})")
+            }
+            _ => {}
+        }
+        Ok(self.steps)
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/test_demo_dsl.rs"]
+mod tests;

--- a/xtask/src/demo/env/local.rs
+++ b/xtask/src/demo/env/local.rs
@@ -1,0 +1,92 @@
+//! Local environment provider: run the demo on the caller's own
+//! interactive desktop session.
+//!
+//! v0's smallest reviewable provider. There is no isolation, no
+//! wallpaper normalisation, and no Carnac. The caller is expected to
+//! launch the command and step away while the demo records.
+//! Sandbox-based isolation arrives in v1.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::demo::{config_override, driver, dsl::Step, DemoSystem};
+
+/// Hosts the v0 canonical script launches csshw with. Kept here (not
+/// in `script.rs`) because `config_override::generate` needs them too,
+/// and it is the env layer that owns the demo-tree on disk.
+pub const V0_HOSTS: &[&str] = &["alpha", "bravo"];
+
+/// Prepare and run the demo on the local desktop.
+///
+/// Sets up `target/demo/` (config, dispatcher, fake homes), copies the
+/// pre-built `csshw.exe` into it (so csshw's startup
+/// `set_current_dir(exe_dir)` lands on our config rather than the
+/// developer's real one), launches csshw, runs the driver, and
+/// terminates csshw on exit.
+///
+/// # Arguments
+///
+/// * `system` - the [`DemoSystem`].
+/// * `steps` - validated steps from [`crate::demo::dsl::Script::build`].
+/// * `out_gif` - desired GIF path.
+/// * `no_record` - forwarded to the driver; skips capture for fast
+///   script iteration.
+pub fn run<S: DemoSystem>(
+    system: &S,
+    steps: &[Step],
+    out_gif: &Path,
+    no_record: bool,
+) -> Result<()> {
+    let workspace = system.workspace_root()?;
+    let demo_root = workspace.join("target").join("demo");
+    system.ensure_dir(&demo_root)?;
+    let layout = config_override::generate(system, &demo_root, V0_HOSTS)?;
+    system.print_info(&format!(
+        "local env: prepared {} fake hosts under {}",
+        V0_HOSTS.len(),
+        layout.csshw_cwd.display(),
+    ));
+
+    // Copy csshw.exe into the demo directory. csshw rebases its cwd
+    // to its own exe_dir on startup (src/cli.rs:548), so the config
+    // we just wrote is only picked up if csshw runs from there.
+    let source_exe = locate_csshw_exe(&workspace)?;
+    let demo_exe = layout.csshw_cwd.join("csshw.exe");
+    system.copy_file(&source_exe, &demo_exe)?;
+
+    let host_args: Vec<String> = V0_HOSTS.iter().map(|h| (*h).to_string()).collect();
+    system.print_info(&format!(
+        "local env: launching {} {}",
+        demo_exe.display(),
+        host_args.join(" "),
+    ));
+    system.spawn_csshw(&demo_exe, &host_args, &layout.csshw_cwd)?;
+
+    let driver_result = driver::run(system, steps, out_gif, no_record);
+
+    // Always attempt cleanup, regardless of driver outcome.
+    if let Err(e) = system.terminate_csshw() {
+        system.print_debug(&format!("terminate_csshw failed: {e}"));
+    }
+
+    driver_result
+}
+
+/// Locate a built csshw.exe under the workspace's `target/` directory.
+///
+/// Prefers a release build (smaller, no debug overhead) and falls back
+/// to debug. v0 fails loudly if neither exists; v1 will offer to build
+/// it for the caller.
+fn locate_csshw_exe(workspace: &Path) -> Result<PathBuf> {
+    for profile in ["release", "debug"] {
+        let candidate = workspace.join("target").join(profile).join("csshw.exe");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    anyhow::bail!(
+        "could not find csshw.exe under target/release or target/debug. \
+         Run `cargo build --release` first."
+    )
+}

--- a/xtask/src/demo/env/local.rs
+++ b/xtask/src/demo/env/local.rs
@@ -51,7 +51,7 @@ pub fn run<S: DemoSystem>(
     // Copy csshw.exe into the demo directory. csshw rebases its cwd
     // to its own exe_dir on startup (src/cli.rs:548), so the config
     // we just wrote is only picked up if csshw runs from there.
-    let source_exe = locate_csshw_exe(&workspace)?;
+    let source_exe = locate_csshw_exe(system, &workspace)?;
     let demo_exe = layout.csshw_cwd.join("csshw.exe");
     system.copy_file(&source_exe, &demo_exe)?;
 
@@ -77,11 +77,13 @@ pub fn run<S: DemoSystem>(
 ///
 /// Prefers a release build (smaller, no debug overhead) and falls back
 /// to debug. v0 fails loudly if neither exists; v1 will offer to build
-/// it for the caller.
-fn locate_csshw_exe(workspace: &Path) -> Result<PathBuf> {
+/// it for the caller. The existence check goes through
+/// [`DemoSystem::file_exists`] so this function is unit-testable with
+/// a pure mock.
+fn locate_csshw_exe<S: DemoSystem>(system: &S, workspace: &Path) -> Result<PathBuf> {
     for profile in ["release", "debug"] {
         let candidate = workspace.join("target").join(profile).join("csshw.exe");
-        if candidate.exists() {
+        if system.file_exists(&candidate) {
             return Ok(candidate);
         }
     }

--- a/xtask/src/demo/env/mod.rs
+++ b/xtask/src/demo/env/mod.rs
@@ -1,0 +1,8 @@
+//! Per-environment glue for `record-demo`.
+//!
+//! Each submodule is responsible for preparing the recording
+//! environment (config override, fake homes, optional desktop
+//! normalisation) and then handing control to
+//! [`crate::demo::driver::run`]. v0 ships only [`local`].
+
+pub mod local;

--- a/xtask/src/demo/mod.rs
+++ b/xtask/src/demo/mod.rs
@@ -92,6 +92,11 @@ pub trait DemoSystem {
     /// Copy `from` to `to`, replacing any existing file.
     fn copy_file(&self, from: &Path, to: &Path) -> Result<()>;
 
+    /// Return whether `path` exists on disk. Routed through the
+    /// trait (rather than `Path::exists`) so the env layer can be
+    /// unit-tested with a pure mock.
+    fn file_exists(&self, path: &Path) -> bool;
+
     /// Enumerate visible top-level windows.
     fn enum_windows(&self) -> Result<Vec<WindowInfo>>;
 
@@ -197,6 +202,10 @@ impl DemoSystem for RealSystem {
         std::fs::copy(from, to).map(|_| ()).map_err(|e| {
             anyhow::anyhow!("failed to copy {} -> {}: {e}", from.display(), to.display())
         })
+    }
+
+    fn file_exists(&self, path: &Path) -> bool {
+        path.exists()
     }
 
     fn enum_windows(&self) -> Result<Vec<WindowInfo>> {
@@ -310,6 +319,14 @@ pub fn record_demo<S: DemoSystem>(
     no_record: bool,
     no_overlay: bool,
 ) -> Result<()> {
+    // The demo subcommand drives Windows desktop input via
+    // `windows_input` and captures the screen with ffmpeg gdigrab,
+    // both of which only exist on Windows. Bail early with a clear
+    // message instead of letting the caller hit a misleading
+    // "csshw.exe not found" or "gdigrab unavailable" error mid-run.
+    if !cfg!(target_os = "windows") {
+        anyhow::bail!("record-demo is Windows-only; this is a non-Windows build");
+    }
     let workspace = system.workspace_root()?;
     let out = out.unwrap_or_else(|| workspace.join("target/demo/csshw.gif"));
     let script = script::build_canonical_v0().build()?;

--- a/xtask/src/demo/mod.rs
+++ b/xtask/src/demo/mod.rs
@@ -1,0 +1,329 @@
+//! Automated demo recording (`record-demo` xtask subcommand).
+//!
+//! This module turns the README's `demo/csshw.gif` from a hand-recorded
+//! artifact into a reproducible build output. A typed Rust DSL
+//! ([`dsl::Step`]) describes the demo as an ordered list of actions
+//! (launch, wait-for-window, focus, type, sleep, start/stop capture);
+//! the [`driver`] interprets it against a [`DemoSystem`] that abstracts
+//! every side effect (Windows input synthesis, filesystem writes,
+//! subprocess spawning, sleeps). Tests mock [`DemoSystem`] to assert
+//! step semantics with zero real-system effects.
+//!
+//! v0 scope: a single `--env local` provider that runs on the caller's
+//! own desktop (no isolation) and a hard-coded canonical script that
+//! launches `csshw alpha bravo`, types a broadcast command, and stops.
+//! Sandbox + Carnac + visual normalisation arrive in v1; CI workflows
+//! and the orphan-branch publish flow arrive in v2; the full
+//! control-mode + vim + ping scene arrives in v3.
+
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+pub mod config_override;
+pub mod driver;
+pub mod dsl;
+pub mod env;
+pub mod recorder;
+pub mod script;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::ValueEnum;
+
+/// Supported environment providers for `record-demo`.
+///
+/// Each variant maps to a module under [`env`] that is responsible for
+/// preparing the recording environment (writing csshw config, building
+/// a fake-host home tree, optionally normalising the desktop) and then
+/// invoking the shared [`driver`].
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum DemoEnv {
+    /// Run on the caller's own interactive desktop session. v0 default.
+    /// No isolation - the caller is expected to step away while the
+    /// demo records.
+    Local,
+}
+
+/// One top-level window snapshot returned by [`DemoSystem::enum_windows`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowInfo {
+    /// Opaque handle. We model `HWND` as `u64` so the trait stays
+    /// portable across platforms; the production impl casts back.
+    pub hwnd: u64,
+    /// Title text as returned by `GetWindowTextW` and lossily decoded.
+    pub title: String,
+    /// Window rect in screen coordinates.
+    pub rect: WindowRect,
+}
+
+/// Window bounds in screen pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowRect {
+    /// Left edge.
+    pub x: i32,
+    /// Top edge.
+    pub y: i32,
+    /// Width in pixels.
+    pub width: i32,
+    /// Height in pixels.
+    pub height: i32,
+}
+
+/// All side effects the demo subcommand needs.
+///
+/// Implemented for production by [`RealSystem`] and mocked in tests via
+/// `mockall`. Following the pattern of `xtask/src/social_preview.rs`,
+/// every concrete I/O call lives behind one of these methods so unit
+/// tests assert behaviour without touching the real system.
+///
+/// `hosts` is `&[String]` rather than `&[&str]` because mockall does
+/// not handle the implicit lifetime in the latter.
+pub trait DemoSystem {
+    /// Absolute path to the workspace root (parent of `xtask/`).
+    fn workspace_root(&self) -> Result<PathBuf>;
+
+    /// Create `path` and any missing ancestors. No-op if it exists.
+    fn ensure_dir(&self, path: &Path) -> Result<()>;
+
+    /// Write `content` to `path`, creating ancestor directories.
+    fn write_file(&self, path: &Path, content: &str) -> Result<()>;
+
+    /// Copy `from` to `to`, replacing any existing file.
+    fn copy_file(&self, from: &Path, to: &Path) -> Result<()>;
+
+    /// Enumerate visible top-level windows.
+    fn enum_windows(&self) -> Result<Vec<WindowInfo>>;
+
+    /// Bring the window identified by `hwnd` to the foreground.
+    /// Production impl applies the `AttachThreadInput` workaround.
+    fn set_foreground(&self, hwnd: u64) -> Result<()>;
+
+    /// Synthesise a Unicode keypress for the given codepoint via
+    /// `SendInput(KEYEVENTF_UNICODE)`. The character lands in the
+    /// foreground window.
+    fn send_unicode_char(&self, c: char) -> Result<()>;
+
+    /// Synthesise a virtual-key keypress (e.g. VK_RETURN). Used for
+    /// keys Unicode injection can't carry as text (Enter, Esc, F-keys).
+    fn send_vk(&self, vk: u16) -> Result<()>;
+
+    /// Block the current thread for `duration`. Trait method (rather
+    /// than `std::thread::sleep`) so tests can short-circuit waits.
+    fn sleep(&self, duration: Duration);
+
+    /// Launch csshw with the given hosts, working directory, and exe
+    /// path. Fire-and-forget: returns once the daemon process is
+    /// spawned, not when it exits. Production impl tracks the child
+    /// internally so [`terminate_csshw`](Self::terminate_csshw) can
+    /// kill it on cleanup.
+    fn spawn_csshw(&self, exe: &Path, hosts: &[String], cwd: &Path) -> Result<()>;
+
+    /// Kill the in-flight csshw daemon (if any) and best-effort kill
+    /// any leaked client `csshw.exe` instances. Idempotent.
+    fn terminate_csshw(&self) -> Result<()>;
+
+    /// Start a screen capture writing to `out_raw`. Production impl
+    /// spawns ffmpeg gdigrab and stores the child handle internally so
+    /// [`stop_recording`](Self::stop_recording) can terminate it.
+    fn start_recording(&self, out_raw: &Path) -> Result<()>;
+
+    /// Terminate the in-flight capture, run the post-encode pipeline
+    /// (frame extraction + gifski), and produce `out_gif`.
+    fn stop_recording(&self, out_raw: &Path, out_gif: &Path) -> Result<()>;
+
+    /// Print an informational message to stdout.
+    fn print_info(&self, message: &str);
+
+    /// Print a verbose message to stderr (gated on `CSSHW_XTASK_VERBOSE`).
+    fn print_debug(&self, message: &str);
+}
+
+/// Production implementation of [`DemoSystem`].
+///
+/// Holds two long-lived child processes between method calls:
+/// the in-flight ffmpeg gdigrab capture, and the spawned csshw
+/// daemon. All Windows-API calls live in the `windows_input` private
+/// module behind `cfg(target_os = "windows")`.
+pub struct RealSystem {
+    capture: std::sync::Mutex<Option<std::process::Child>>,
+    csshw: std::sync::Mutex<Option<std::process::Child>>,
+}
+
+impl RealSystem {
+    /// Construct a [`RealSystem`] with no in-flight children.
+    pub fn new() -> Self {
+        Self {
+            capture: std::sync::Mutex::new(None),
+            csshw: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl Default for RealSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+mod windows_input;
+
+impl DemoSystem for RealSystem {
+    fn workspace_root(&self) -> Result<PathBuf> {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        Path::new(manifest_dir)
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| anyhow::anyhow!("failed to resolve workspace root"))
+    }
+
+    fn ensure_dir(&self, path: &Path) -> Result<()> {
+        std::fs::create_dir_all(path)
+            .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", path.display()))
+    }
+
+    fn write_file(&self, path: &Path, content: &str) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            self.ensure_dir(parent)?;
+        }
+        std::fs::write(path, content)
+            .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))
+    }
+
+    fn copy_file(&self, from: &Path, to: &Path) -> Result<()> {
+        if let Some(parent) = to.parent() {
+            self.ensure_dir(parent)?;
+        }
+        std::fs::copy(from, to).map(|_| ()).map_err(|e| {
+            anyhow::anyhow!("failed to copy {} -> {}: {e}", from.display(), to.display())
+        })
+    }
+
+    fn enum_windows(&self) -> Result<Vec<WindowInfo>> {
+        windows_input::enum_windows()
+    }
+
+    fn set_foreground(&self, hwnd: u64) -> Result<()> {
+        windows_input::set_foreground(hwnd)
+    }
+
+    fn send_unicode_char(&self, c: char) -> Result<()> {
+        windows_input::send_unicode_char(c)
+    }
+
+    fn send_vk(&self, vk: u16) -> Result<()> {
+        windows_input::send_vk(vk)
+    }
+
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+
+    fn spawn_csshw(&self, exe: &Path, hosts: &[String], cwd: &Path) -> Result<()> {
+        let mut slot = self.csshw.lock().expect("csshw mutex poisoned");
+        if slot.is_some() {
+            anyhow::bail!("spawn_csshw called while a daemon is already running");
+        }
+        let mut cmd = std::process::Command::new(exe);
+        cmd.args(hosts).current_dir(cwd);
+        let child = cmd
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to spawn {}: {e}", exe.display()))?;
+        *slot = Some(child);
+        Ok(())
+    }
+
+    fn terminate_csshw(&self) -> Result<()> {
+        // Kill the daemon child we tracked.
+        if let Some(mut child) = self.csshw.lock().expect("csshw mutex poisoned").take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        // Belt-and-braces: the daemon spawns clients via
+        // CreateProcessW(CREATE_NEW_CONSOLE), which detaches them from
+        // the daemon. Kill any lingering csshw.exe by image name.
+        // This is acceptable in dev contexts; v1 will switch to a
+        // Job Object so cleanup is automatic and safe.
+        let _ = std::process::Command::new("taskkill")
+            .args(["/IM", "csshw.exe", "/T", "/F"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        Ok(())
+    }
+
+    fn start_recording(&self, out_raw: &Path) -> Result<()> {
+        let mut slot = self.capture.lock().expect("capture mutex poisoned");
+        if slot.is_some() {
+            anyhow::bail!("start_recording called while a capture is already running");
+        }
+        let child = recorder::spawn_ffmpeg_gdigrab(out_raw)?;
+        *slot = Some(child);
+        Ok(())
+    }
+
+    fn stop_recording(&self, out_raw: &Path, out_gif: &Path) -> Result<()> {
+        let child = self
+            .capture
+            .lock()
+            .expect("capture mutex poisoned")
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("stop_recording called with no active capture"))?;
+        recorder::stop_ffmpeg_and_encode(child, out_raw, out_gif)
+    }
+
+    fn print_info(&self, message: &str) {
+        println!("INFO - {message}");
+    }
+
+    fn print_debug(&self, message: &str) {
+        if std::env::var("CSSHW_XTASK_VERBOSE")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
+            eprintln!("DEBUG - {message}");
+        }
+    }
+}
+
+/// Top-level entry point for `cargo xtask record-demo`.
+///
+/// Orchestrates: build the canonical [`dsl::Script`], delegate
+/// environment preparation to the matching `env::*` module, run the
+/// driver, return.
+///
+/// # Arguments
+///
+/// * `system` - the [`DemoSystem`] (real or mocked).
+/// * `out` - desired GIF path. Defaults to
+///   `<workspace>/target/demo/csshw.gif`.
+/// * `env` - which environment provider to use.
+/// * `no_record` - skip [`dsl::Step::StartCapture`] /
+///   [`dsl::Step::StopCapture`]. Useful for iterating on the script
+///   without burning capture time.
+/// * `no_overlay` - skip the Carnac keystroke overlay. v0 always
+///   behaves as if this is true (Carnac arrives in v1).
+pub fn record_demo<S: DemoSystem>(
+    system: &S,
+    out: Option<PathBuf>,
+    env: DemoEnv,
+    no_record: bool,
+    no_overlay: bool,
+) -> Result<()> {
+    let workspace = system.workspace_root()?;
+    let out = out.unwrap_or_else(|| workspace.join("target/demo/csshw.gif"));
+    let script = script::build_canonical_v0().build()?;
+    system.print_info(&format!(
+        "record-demo: env={env:?} out={} steps={} no_record={no_record} no_overlay={no_overlay}",
+        out.display(),
+        script.len(),
+    ));
+    match env {
+        DemoEnv::Local => env::local::run(system, &script, &out, no_record)?,
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "../tests/test_demo_mod.rs"]
+mod tests;

--- a/xtask/src/demo/recorder.rs
+++ b/xtask/src/demo/recorder.rs
@@ -1,0 +1,145 @@
+//! ffmpeg + gifski subprocess orchestration for the demo recorder.
+//!
+//! Two-stage pipeline (matches industry practice for high-quality GIFs):
+//!
+//! 1. `ffmpeg -f gdigrab` -> lossless `.mkv` (writing during the run)
+//! 2. `ffmpeg -i raw.mkv -vf "fps=20,scale=1280:-1:flags=lanczos"`
+//!    -> PNG frames in `target/demo/frames/`
+//! 3. `gifski` -> the final `.gif`
+//!
+//! v0 expects `ffmpeg` and `gifski` on `PATH`. v1 will SHA-pin
+//! vendored binaries downloaded into `target/demo/bin/`.
+//!
+//! These free functions are called from [`crate::demo::RealSystem`].
+//! They are kept out of the [`crate::demo::DemoSystem`] trait so the
+//! trait can be mocked without dragging in `std::process::Child`.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+use anyhow::{bail, Context, Result};
+
+/// Capture resolution and framerate. Pinned to keep recordings
+/// identical across developer machines and CI runners.
+const CAPTURE_FRAMERATE: &str = "30";
+const CAPTURE_VIDEO_SIZE: &str = "1920x1080";
+
+/// Encode parameters for the GIF. Re-used in the retry ladder if the
+/// output exceeds the size budget (deferred to v3).
+const ENCODE_FPS: &str = "20";
+const ENCODE_WIDTH: &str = "1280";
+const ENCODE_QUALITY: &str = "90";
+
+/// Spawn the long-running ffmpeg gdigrab capture writing to `out_raw`.
+///
+/// Returns the child process so [`stop_ffmpeg_and_encode`] can shut it
+/// down cleanly via `q\n` on stdin.
+pub fn spawn_ffmpeg_gdigrab(out_raw: &Path) -> Result<Child> {
+    if let Some(parent) = out_raw.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let child = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-f",
+            "gdigrab",
+            "-framerate",
+            CAPTURE_FRAMERATE,
+            "-video_size",
+            CAPTURE_VIDEO_SIZE,
+            "-i",
+            "desktop",
+            "-c:v",
+            "ffvhuff",
+        ])
+        .arg(out_raw)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context(
+            "failed to spawn `ffmpeg`. v0 requires ffmpeg on PATH; \
+             install via winget (`winget install Gyan.FFmpeg`) or chocolatey",
+        )?;
+    Ok(child)
+}
+
+/// Stop the in-flight ffmpeg, run the frame-extract step, then gifski.
+///
+/// `out_raw` is the lossless `.mkv` ffmpeg has been writing.
+/// `out_gif` is the final GIF the caller asked for.
+pub fn stop_ffmpeg_and_encode(mut child: Child, out_raw: &Path, out_gif: &Path) -> Result<()> {
+    // Politely ask ffmpeg to flush + exit by sending `q\n` on stdin;
+    // it converts the partial buffer into a valid container.
+    if let Some(stdin) = child.stdin.as_mut() {
+        let _ = stdin.write_all(b"q\n");
+    }
+    let status = child.wait().context("waiting for ffmpeg gdigrab")?;
+    if !status.success() {
+        // Non-zero on graceful `q` is rare but documented; do not
+        // bail unconditionally because the .mkv may still be valid.
+        eprintln!("ffmpeg gdigrab exited with {status}; continuing to encode");
+    }
+    if !out_raw.exists() {
+        bail!(
+            "ffmpeg did not produce {}: cannot continue to gifski",
+            out_raw.display()
+        );
+    }
+
+    let frames_dir = out_raw
+        .parent()
+        .map(|p| p.join("frames"))
+        .unwrap_or_else(|| Path::new("frames").to_path_buf());
+    if frames_dir.exists() {
+        std::fs::remove_dir_all(&frames_dir)
+            .with_context(|| format!("failed to clear {}", frames_dir.display()))?;
+    }
+    std::fs::create_dir_all(&frames_dir)
+        .with_context(|| format!("failed to create {}", frames_dir.display()))?;
+
+    // Frame extraction.
+    let extract_status = Command::new("ffmpeg")
+        .args(["-y", "-i"])
+        .arg(out_raw)
+        .args([
+            "-vf",
+            &format!("fps={ENCODE_FPS},scale={ENCODE_WIDTH}:-1:flags=lanczos"),
+        ])
+        .arg(frames_dir.join("%05d.png"))
+        .status()
+        .context("failed to spawn `ffmpeg` for frame extraction")?;
+    if !extract_status.success() {
+        bail!("ffmpeg frame extraction failed with {extract_status}");
+    }
+
+    // gifski encode.
+    if let Some(parent) = out_gif.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let frame_glob = frames_dir.join("*.png");
+    let gifski_status = Command::new("gifski")
+        .args([
+            "--fps",
+            ENCODE_FPS,
+            "--width",
+            ENCODE_WIDTH,
+            "--quality",
+            ENCODE_QUALITY,
+            "-o",
+        ])
+        .arg(out_gif)
+        .arg(frame_glob)
+        .status()
+        .context(
+            "failed to spawn `gifski`. v0 requires gifski on PATH; \
+             install via `cargo install gifski` or download from gif.ski",
+        )?;
+    if !gifski_status.success() {
+        bail!("gifski exited with {gifski_status}");
+    }
+    Ok(())
+}

--- a/xtask/src/demo/script.rs
+++ b/xtask/src/demo/script.rs
@@ -1,0 +1,44 @@
+//! The canonical demo script.
+//!
+//! This file is the "demo as code" surface: edit it to change what the
+//! GIF shows. The DSL ([`crate::demo::dsl`]) is type-checked, so a
+//! typo here surfaces as a compile error rather than a recording-time
+//! failure.
+//!
+//! v0 ships [`build_canonical_v0`]: launch csshw with two hosts, wait
+//! for both client windows, broadcast a single command, stop. The
+//! richer scene (control-mode add-host, vim broadcast, ping/Ctrl+C)
+//! arrives in v3 once the chord primitive lands in the DSL.
+
+use crate::demo::dsl::Script;
+
+/// Build the v0 canonical demo: launch + broadcast + stop.
+///
+/// Returns the unbuilt [`Script`]. Callers (the production
+/// `record_demo` entrypoint and unit tests) are expected to call
+/// `.build()` to validate and consume into a `Vec<Step>`.
+///
+/// # Window-title regexes
+///
+/// The regexes match titles produced by csshw itself when it spawns
+/// console windows. csshw uses titles like `daemon [...]` and
+/// `<user>@<host>` for clients; we keep the regexes loose (`(?i)` and
+/// no anchors) so future title tweaks do not silently break the demo.
+pub fn build_canonical_v0() -> Script {
+    let mut s = Script::new("csshw-demo-v0");
+    s.start_capture()
+        .marker("v0: launch + broadcast + stop")
+        .wait_for(r"(?i)daemon")
+        .wait_for(r"(?i)alpha")
+        .wait_for(r"(?i)bravo")
+        .focus(r"(?i)daemon")
+        .sleep_ms(800)
+        .type_text("whoami\r")
+        .sleep_ms(2000)
+        .stop_capture();
+    s
+}
+
+#[cfg(test)]
+#[path = "../tests/test_demo_script.rs"]
+mod tests;

--- a/xtask/src/demo/windows_input.rs
+++ b/xtask/src/demo/windows_input.rs
@@ -1,0 +1,236 @@
+//! Thin wrappers around the Win32 input + window-enumeration APIs.
+//!
+//! Kept private to [`crate::demo`] so the rest of the module tree never
+//! touches `unsafe`. Only [`crate::demo::RealSystem`] calls in here.
+//! All functions return `anyhow::Error` instead of `windows::core::Error`
+//! so callers compose with the rest of xtask uniformly.
+//!
+//! Non-Windows builds still compile (xtask is a workspace member) by
+//! returning a clear "Windows-only" error from each entry point.
+
+use anyhow::Result;
+
+use super::{WindowInfo, WindowRect};
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::*;
+    use std::ffi::c_void;
+
+    use windows::Win32::Foundation::{BOOL, HWND, LPARAM, RECT};
+    use windows::Win32::System::Threading::AttachThreadInput;
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
+        KEYEVENTF_UNICODE, VIRTUAL_KEY,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetForegroundWindow, GetWindowRect, GetWindowTextLengthW, GetWindowTextW,
+        GetWindowThreadProcessId, IsWindowVisible, SetForegroundWindow,
+    };
+
+    /// Closure-based EnumWindows callback context.
+    ///
+    /// We accumulate visible top-level windows with non-empty titles
+    /// into a `Vec<WindowInfo>` passed via `LPARAM`.
+    extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        // SAFETY: lparam is a `*mut Vec<WindowInfo>` we set in
+        // enum_windows() below. The pointer is valid for the duration
+        // of the EnumWindows call.
+        let acc = unsafe { &mut *(lparam.0 as *mut Vec<WindowInfo>) };
+        // SAFETY: HWND is valid for the duration of this callback.
+        let visible = unsafe { IsWindowVisible(hwnd).as_bool() };
+        if !visible {
+            return BOOL(1);
+        }
+        // SAFETY: HWND valid; returns text length without trailing NUL.
+        let len = unsafe { GetWindowTextLengthW(hwnd) };
+        if len <= 0 {
+            return BOOL(1);
+        }
+        let mut buf = vec![0u16; (len as usize) + 1];
+        // SAFETY: HWND valid; buffer length matches the slot count.
+        let copied = unsafe { GetWindowTextW(hwnd, &mut buf) };
+        if copied <= 0 {
+            return BOOL(1);
+        }
+        let title = String::from_utf16_lossy(&buf[..copied as usize]);
+        let mut rect = RECT::default();
+        // SAFETY: HWND valid; rect is a stack RECT we own.
+        if unsafe { GetWindowRect(hwnd, &mut rect) }.is_err() {
+            return BOOL(1);
+        }
+        acc.push(WindowInfo {
+            hwnd: hwnd.0 as u64,
+            title,
+            rect: WindowRect {
+                x: rect.left,
+                y: rect.top,
+                width: rect.right - rect.left,
+                height: rect.bottom - rect.top,
+            },
+        });
+        BOOL(1)
+    }
+
+    /// Enumerate visible top-level windows with non-empty titles.
+    pub fn enum_windows() -> Result<Vec<WindowInfo>> {
+        let mut acc: Vec<WindowInfo> = Vec::new();
+        let lparam = LPARAM(&mut acc as *mut _ as isize);
+        // SAFETY: enum_proc is a valid extern "system" callback;
+        // EnumWindows blocks until iteration completes so `acc` stays
+        // valid for the entire call.
+        unsafe { EnumWindows(Some(enum_proc), lparam) }
+            .map_err(|e| anyhow::anyhow!("EnumWindows failed: {e}"))?;
+        Ok(acc)
+    }
+
+    /// Bring the window to the foreground using the standard
+    /// `AttachThreadInput` workaround (Windows blocks
+    /// `SetForegroundWindow` from background processes since Win2K).
+    pub fn set_foreground(hwnd: u64) -> Result<()> {
+        let target = HWND(hwnd as *mut c_void);
+        // SAFETY: HWND value originates from a recent enum_windows()
+        // call. Worst case it has been destroyed and the API returns
+        // an error, which we propagate.
+        let foreground = unsafe { GetForegroundWindow() };
+        let mut fg_thread = 0u32;
+        // SAFETY: foreground is the current foreground window handle
+        // from the OS; the out-pointer is a stack u32.
+        let _ = unsafe { GetWindowThreadProcessId(foreground, Some(&mut fg_thread)) };
+        let mut target_thread = 0u32;
+        // SAFETY: target is the window we want to focus; out-pointer
+        // is a stack u32.
+        let _ = unsafe { GetWindowThreadProcessId(target, Some(&mut target_thread)) };
+        let attached = if fg_thread != 0 && target_thread != 0 && fg_thread != target_thread {
+            // SAFETY: thread IDs come from GetWindowThreadProcessId.
+            unsafe { AttachThreadInput(fg_thread, target_thread, true) }.as_bool()
+        } else {
+            false
+        };
+        // SAFETY: HWND validated at top of function.
+        let ok = unsafe { SetForegroundWindow(target) }.as_bool();
+        if attached {
+            // SAFETY: must mirror the AttachThreadInput call above.
+            let _ = unsafe { AttachThreadInput(fg_thread, target_thread, false) };
+        }
+        if !ok {
+            anyhow::bail!("SetForegroundWindow returned FALSE for hwnd={hwnd:#x}");
+        }
+        Ok(())
+    }
+
+    /// Send a single Unicode codepoint via `SendInput(KEYEVENTF_UNICODE)`.
+    pub fn send_unicode_char(c: char) -> Result<()> {
+        // BMP characters fit in a single u16; supplementary plane
+        // codepoints need surrogate pairs. We synthesise both halves
+        // when needed.
+        let mut buf = [0u16; 2];
+        let units = c.encode_utf16(&mut buf);
+        for unit in units.iter().copied() {
+            push_unicode(unit)?;
+        }
+        Ok(())
+    }
+
+    /// Send VK_DOWN + VK_UP for a single Unicode code unit.
+    fn push_unicode(unit: u16) -> Result<()> {
+        let down = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VIRTUAL_KEY(0),
+                    wScan: unit,
+                    dwFlags: KEYEVENTF_UNICODE,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        let up = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VIRTUAL_KEY(0),
+                    wScan: unit,
+                    dwFlags: KEYEVENTF_UNICODE | KEYEVENTF_KEYUP,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        send_pair(&[down, up])
+    }
+
+    /// Send a virtual-key down + up pair.
+    pub fn send_vk(vk: u16) -> Result<()> {
+        let down = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VIRTUAL_KEY(vk),
+                    wScan: 0,
+                    dwFlags: KEYBD_EVENT_FLAGS(0),
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        let up = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VIRTUAL_KEY(vk),
+                    wScan: 0,
+                    dwFlags: KEYEVENTF_KEYUP,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        send_pair(&[down, up])
+    }
+
+    fn send_pair(events: &[INPUT]) -> Result<()> {
+        // SAFETY: events is a valid slice; SendInput reads `len`
+        // entries each of size_of::<INPUT>().
+        let sent = unsafe { SendInput(events, std::mem::size_of::<INPUT>() as i32) };
+        if sent as usize != events.len() {
+            anyhow::bail!(
+                "SendInput injected {sent}/{} events; the input desktop may be locked",
+                events.len()
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub(super) use imp::{enum_windows, send_unicode_char, send_vk, set_foreground};
+
+#[cfg(not(target_os = "windows"))]
+mod imp_stub {
+    use super::*;
+
+    /// Stub that errors on non-Windows hosts. The demo subcommand is
+    /// Windows-only; this stub exists so `cargo check` on Linux still
+    /// compiles the rest of the workspace.
+    fn unsupported<T>() -> Result<T> {
+        anyhow::bail!("record-demo is Windows-only; this is a non-Windows build")
+    }
+
+    pub fn enum_windows() -> Result<Vec<WindowInfo>> {
+        unsupported()
+    }
+    pub fn set_foreground(_hwnd: u64) -> Result<()> {
+        unsupported()
+    }
+    pub fn send_unicode_char(_c: char) -> Result<()> {
+        unsupported()
+    }
+    pub fn send_vk(_vk: u16) -> Result<()> {
+        unsupported()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(super) use imp_stub::{enum_windows, send_unicode_char, send_vk, set_foreground};

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@
 
 mod changelog;
 mod coverage;
+mod demo;
 mod inject_agent_token;
 mod readme;
 mod release;
@@ -65,6 +66,28 @@ enum Command {
     /// Scan tracked text files for forbidden decorative Unicode
     /// punctuation and fail with a list of offending locations.
     CheckTypography,
+    /// Record an automated demo of csshw and produce `target/demo/csshw.gif`.
+    ///
+    /// v0 only supports `--env local` (runs on the caller's interactive
+    /// desktop session, no isolation) and requires `ffmpeg` and
+    /// `gifski` on PATH.
+    RecordDemo {
+        /// Output GIF path. Defaults to
+        /// `<workspace>/target/demo/csshw.gif`.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Recording environment provider.
+        #[arg(long, value_enum, default_value_t = demo::DemoEnv::Local)]
+        env: demo::DemoEnv,
+        /// Skip ffmpeg capture; useful for iterating on the demo
+        /// script without burning a recording cycle.
+        #[arg(long)]
+        no_record: bool,
+        /// Skip the keystroke overlay. v0 always behaves as if this
+        /// is set; the flag exists so v1+ scripts can opt out.
+        #[arg(long)]
+        no_overlay: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -100,6 +123,14 @@ fn main() -> Result<()> {
         }
         Command::CheckTypography => {
             typography::check_typography(&typography::RealSystem)?;
+        }
+        Command::RecordDemo {
+            out,
+            env,
+            no_record,
+            no_overlay,
+        } => {
+            demo::record_demo(&demo::RealSystem::new(), out, env, no_record, no_overlay)?;
         }
     }
     Ok(())

--- a/xtask/src/tests/test_demo_config_override.rs
+++ b/xtask/src/tests/test_demo_config_override.rs
@@ -20,6 +20,7 @@ mock! {
         fn ensure_dir(&self, path: &Path) -> anyhow::Result<()>;
         fn write_file(&self, path: &Path, content: &str) -> anyhow::Result<()>;
         fn copy_file(&self, from: &Path, to: &Path) -> anyhow::Result<()>;
+        fn file_exists(&self, path: &Path) -> bool;
         fn enum_windows(&self) -> anyhow::Result<Vec<WindowInfo>>;
         fn set_foreground(&self, hwnd: u64) -> anyhow::Result<()>;
         fn send_unicode_char(&self, c: char) -> anyhow::Result<()>;

--- a/xtask/src/tests/test_demo_config_override.rs
+++ b/xtask/src/tests/test_demo_config_override.rs
@@ -1,0 +1,180 @@
+//! Tests for the `csshw-config.toml` override generator.
+//!
+//! Asserts the generator (a) writes one config file plus per-host
+//! enter.bat files, (b) only writes host-specific files for the
+//! intended host, and (c) emits a TOML body that targets cmd.exe via
+//! a single `dispatcher.bat`.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use mockall::mock;
+
+use crate::demo::{config_override, DemoSystem, WindowInfo};
+
+mock! {
+    DemoSystemMock {}
+    impl DemoSystem for DemoSystemMock {
+        fn workspace_root(&self) -> anyhow::Result<PathBuf>;
+        fn ensure_dir(&self, path: &Path) -> anyhow::Result<()>;
+        fn write_file(&self, path: &Path, content: &str) -> anyhow::Result<()>;
+        fn copy_file(&self, from: &Path, to: &Path) -> anyhow::Result<()>;
+        fn enum_windows(&self) -> anyhow::Result<Vec<WindowInfo>>;
+        fn set_foreground(&self, hwnd: u64) -> anyhow::Result<()>;
+        fn send_unicode_char(&self, c: char) -> anyhow::Result<()>;
+        fn send_vk(&self, vk: u16) -> anyhow::Result<()>;
+        fn sleep(&self, duration: Duration);
+        fn spawn_csshw(&self, exe: &Path, hosts: &[String], cwd: &Path) -> anyhow::Result<()>;
+        fn terminate_csshw(&self) -> anyhow::Result<()>;
+        fn start_recording(&self, out_raw: &Path) -> anyhow::Result<()>;
+        fn stop_recording(&self, out_raw: &Path, out_gif: &Path) -> anyhow::Result<()>;
+        fn print_info(&self, message: &str);
+        fn print_debug(&self, message: &str);
+    }
+}
+
+#[derive(Default, Clone)]
+struct WriteCapture {
+    files: Vec<(PathBuf, String)>,
+}
+
+fn capturing_mock() -> (MockDemoSystemMock, Arc<Mutex<WriteCapture>>) {
+    let cap: Arc<Mutex<WriteCapture>> = Arc::new(Mutex::new(WriteCapture::default()));
+    let mut mock = MockDemoSystemMock::new();
+    mock.expect_ensure_dir().returning(|_| Ok(()));
+    let slot = cap.clone();
+    mock.expect_write_file().returning(move |p, c| {
+        slot.lock()
+            .unwrap()
+            .files
+            .push((p.to_path_buf(), c.to_string()));
+        Ok(())
+    });
+    (mock, cap)
+}
+
+#[test]
+fn test_generate_writes_config_and_per_host_bat() {
+    // Arrange
+    let (mock, cap) = capturing_mock();
+    let demo_root = PathBuf::from("/demo");
+
+    // Act
+    let layout = config_override::generate(&mock, &demo_root, &["alpha", "bravo"]).unwrap();
+
+    // Assert
+    assert_eq!(layout.csshw_cwd, demo_root);
+    let files = cap.lock().unwrap().files.clone();
+    let names: Vec<String> = files
+        .iter()
+        .map(|(p, _)| p.display().to_string().replace('\\', "/"))
+        .collect();
+    assert!(names.iter().any(|n| n.ends_with("/csshw-config.toml")));
+    assert!(names.iter().any(|n| n.ends_with("/dispatcher.bat")));
+    assert!(names
+        .iter()
+        .any(|n| n.ends_with("fakehosts/alpha/enter.bat")));
+    assert!(names
+        .iter()
+        .any(|n| n.ends_with("fakehosts/bravo/enter.bat")));
+    // Shared README is written for both hosts.
+    assert_eq!(
+        names.iter().filter(|n| n.ends_with("README.txt")).count(),
+        2
+    );
+}
+
+#[test]
+fn test_generate_writes_host_specific_file_only_for_owning_host() {
+    // Arrange
+    let (mock, cap) = capturing_mock();
+
+    // Act
+    config_override::generate(&mock, Path::new("/demo"), &["alpha", "charlie"]).unwrap();
+
+    // Assert
+    let files = cap.lock().unwrap().files.clone();
+    let secret_writes: Vec<_> = files
+        .iter()
+        .filter(|(p, _)| p.display().to_string().ends_with("secret.txt"))
+        .collect();
+    assert_eq!(secret_writes.len(), 1, "secret.txt should appear once");
+    let path = secret_writes[0].0.display().to_string().replace('\\', "/");
+    assert!(path.contains("fakehosts/charlie/"), "got: {path}");
+}
+
+#[test]
+fn test_generated_toml_targets_cmd_exe_via_dispatcher() {
+    // Arrange
+    let (mock, cap) = capturing_mock();
+
+    // Act
+    config_override::generate(&mock, Path::new("/demo"), &["alpha"]).unwrap();
+
+    // Assert
+    let files = cap.lock().unwrap().files.clone();
+    let toml = files
+        .iter()
+        .find(|(p, _)| p.display().to_string().ends_with("csshw-config.toml"))
+        .map(|(_, c)| c.clone())
+        .expect("csshw-config.toml not written");
+    assert!(toml.contains("program = \"cmd.exe\""), "toml: {toml}");
+    assert!(
+        toml.contains("{{USERNAME_AT_HOST}}"),
+        "placeholder missing - toml: {toml}"
+    );
+    assert!(toml.contains("dispatcher.bat"), "toml: {toml}");
+}
+
+#[test]
+fn test_dispatcher_bat_strips_user_prefix() {
+    // Arrange
+    let (mock, cap) = capturing_mock();
+
+    // Act
+    config_override::generate(&mock, Path::new("/demo"), &["alpha"]).unwrap();
+
+    // Assert
+    let files = cap.lock().unwrap().files.clone();
+    let dispatcher = files
+        .iter()
+        .find(|(p, _)| p.display().to_string().ends_with("dispatcher.bat"))
+        .map(|(_, c)| c.clone())
+        .expect("dispatcher.bat not written");
+    // Must use cmd's `:*@=` substring substitution. The
+    // `for /f tokens=2 delims=@` form skips a leading `@` and
+    // produces only one token, leaving HOST as `@alpha` and
+    // breaking the call below with "the system cannot find the
+    // path specified".
+    assert!(
+        dispatcher.contains(":*@="),
+        "dispatcher should use substring substitution: {dispatcher}"
+    );
+    assert!(
+        !dispatcher.contains("delims=@"),
+        "dispatcher must not use `for /f delims=@` (mishandles leading @): {dispatcher}"
+    );
+    assert!(dispatcher.contains("fakehosts"), "dispatcher: {dispatcher}");
+    assert!(dispatcher.contains("enter.bat"), "dispatcher: {dispatcher}");
+}
+
+#[test]
+fn test_enter_bat_sets_prompt_and_cd() {
+    // Arrange
+    let (mock, cap) = capturing_mock();
+
+    // Act
+    config_override::generate(&mock, Path::new("/demo"), &["alpha"]).unwrap();
+
+    // Assert
+    let files = cap.lock().unwrap().files.clone();
+    let bat = files
+        .iter()
+        .find(|(p, _)| p.display().to_string().ends_with("enter.bat"))
+        .map(|(_, c)| c.clone())
+        .expect("enter.bat not written");
+    assert!(bat.contains("set PROMPT="), "bat: {bat}");
+    assert!(bat.contains("cd /d"), "bat: {bat}");
+    assert!(bat.contains("alpha"), "bat: {bat}");
+}

--- a/xtask/src/tests/test_demo_driver.rs
+++ b/xtask/src/tests/test_demo_driver.rs
@@ -20,6 +20,7 @@ mock! {
         fn ensure_dir(&self, path: &Path) -> anyhow::Result<()>;
         fn write_file(&self, path: &Path, content: &str) -> anyhow::Result<()>;
         fn copy_file(&self, from: &Path, to: &Path) -> anyhow::Result<()>;
+        fn file_exists(&self, path: &Path) -> bool;
         fn enum_windows(&self) -> anyhow::Result<Vec<WindowInfo>>;
         fn set_foreground(&self, hwnd: u64) -> anyhow::Result<()>;
         fn send_unicode_char(&self, c: char) -> anyhow::Result<()>;

--- a/xtask/src/tests/test_demo_driver.rs
+++ b/xtask/src/tests/test_demo_driver.rs
@@ -1,0 +1,268 @@
+//! Tests for the demo driver.
+//!
+//! All side effects route through the [`DemoSystem`] trait, so the
+//! driver is fully mockable without any Windows API or filesystem
+//! contact.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use mockall::mock;
+
+use crate::demo::dsl::Step;
+use crate::demo::{driver, DemoSystem, WindowInfo, WindowRect};
+
+mock! {
+    DemoSystemMock {}
+    impl DemoSystem for DemoSystemMock {
+        fn workspace_root(&self) -> anyhow::Result<PathBuf>;
+        fn ensure_dir(&self, path: &Path) -> anyhow::Result<()>;
+        fn write_file(&self, path: &Path, content: &str) -> anyhow::Result<()>;
+        fn copy_file(&self, from: &Path, to: &Path) -> anyhow::Result<()>;
+        fn enum_windows(&self) -> anyhow::Result<Vec<WindowInfo>>;
+        fn set_foreground(&self, hwnd: u64) -> anyhow::Result<()>;
+        fn send_unicode_char(&self, c: char) -> anyhow::Result<()>;
+        fn send_vk(&self, vk: u16) -> anyhow::Result<()>;
+        fn sleep(&self, duration: Duration);
+        fn spawn_csshw(&self, exe: &Path, hosts: &[String], cwd: &Path) -> anyhow::Result<()>;
+        fn terminate_csshw(&self) -> anyhow::Result<()>;
+        fn start_recording(&self, out_raw: &Path) -> anyhow::Result<()>;
+        fn stop_recording(&self, out_raw: &Path, out_gif: &Path) -> anyhow::Result<()>;
+        fn print_info(&self, message: &str);
+        fn print_debug(&self, message: &str);
+    }
+}
+
+/// Build a mock with no-op `print_*` and `sleep` so callers only set
+/// expectations on the calls they actually want to assert.
+fn base_mock() -> MockDemoSystemMock {
+    let mut mock = MockDemoSystemMock::new();
+    mock.expect_print_info().returning(|_| ());
+    mock.expect_print_debug().returning(|_| ());
+    mock.expect_sleep().returning(|_| ());
+    mock
+}
+
+/// Single window with a stable rect, used by tests that expect
+/// `WaitForWindow` and `Focus` to succeed on the first poll.
+fn one_window(title: &str) -> Vec<WindowInfo> {
+    vec![WindowInfo {
+        hwnd: 0xDEAD,
+        title: title.to_string(),
+        rect: WindowRect {
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 600,
+        },
+    }]
+}
+
+#[test]
+fn test_no_record_skips_capture_calls() {
+    // Arrange
+    let mut mock = base_mock();
+    mock.expect_start_recording().times(0);
+    mock.expect_stop_recording().times(0);
+    let steps = vec![
+        Step::StartCapture,
+        Step::Sleep(Duration::from_millis(1)),
+        Step::StopCapture,
+    ];
+
+    // Act
+    let res = driver::run(&mock, &steps, Path::new("ignored.gif"), true);
+
+    // Assert
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_capture_calls_are_paired_when_recording() {
+    // Arrange
+    let mut mock = base_mock();
+    let captured_raw: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
+    let captured_gif: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
+    let raw_slot = captured_raw.clone();
+    mock.expect_start_recording().times(1).returning(move |p| {
+        *raw_slot.lock().unwrap() = Some(p.to_path_buf());
+        Ok(())
+    });
+    let gif_slot = captured_gif.clone();
+    mock.expect_stop_recording()
+        .times(1)
+        .returning(move |_raw, gif| {
+            *gif_slot.lock().unwrap() = Some(gif.to_path_buf());
+            Ok(())
+        });
+    let steps = vec![Step::StartCapture, Step::StopCapture];
+
+    // Act
+    let res = driver::run(&mock, &steps, Path::new("/x/csshw.gif"), false);
+
+    // Assert
+    assert!(res.is_ok());
+    assert_eq!(
+        captured_raw.lock().unwrap().as_deref(),
+        Some(Path::new("/x/csshw.mkv"))
+    );
+    assert_eq!(
+        captured_gif.lock().unwrap().as_deref(),
+        Some(Path::new("/x/csshw.gif"))
+    );
+}
+
+#[test]
+fn test_capture_is_cleaned_up_on_step_error() {
+    // Arrange
+    let mut mock = base_mock();
+    mock.expect_start_recording().times(1).returning(|_| Ok(()));
+    // The Type step below will fail because send_unicode_char errors;
+    // the driver MUST still call stop_recording.
+    mock.expect_stop_recording()
+        .times(1)
+        .returning(|_, _| Ok(()));
+    mock.expect_send_unicode_char()
+        .returning(|_| Err(anyhow::anyhow!("simulated failure")));
+    let steps = vec![
+        Step::StartCapture,
+        Step::Type {
+            text: "x".into(),
+            per_char_delay: Duration::from_millis(0),
+        },
+        Step::StopCapture,
+    ];
+
+    // Act
+    let res = driver::run(&mock, &steps, Path::new("/x/csshw.gif"), false);
+
+    // Assert
+    assert!(res.is_err());
+    let err = res.unwrap_err().to_string();
+    assert!(
+        err.contains("Type") || err.contains("simulated"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn test_wait_for_window_succeeds_when_match_appears() {
+    // Arrange
+    let mut mock = base_mock();
+    mock.expect_enum_windows()
+        .returning(|| Ok(one_window("daemon [csshw]")));
+    let steps = vec![
+        Step::StartCapture,
+        Step::WaitForWindow {
+            title_regex: r"(?i)daemon".to_string(),
+            timeout: Duration::from_millis(500),
+            stable_for: Duration::from_millis(0),
+        },
+        Step::StopCapture,
+    ];
+    mock.expect_start_recording().returning(|_| Ok(()));
+    mock.expect_stop_recording().returning(|_, _| Ok(()));
+
+    // Act
+    let res = driver::run(&mock, &steps, Path::new("/x/csshw.gif"), false);
+
+    // Assert
+    assert!(res.is_ok(), "{res:?}");
+}
+
+#[test]
+fn test_wait_for_window_times_out_when_no_match() {
+    // Arrange
+    let mut mock = base_mock();
+    mock.expect_enum_windows()
+        .returning(|| Ok(one_window("not the right window")));
+    let steps = vec![
+        Step::StartCapture,
+        Step::WaitForWindow {
+            title_regex: r"(?i)daemon".to_string(),
+            timeout: Duration::from_millis(50),
+            stable_for: Duration::from_millis(0),
+        },
+        Step::StopCapture,
+    ];
+    mock.expect_start_recording().returning(|_| Ok(()));
+    mock.expect_stop_recording().returning(|_, _| Ok(()));
+
+    // Act
+    let res = driver::run(&mock, &steps, Path::new("/x/csshw.gif"), false);
+
+    // Assert
+    let err = res.expect_err("expected timeout").to_string();
+    assert!(
+        err.contains("WaitForWindow") || err.contains("stabilised"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn test_focus_calls_set_foreground_with_matching_hwnd() {
+    // Arrange
+    let mut mock = base_mock();
+    mock.expect_enum_windows()
+        .returning(|| Ok(one_window("alpha@alpha-fake")));
+    let captured_hwnd: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
+    let slot = captured_hwnd.clone();
+    mock.expect_set_foreground().times(1).returning(move |h| {
+        *slot.lock().unwrap() = Some(h);
+        Ok(())
+    });
+    let steps = vec![
+        Step::StartCapture,
+        Step::Focus {
+            title_regex: r"(?i)alpha".to_string(),
+        },
+        Step::StopCapture,
+    ];
+    mock.expect_start_recording().returning(|_| Ok(()));
+    mock.expect_stop_recording().returning(|_, _| Ok(()));
+
+    // Act
+    let res = driver::run(&mock, &steps, Path::new("/x/csshw.gif"), false);
+
+    // Assert
+    assert!(res.is_ok());
+    assert_eq!(*captured_hwnd.lock().unwrap(), Some(0xDEAD));
+}
+
+#[test]
+fn test_type_text_translates_newline_to_vk_return() {
+    // Arrange
+    let mut mock = base_mock();
+    let unicode_chars: Arc<Mutex<Vec<char>>> = Arc::new(Mutex::new(Vec::new()));
+    let vk_codes: Arc<Mutex<Vec<u16>>> = Arc::new(Mutex::new(Vec::new()));
+    let cs = unicode_chars.clone();
+    mock.expect_send_unicode_char().returning(move |c| {
+        cs.lock().unwrap().push(c);
+        Ok(())
+    });
+    let vs = vk_codes.clone();
+    mock.expect_send_vk().returning(move |vk| {
+        vs.lock().unwrap().push(vk);
+        Ok(())
+    });
+    let steps = vec![
+        Step::StartCapture,
+        Step::Type {
+            text: "ab\r".into(),
+            per_char_delay: Duration::from_millis(0),
+        },
+        Step::StopCapture,
+    ];
+    mock.expect_start_recording().returning(|_| Ok(()));
+    mock.expect_stop_recording().returning(|_, _| Ok(()));
+
+    // Act
+    let res = driver::run(&mock, &steps, Path::new("/x/csshw.gif"), false);
+
+    // Assert
+    assert!(res.is_ok());
+    assert_eq!(*unicode_chars.lock().unwrap(), vec!['a', 'b']);
+    // 0x0D is VK_RETURN.
+    assert_eq!(*vk_codes.lock().unwrap(), vec![0x0Du16]);
+}

--- a/xtask/src/tests/test_demo_dsl.rs
+++ b/xtask/src/tests/test_demo_dsl.rs
@@ -1,0 +1,147 @@
+//! Tests for the demo DSL.
+//!
+//! Pure data manipulation - no `DemoSystem` mock needed.
+
+use std::time::Duration;
+
+use crate::demo::dsl::{
+    Script, Step, DEFAULT_PER_CHAR_DELAY, DEFAULT_WAIT_STABLE_FOR, DEFAULT_WAIT_TIMEOUT,
+};
+
+#[test]
+fn test_script_records_steps_in_order() {
+    // Arrange
+    let mut s = Script::new("ordering");
+    // Act
+    s.start_capture()
+        .wait_for("daemon")
+        .focus("daemon")
+        .type_text("hi\r")
+        .sleep_ms(500)
+        .stop_capture();
+    // Assert
+    let steps = s.build().unwrap();
+    assert_eq!(steps.len(), 6);
+    assert!(matches!(steps[0], Step::StartCapture));
+    assert!(matches!(steps[1], Step::WaitForWindow { .. }));
+    assert!(matches!(steps[2], Step::Focus { .. }));
+    assert!(matches!(steps[3], Step::Type { .. }));
+    assert!(matches!(steps[4], Step::Sleep(_)));
+    assert!(matches!(steps[5], Step::StopCapture));
+}
+
+#[test]
+fn test_wait_for_uses_defaults() {
+    // Arrange
+    let mut s = Script::new("defaults");
+    s.start_capture().wait_for("d").stop_capture();
+    // Act
+    let steps = s.build().unwrap();
+    // Assert
+    let Step::WaitForWindow {
+        timeout,
+        stable_for,
+        ..
+    } = &steps[1]
+    else {
+        panic!("expected WaitForWindow");
+    };
+    assert_eq!(*timeout, DEFAULT_WAIT_TIMEOUT);
+    assert_eq!(*stable_for, DEFAULT_WAIT_STABLE_FOR);
+}
+
+#[test]
+fn test_type_text_uses_default_per_char_delay() {
+    // Arrange
+    let mut s = Script::new("defaults");
+    s.start_capture().type_text("ab").stop_capture();
+    // Act
+    let steps = s.build().unwrap();
+    // Assert
+    let Step::Type { per_char_delay, .. } = &steps[1] else {
+        panic!("expected Type");
+    };
+    assert_eq!(*per_char_delay, DEFAULT_PER_CHAR_DELAY);
+}
+
+#[test]
+fn test_build_rejects_invalid_regex() {
+    // Arrange
+    let mut s = Script::new("bad-regex");
+    s.start_capture().wait_for("(unclosed").stop_capture();
+    // Act
+    let err = s.build().unwrap_err().to_string();
+    // Assert
+    assert!(err.contains("invalid title_regex"), "got: {err}");
+}
+
+#[test]
+fn test_build_rejects_missing_start_capture() {
+    // Arrange
+    let mut s = Script::new("no-start");
+    s.wait_for("daemon").stop_capture();
+    // Act
+    let err = s.build().unwrap_err().to_string();
+    // Assert
+    assert!(err.contains("missing StartCapture"), "got: {err}");
+}
+
+#[test]
+fn test_build_rejects_missing_stop_capture() {
+    // Arrange
+    let mut s = Script::new("no-stop");
+    s.start_capture().wait_for("daemon");
+    // Act
+    let err = s.build().unwrap_err().to_string();
+    // Assert
+    assert!(err.contains("missing StopCapture"), "got: {err}");
+}
+
+#[test]
+fn test_build_rejects_duplicate_capture() {
+    // Arrange
+    let mut s = Script::new("dup");
+    s.start_capture().start_capture().stop_capture();
+    // Act
+    let err = s.build().unwrap_err().to_string();
+    // Assert
+    assert!(
+        err.contains("StartCapture appears more than once"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn test_build_rejects_stop_before_start() {
+    // Arrange
+    let mut s = Script::new("inverted");
+    s.stop_capture().start_capture();
+    // Act
+    let err = s.build().unwrap_err().to_string();
+    // Assert
+    assert!(err.contains("precedes StartCapture"), "got: {err}");
+}
+
+#[test]
+fn test_wait_for_with_overrides_durations() {
+    // Arrange
+    let custom_timeout = Duration::from_secs(7);
+    let custom_stable = Duration::from_millis(123);
+    let mut s = Script::new("custom");
+    s.start_capture()
+        .wait_for_with("d", custom_timeout, custom_stable)
+        .stop_capture();
+    // Act
+    let steps = s.build().unwrap();
+    // Assert
+    let Step::WaitForWindow {
+        timeout,
+        stable_for,
+        ..
+    } = &steps[1]
+    else {
+        panic!("expected WaitForWindow");
+    };
+    assert_eq!(*timeout, custom_timeout);
+    assert_eq!(*stable_for, custom_stable);
+}

--- a/xtask/src/tests/test_demo_mod.rs
+++ b/xtask/src/tests/test_demo_mod.rs
@@ -1,0 +1,37 @@
+//! Top-level smoke tests for the demo module.
+//!
+//! Per-submodule behaviour is exercised by `test_demo_dsl.rs`,
+//! `test_demo_driver.rs`, `test_demo_config_override.rs`, and
+//! `test_demo_script.rs`. This file holds only assertions about the
+//! module's public surface.
+
+use crate::demo::{DemoEnv, WindowRect};
+
+#[test]
+fn test_demo_env_default_is_local() {
+    // The default for `--env` lives in `main.rs` as `DemoEnv::Local`.
+    // Pin that here so renaming the variant later flags the
+    // documentation in the plan as out of date.
+    let env = DemoEnv::Local;
+    assert!(matches!(env, DemoEnv::Local));
+}
+
+#[test]
+fn test_window_rect_is_value_equality() {
+    // Arrange
+    let a = WindowRect {
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1080,
+    };
+    let b = WindowRect {
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1080,
+    };
+    // Assert: PartialEq must derive structurally so the driver's
+    // stability check (rect-equality across polls) works.
+    assert_eq!(a, b);
+}

--- a/xtask/src/tests/test_demo_script.rs
+++ b/xtask/src/tests/test_demo_script.rs
@@ -1,0 +1,28 @@
+//! Sanity test for the canonical v0 script.
+//!
+//! The point of having a typed DSL is that the script validates at
+//! `cargo build` time. This test pins down the contract: the canonical
+//! script must build without errors and contain the expected first /
+//! last steps. Future scripts (v1+) can clone this pattern.
+
+use crate::demo::dsl::Step;
+use crate::demo::script;
+
+#[test]
+fn test_canonical_v0_builds() {
+    // Act
+    let steps = script::build_canonical_v0().build().unwrap();
+    // Assert
+    assert!(!steps.is_empty());
+    assert!(matches!(steps.first(), Some(Step::StartCapture)));
+    assert!(matches!(steps.last(), Some(Step::StopCapture)));
+}
+
+#[test]
+fn test_canonical_v0_contains_a_type_step() {
+    // Act
+    let steps = script::build_canonical_v0().build().unwrap();
+    // Assert
+    let typed = steps.iter().any(|s| matches!(s, Step::Type { .. }));
+    assert!(typed, "canonical v0 should type at least one command");
+}


### PR DESCRIPTION
## Summary

The README's `demo/csshw.gif` is currently re-recorded by hand each
time it drifts from the product, requiring a developer to manually
configure their workstation (wallpaper, fake SSH hosts, keystroke
overlay, ScreenToGif). This PR turns that artifact into a
reproducible build output.

This is **v0** of a four-stage plan: a typed Rust DSL + driver +
local env that produces `target/demo/csshw.gif` on the developer's
own desktop. Requires `ffmpeg` and `gifski` on PATH. v1 (Windows
Sandbox provider, vendored SHA-pinned binaries, Carnac overlay,
visual normalisation) is in a separate stacked PR. v2 (CI workflows
+ append-only demo-assets orphan branch) and v3 (`Press(Chord)`
primitive + full canonical scene) are out of scope.

The PRs are stacked Gerrit-style: the v1 PR currently contains v0+v1
commits and targets `main`; once this PR merges, the v1 PR will be
rebased on `main` so only v1 changes remain.

## v0 highlights

- `DemoSystem` trait + `RealSystem` behind which all side effects
  (Windows input synthesis, fs, subprocess) sit so unit tests
  exercise the driver via mockall with zero real-system effects.
- Closed `Step` enum + `Script` builder validating capture pairing
  and regex compilation at build time, so a typo in the script
  fails `cargo check` rather than a half-completed recording.
- Driver interprets steps via the trait; the in-flight ffmpeg
  capture is cleaned up even when a step errors mid-script.
- `config_override` writes `target/demo/csshw-config.toml`, a
  `dispatcher.bat` that strips an optional `user@` prefix from
  csshw's `USERNAME_AT_HOST` substitution, and per-host
  `enter.bat` scripts with curated home directories.
- `env/local.rs` copies `csshw.exe` into `target/demo/` so
  csshw's startup `set_current_dir(exe_dir)` lands on our config.
- `terminate_csshw` kills the daemon child and best-effort kills
  any `CREATE_NEW_CONSOLE`-detached client `csshw.exe` instances.

## Test plan

- [x] `cargo build -p xtask` clean (no warnings)
- [x] `cargo fmt` clean
- [x] `cargo lint` clean
- [x] `cargo test` (all green)
- [x] `cargo doc-tests` clean
- [x] `cargo xtask check-typography` clean
- [ ] Manual: `cargo xtask record-demo --env local` produces a
  playable `target/demo/csshw.gif`

The full plan lives at
`C:/Users/whme/.claude/plans/tranquil-hopping-karp.md`.
