### PR TITLE
control mode: expand braces in [c]reate window(s) input

### DIFF
--- a/news/193.bugfix.md
+++ b/news/193.bugfix.md
@@ -1,0 +1,4 @@
+Fixed `[c]reate window(s)` in control mode to expand brace expressions
+and cluster tags in the entered hostnames, so input like `{1..10}.local`
+now spawns ten client windows instead of a single window literally named
+`{1..10}.local`.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -562,13 +562,10 @@ impl<'a> Daemon<'a> {
                             let number_of_existing_clients = clients.lock().unwrap().len();
                             let new_clients = launch_clients(
                                 windows_api,
-                                resolve_cluster_tags(
+                                expand_hosts(
                                     hostnames.split(' ').map(|x| return x.trim()).collect(),
                                     self.clusters,
-                                )
-                                .into_iter()
-                                .map(|x| return x.to_owned())
-                                .collect(),
+                                ),
                                 &self.username,
                                 self.port,
                                 self.debug,
@@ -859,6 +856,29 @@ pub fn resolve_cluster_tags<'a>(hosts: Vec<&'a str>, clusters: &'a [Cluster]) ->
         }
     }
     return resolved_hosts;
+}
+
+/// Resolve cluster tags in `hosts` and expand brace expressions
+/// (e.g. `host{1..3}.local`) in each resulting hostname.
+///
+/// Used by the control-mode `[c]reate window(s)` path so hostname
+/// input behaves the same as on the CLI. Each cluster-resolved
+/// hostname is passed through [`bracoxide::explode`] individually;
+/// hostnames that do not contain a brace expression are kept as-is.
+///
+/// # Arguments
+///
+/// * `hosts`    - User-supplied hostnames and/or cluster tags.
+/// * `clusters` - Available cluster definitions.
+///
+/// # Returns
+///
+/// The fully resolved, brace-expanded list of hostnames.
+pub fn expand_hosts(hosts: Vec<&str>, clusters: &[Cluster]) -> Vec<String> {
+    return resolve_cluster_tags(hosts, clusters)
+        .into_iter()
+        .flat_map(|host| return explode(host).unwrap_or_else(|_| return vec![host.to_owned()]))
+        .collect();
 }
 
 /// Launches a client console for each given host and waits for

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -12,7 +12,10 @@ mod daemon_test {
     use windows::Win32::Foundation::{HANDLE, HWND};
 
     use crate::{
-        daemon::{named_pipe_server_routine, resolve_cluster_tags, Client, Clients, HWNDWrapper},
+        daemon::{
+            expand_hosts, named_pipe_server_routine, resolve_cluster_tags, Client, Clients,
+            HWNDWrapper,
+        },
         protocol::{
             serialization::serialize_pid, ClientState, FRAMED_INPUT_RECORD_LENGTH,
             FRAMED_KEEP_ALIVE_LENGTH, FRAMED_STATE_CHANGE_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH,
@@ -114,6 +117,49 @@ mod daemon_test {
             resolve_cluster_tags(hosts, &clusters),
             vec!["host1", "host2", "host3"]
         );
+    }
+
+    #[test]
+    fn test_expand_hosts_brace_only() {
+        let hosts: Vec<&str> = vec!["host{1..3}.local"];
+        let clusters: Vec<Cluster> = vec![];
+        assert_eq!(
+            expand_hosts(hosts, &clusters),
+            vec!["host1.local", "host2.local", "host3.local"]
+        );
+    }
+
+    #[test]
+    fn test_expand_hosts_cluster_with_brace_member() {
+        let hosts: Vec<&str> = vec!["clusterA"];
+        let clusters: Vec<Cluster> = vec![Cluster {
+            name: "clusterA".to_string(),
+            hosts: vec!["box{1..2}.local".to_string()],
+        }];
+        assert_eq!(
+            expand_hosts(hosts, &clusters),
+            vec!["box1.local", "box2.local"]
+        );
+    }
+
+    #[test]
+    fn test_expand_hosts_mixed_cluster_tag_and_brace() {
+        let hosts: Vec<&str> = vec!["clusterA", "edge{1..2}.local"];
+        let clusters: Vec<Cluster> = vec![Cluster {
+            name: "clusterA".to_string(),
+            hosts: vec!["a".to_string(), "b".to_string()],
+        }];
+        assert_eq!(
+            expand_hosts(hosts, &clusters),
+            vec!["a", "b", "edge1.local", "edge2.local"]
+        );
+    }
+
+    #[test]
+    fn test_expand_hosts_plain_hostnames_unchanged() {
+        let hosts: Vec<&str> = vec!["a.local", "b.local"];
+        let clusters: Vec<Cluster> = vec![];
+        assert_eq!(expand_hosts(hosts, &clusters), vec!["a.local", "b.local"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Hostname input typed after Ctrl+A, c was passed straight to
launch_clients after cluster-tag resolution, skipping the
bracoxide::explode step that the CLI path applies in daemon::main.
Entering `{1..10}.local` therefore produced a single client window
literally named `{1..10}.local` instead of ten expanded clients.

Add an `expand_hosts` helper that resolves cluster tags and then
explodes each resulting hostname individually, and call it from the
control-mode (VK_C, 0) arm. Per-host explode (vs. the CLI''s
join-then-explode) also handles mixed input like
`clusterA edge{1..2}.local` correctly, including brace expressions
that live inside cluster member definitions.

GitHub: #193
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
