### PR TITLE
control mode: add `[e]nable/disable input` submenu

### DIFF
--- a/news/195.feature.md
+++ b/news/195.feature.md
@@ -1,0 +1,4 @@
+Added a new `[e]nable/disable input` control-mode option that opens
+a submenu offering `[e]nable`, `[d]isable`, and `[t]oggle`. The first
+iteration scopes the action to the first client window; later
+iterations will introduce navigation across the cluster.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -46,7 +46,8 @@ use tokio::{
     task::JoinHandle,
 };
 use windows::Win32::System::Console::{
-    CONSOLE_CHARACTER_ATTRIBUTES, INPUT_RECORD_0, LEFT_CTRL_PRESSED, RIGHT_CTRL_PRESSED,
+    CONSOLE_CHARACTER_ATTRIBUTES, INPUT_RECORD_0, KEY_EVENT_RECORD, LEFT_CTRL_PRESSED,
+    RIGHT_CTRL_PRESSED,
 };
 
 use windows::Win32::UI::Input::KeyboardAndMouse::{
@@ -282,6 +283,29 @@ struct Daemon<'a> {
 }
 
 impl<'a> Daemon<'a> {
+    /// Builds a minimal [`Daemon`] suitable for unit tests.
+    ///
+    /// Populates every field with defaults that do not touch the
+    /// Windows API or the network. Tests pick the
+    /// [`ControlModeState`] they need to exercise; everything else
+    /// stays inert.
+    #[cfg(test)]
+    fn for_test(
+        config: &'a DaemonConfig,
+        clusters: &'a [Cluster],
+        control_mode_state: ControlModeState,
+    ) -> Self {
+        return Self {
+            hosts: Vec::new(),
+            username: None,
+            port: None,
+            config,
+            clusters,
+            control_mode_state,
+            debug: false,
+        };
+    }
+
     /// Launches all client windows and blocks on the main run loop.
     ///
     /// Sets up the daemon console by disabling processed input mode and applying
@@ -517,54 +541,7 @@ impl<'a> Daemon<'a> {
                 return;
             }
             if self.control_mode_state == ControlModeState::EnableDisableSubmenu {
-                match (
-                    VIRTUAL_KEY(key_event.wVirtualKeyCode),
-                    key_event.dwControlKeyState,
-                ) {
-                    (VK_E, 0) => {
-                        self.update_client_states(clients, |clients_guard| {
-                            return clients_guard
-                                .iter()
-                                .next()
-                                .map(|client| {
-                                    return vec![(client.process_id, ClientState::Active)];
-                                })
-                                .unwrap_or_default();
-                        });
-                        self.quit_control_mode(windows_api);
-                    }
-                    (VK_D, 0) => {
-                        self.update_client_states(clients, |clients_guard| {
-                            return clients_guard
-                                .iter()
-                                .next()
-                                .map(|client| {
-                                    return vec![(client.process_id, ClientState::Disabled)];
-                                })
-                                .unwrap_or_default();
-                        });
-                        self.quit_control_mode(windows_api);
-                    }
-                    (VK_T, 0) => {
-                        // Snapshot before flipping so the first client toggles
-                        // relative to its own pre-action state.
-                        self.update_client_states(clients, |clients_guard| {
-                            return clients_guard
-                                .iter()
-                                .next()
-                                .map(|client| {
-                                    let flipped = match *client.state_tx.borrow() {
-                                        ClientState::Active => ClientState::Disabled,
-                                        ClientState::Disabled => ClientState::Active,
-                                    };
-                                    return vec![(client.process_id, flipped)];
-                                })
-                                .unwrap_or_default();
-                        });
-                        self.quit_control_mode(windows_api);
-                    }
-                    _ => {}
-                }
+                self.handle_enable_disable_submenu_key(windows_api, clients, key_event);
                 return;
             }
             match (
@@ -794,6 +771,83 @@ impl<'a> Daemon<'a> {
                 valid_clients.len(),
                 self.config.aspect_ratio_adjustement,
             )
+        }
+    }
+
+    /// Dispatch a key press received while the daemon is in the
+    /// [`ControlModeState::EnableDisableSubmenu`] state.
+    ///
+    /// Matches the submenu's `[e]nable`, `[d]isable`, and `[t]oggle`
+    /// bindings; any other key is ignored and leaves the submenu
+    /// active. The first iteration scopes every action to the first
+    /// client window; later iterations will introduce navigation
+    /// across the cluster.
+    ///
+    /// After a recognised key, the submenu exits via
+    /// [`Daemon::quit_control_mode`] so the next keystroke returns to
+    /// forwarding clients normally.
+    ///
+    /// # Arguments
+    ///
+    /// * `windows_api` - The Windows API implementation to use.
+    /// * `clients`     - Shared client collection. Empty lists are a
+    ///                   no-op for `[e]`/`[d]`/`[t]` but still exit
+    ///                   the submenu.
+    /// * `key_event`   - The key-down [`KEY_EVENT_RECORD`] dispatched
+    ///                   from `handle_input_record`.
+    fn handle_enable_disable_submenu_key<W: WindowsApi>(
+        &mut self,
+        windows_api: &W,
+        clients: &Mutex<Clients>,
+        key_event: KEY_EVENT_RECORD,
+    ) {
+        match (
+            VIRTUAL_KEY(key_event.wVirtualKeyCode),
+            key_event.dwControlKeyState,
+        ) {
+            (VK_E, 0) => {
+                self.update_client_states(clients, |clients_guard| {
+                    return clients_guard
+                        .iter()
+                        .next()
+                        .map(|client| {
+                            return vec![(client.process_id, ClientState::Active)];
+                        })
+                        .unwrap_or_default();
+                });
+                self.quit_control_mode(windows_api);
+            }
+            (VK_D, 0) => {
+                self.update_client_states(clients, |clients_guard| {
+                    return clients_guard
+                        .iter()
+                        .next()
+                        .map(|client| {
+                            return vec![(client.process_id, ClientState::Disabled)];
+                        })
+                        .unwrap_or_default();
+                });
+                self.quit_control_mode(windows_api);
+            }
+            (VK_T, 0) => {
+                // Snapshot before flipping so the first client toggles
+                // relative to its own pre-action state.
+                self.update_client_states(clients, |clients_guard| {
+                    return clients_guard
+                        .iter()
+                        .next()
+                        .map(|client| {
+                            let flipped = match *client.state_tx.borrow() {
+                                ClientState::Active => ClientState::Disabled,
+                                ClientState::Disabled => ClientState::Active,
+                            };
+                            return vec![(client.process_id, flipped)];
+                        })
+                        .unwrap_or_default();
+                });
+                self.quit_control_mode(windows_api);
+            }
+            _ => {}
         }
     }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -50,7 +50,7 @@ use windows::Win32::System::Console::{
 };
 
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    VIRTUAL_KEY, VK_A, VK_C, VK_E, VK_ESCAPE, VK_H, VK_N, VK_R, VK_T,
+    VIRTUAL_KEY, VK_A, VK_C, VK_D, VK_E, VK_ESCAPE, VK_H, VK_N, VK_R, VK_T,
 };
 use windows::Win32::UI::WindowsAndMessaging::{SW_RESTORE, SW_SHOWMINIMIZED};
 use windows::Win32::{
@@ -245,6 +245,16 @@ enum ControlModeState {
     ///
     /// Active control mode prevents any input records from being sent to clients.
     Active,
+    /// The user opened the `[e]nable/disable input` submenu from
+    /// [`ControlModeState::Active`].
+    ///
+    /// The next non-`Esc` key is interpreted as the submenu action
+    /// (`[e]`, `[d]`, `[t]`) applied to the currently selected client.
+    /// The first iteration hardcodes the selection to the first client;
+    /// later iterations will introduce navigation across the cluster.
+    /// Like [`ControlModeState::Active`], this state suppresses input
+    /// forwarding to clients.
+    EnableDisableSubmenu,
 }
 
 /// The daemon is responsible to launch a client for
@@ -497,13 +507,64 @@ impl<'a> Daemon<'a> {
                 clear_screen(windows_api);
                 println!("Control Mode (Esc to exit)");
                 println!(
-                    "[c]reate window(s), [r]etile, [t]oggle enabled, e[n]able all, copy active [h]ostname(s)"
+                    "[c]reate window(s), [r]etile, [e]nable/disable input, [t]oggle enabled, e[n]able all, copy active [h]ostname(s)"
                 );
                 self.control_mode_state = ControlModeState::Active;
                 return;
             }
             let key_event = unsafe { input_record.KeyEvent };
             if !key_event.bKeyDown.as_bool() {
+                return;
+            }
+            if self.control_mode_state == ControlModeState::EnableDisableSubmenu {
+                match (
+                    VIRTUAL_KEY(key_event.wVirtualKeyCode),
+                    key_event.dwControlKeyState,
+                ) {
+                    (VK_E, 0) => {
+                        self.update_client_states(clients, |clients_guard| {
+                            return clients_guard
+                                .iter()
+                                .next()
+                                .map(|client| {
+                                    return vec![(client.process_id, ClientState::Active)];
+                                })
+                                .unwrap_or_default();
+                        });
+                        self.quit_control_mode(windows_api);
+                    }
+                    (VK_D, 0) => {
+                        self.update_client_states(clients, |clients_guard| {
+                            return clients_guard
+                                .iter()
+                                .next()
+                                .map(|client| {
+                                    return vec![(client.process_id, ClientState::Disabled)];
+                                })
+                                .unwrap_or_default();
+                        });
+                        self.quit_control_mode(windows_api);
+                    }
+                    (VK_T, 0) => {
+                        // Snapshot before flipping so the first client toggles
+                        // relative to its own pre-action state.
+                        self.update_client_states(clients, |clients_guard| {
+                            return clients_guard
+                                .iter()
+                                .next()
+                                .map(|client| {
+                                    let flipped = match *client.state_tx.borrow() {
+                                        ClientState::Active => ClientState::Disabled,
+                                        ClientState::Disabled => ClientState::Active,
+                                    };
+                                    return vec![(client.process_id, flipped)];
+                                })
+                                .unwrap_or_default();
+                        });
+                        self.quit_control_mode(windows_api);
+                    }
+                    _ => {}
+                }
                 return;
             }
             match (
@@ -519,7 +580,10 @@ impl<'a> Daemon<'a> {
                     self.arrange_daemon_console(windows_api, workspace_area);
                 }
                 (VK_E, 0) => {
-                    // TODO: Select windows
+                    clear_screen(windows_api);
+                    println!("Enable/Disable input (first window) (Esc to exit)");
+                    println!("[e]nable, [d]isable, [t]oggle");
+                    self.control_mode_state = ControlModeState::EnableDisableSubmenu;
                 }
                 (VK_T, 0) => {
                     // Snapshot before flipping so each client toggles relative
@@ -655,7 +719,9 @@ impl<'a> Daemon<'a> {
         input_record: INPUT_RECORD_0,
     ) -> bool {
         let key_event = unsafe { input_record.KeyEvent };
-        if self.control_mode_state == ControlModeState::Active {
+        if self.control_mode_state == ControlModeState::Active
+            || self.control_mode_state == ControlModeState::EnableDisableSubmenu
+        {
             if key_event.wVirtualKeyCode == VK_ESCAPE.0 {
                 self.quit_control_mode(windows_api);
                 return false;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -249,11 +249,14 @@ enum ControlModeState {
     /// The user opened the `[e]nable/disable input` submenu from
     /// [`ControlModeState::Active`].
     ///
-    /// The next non-`Esc` key is interpreted as the submenu action
-    /// (`[e]`, `[d]`, `[t]`) applied to the currently selected client.
-    /// The first iteration hardcodes the selection to the first client;
-    /// later iterations will introduce navigation across the cluster.
-    /// Like [`ControlModeState::Active`], this state suppresses input
+    /// While in this state, each non-`Esc` key is interpreted as a
+    /// submenu action (`[e]`, `[d]`, `[t]`) applied to the currently
+    /// selected client; unrecognised keys are ignored. The submenu
+    /// remains open after every key press and is left only via `Esc`,
+    /// which exits control mode entirely. The first iteration hardcodes
+    /// the selection to the first client; later iterations will
+    /// introduce navigation across the cluster. Like
+    /// [`ControlModeState::Active`], this state suppresses input
     /// forwarding to clients.
     EnableDisableSubmenu,
 }
@@ -779,13 +782,14 @@ impl<'a> Daemon<'a> {
     ///
     /// Matches the submenu's `[e]nable`, `[d]isable`, and `[t]oggle`
     /// bindings; any other key is ignored. The submenu stays open
-    /// after every key press (recognised or not) so the user can
-    /// navigate across clients and toggle them in sequence without
-    /// having to re-enter the submenu between actions. The submenu
-    /// is left only via `ESC`, which is handled by the caller. The
-    /// first iteration scopes every action to the first client
-    /// window; later iterations will introduce navigation across
-    /// the cluster.
+    /// after every key press (recognised or not) so subsequent
+    /// actions can be issued without having to re-enter the submenu
+    /// between them. The submenu is left only via `ESC`, which is
+    /// handled by the caller. The first iteration scopes every
+    /// action to the first client window; later iterations will
+    /// introduce navigation across the cluster, at which point
+    /// keeping the submenu open lets the user move between clients
+    /// and toggle them in sequence.
     ///
     /// # Arguments
     ///

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -541,7 +541,7 @@ impl<'a> Daemon<'a> {
                 return;
             }
             if self.control_mode_state == ControlModeState::EnableDisableSubmenu {
-                self.handle_enable_disable_submenu_key(windows_api, clients, key_event);
+                self.handle_enable_disable_submenu_key(clients, key_event);
                 return;
             }
             match (
@@ -778,26 +778,23 @@ impl<'a> Daemon<'a> {
     /// [`ControlModeState::EnableDisableSubmenu`] state.
     ///
     /// Matches the submenu's `[e]nable`, `[d]isable`, and `[t]oggle`
-    /// bindings; any other key is ignored and leaves the submenu
-    /// active. The first iteration scopes every action to the first
-    /// client window; later iterations will introduce navigation
-    /// across the cluster.
-    ///
-    /// After a recognised key, the submenu exits via
-    /// [`Daemon::quit_control_mode`] so the next keystroke returns to
-    /// forwarding clients normally.
+    /// bindings; any other key is ignored. The submenu stays open
+    /// after every key press (recognised or not) so the user can
+    /// navigate across clients and toggle them in sequence without
+    /// having to re-enter the submenu between actions. The submenu
+    /// is left only via `ESC`, which is handled by the caller. The
+    /// first iteration scopes every action to the first client
+    /// window; later iterations will introduce navigation across
+    /// the cluster.
     ///
     /// # Arguments
     ///
-    /// * `windows_api` - The Windows API implementation to use.
-    /// * `clients`     - Shared client collection. Empty lists are a
-    ///                   no-op for `[e]`/`[d]`/`[t]` but still exit
-    ///                   the submenu.
-    /// * `key_event`   - The key-down [`KEY_EVENT_RECORD`] dispatched
-    ///                   from `handle_input_record`.
-    fn handle_enable_disable_submenu_key<W: WindowsApi>(
+    /// * `clients`   - Shared client collection. Empty lists are a
+    ///                 no-op for `[e]`/`[d]`/`[t]`.
+    /// * `key_event` - The key-down [`KEY_EVENT_RECORD`] dispatched
+    ///                 from `handle_input_record`.
+    fn handle_enable_disable_submenu_key(
         &mut self,
-        windows_api: &W,
         clients: &Mutex<Clients>,
         key_event: KEY_EVENT_RECORD,
     ) {
@@ -815,7 +812,6 @@ impl<'a> Daemon<'a> {
                         })
                         .unwrap_or_default();
                 });
-                self.quit_control_mode(windows_api);
             }
             (VK_D, 0) => {
                 self.update_client_states(clients, |clients_guard| {
@@ -827,7 +823,6 @@ impl<'a> Daemon<'a> {
                         })
                         .unwrap_or_default();
                 });
-                self.quit_control_mode(windows_api);
             }
             (VK_T, 0) => {
                 // Snapshot before flipping so the first client toggles
@@ -845,7 +840,6 @@ impl<'a> Daemon<'a> {
                         })
                         .unwrap_or_default();
                 });
-                self.quit_control_mode(windows_api);
             }
             _ => {}
         }

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -10,9 +10,7 @@ mod daemon_test {
         sync::{broadcast, watch},
     };
     use windows::Win32::Foundation::{HANDLE, HWND};
-    use windows::Win32::System::Console::{
-        CONSOLE_SCREEN_BUFFER_INFO, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0,
-    };
+    use windows::Win32::System::Console::{KEY_EVENT_RECORD, KEY_EVENT_RECORD_0};
     use windows::Win32::UI::Input::KeyboardAndMouse::{VIRTUAL_KEY, VK_D, VK_E, VK_T, VK_X};
 
     use crate::{
@@ -28,7 +26,6 @@ mod daemon_test {
         utils::{
             config::{Cluster, DaemonConfig},
             constants::PIPE_NAME,
-            windows::MockWindowsApi,
         },
     };
 
@@ -1021,23 +1018,12 @@ mod daemon_test {
         };
     }
 
-    /// Registers the [`MockWindowsApi`] expectations required by
-    /// [`Daemon::quit_control_mode`] -> `print_instructions` ->
-    /// `clear_screen`. The daemon never blocks on these results in
-    /// tests, so any consistent stub is fine.
-    fn expect_quit_control_mode_console(api: &mut MockWindowsApi) {
-        api.expect_get_console_screen_buffer_info()
-            .returning(|| return Ok(CONSOLE_SCREEN_BUFFER_INFO::default()));
-        api.expect_scroll_console_screen_buffer()
-            .returning(|_, _, _| return Ok(()));
-        api.expect_set_console_cursor_position()
-            .returning(|_| return Ok(()));
-    }
-
-    /// Verifies that `VK_E` in the enable/disable submenu enables only
-    /// the first client and exits control mode.
+    /// Verifies that `VK_E` in the enable/disable submenu enables
+    /// only the first client and keeps the submenu open so the user
+    /// can chain further enable/disable/toggle actions across
+    /// clients without re-entering the submenu.
     #[test]
-    fn test_submenu_e_enables_only_first_client() {
+    fn test_submenu_e_enables_only_first_client_and_stays_open() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Disabled));
         clients.push(make_client_with_state(2, ClientState::Disabled));
@@ -1049,10 +1035,7 @@ mod daemon_test {
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
 
-        let mut mock_api = MockWindowsApi::new();
-        expect_quit_control_mode_console(&mut mock_api);
-
-        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_E));
+        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_E));
 
         assert_eq!(
             snapshot_states(&clients.lock().unwrap()),
@@ -1062,13 +1045,18 @@ mod daemon_test {
                 ClientState::Disabled,
             ]
         );
-        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
+        assert_eq!(
+            daemon.control_mode_state,
+            ControlModeState::EnableDisableSubmenu
+        );
     }
 
     /// Verifies that `VK_D` in the enable/disable submenu disables
-    /// only the first client and exits control mode.
+    /// only the first client and keeps the submenu open so the user
+    /// can chain further enable/disable/toggle actions across
+    /// clients without re-entering the submenu.
     #[test]
-    fn test_submenu_d_disables_only_first_client() {
+    fn test_submenu_d_disables_only_first_client_and_stays_open() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Active));
         clients.push(make_client_with_state(2, ClientState::Active));
@@ -1080,10 +1068,7 @@ mod daemon_test {
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
 
-        let mut mock_api = MockWindowsApi::new();
-        expect_quit_control_mode_console(&mut mock_api);
-
-        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_D));
+        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_D));
 
         assert_eq!(
             snapshot_states(&clients.lock().unwrap()),
@@ -1093,15 +1078,18 @@ mod daemon_test {
                 ClientState::Active,
             ]
         );
-        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
+        assert_eq!(
+            daemon.control_mode_state,
+            ControlModeState::EnableDisableSubmenu
+        );
     }
 
     /// Verifies that `VK_T` in the enable/disable submenu flips only
-    /// the first client's state and is its own inverse over two
-    /// invocations. Each invocation also exits control mode, so the
-    /// test re-enters the submenu before the second press.
+    /// the first client's state, keeps the submenu open after the
+    /// flip, and is its own inverse over two consecutive presses
+    /// without needing to re-enter the submenu in between.
     #[test]
-    fn test_submenu_t_toggles_only_first_client() {
+    fn test_submenu_t_toggles_only_first_client_and_stays_open() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Active));
         clients.push(make_client_with_state(2, ClientState::Disabled));
@@ -1115,10 +1103,7 @@ mod daemon_test {
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
 
-        let mut mock_api = MockWindowsApi::new();
-        expect_quit_control_mode_console(&mut mock_api);
-
-        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_T));
+        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_T));
         assert_eq!(
             snapshot_states(&clients.lock().unwrap()),
             vec![
@@ -1127,12 +1112,20 @@ mod daemon_test {
                 ClientState::Active,
             ]
         );
-        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
+        assert_eq!(
+            daemon.control_mode_state,
+            ControlModeState::EnableDisableSubmenu
+        );
 
-        daemon.control_mode_state = ControlModeState::EnableDisableSubmenu;
-        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_T));
+        // Second press without re-entering the submenu: the submenu
+        // must still be open from the first press, and the toggle is
+        // its own inverse.
+        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_T));
         assert_eq!(snapshot_states(&clients.lock().unwrap()), initial);
-        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
+        assert_eq!(
+            daemon.control_mode_state,
+            ControlModeState::EnableDisableSubmenu
+        );
     }
 
     /// Verifies that an unrecognised key in the enable/disable
@@ -1152,9 +1145,7 @@ mod daemon_test {
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
 
-        let mock_api = MockWindowsApi::new();
-
-        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_X));
+        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_X));
 
         assert_eq!(snapshot_states(&clients.lock().unwrap()), initial);
         assert_eq!(
@@ -1164,8 +1155,8 @@ mod daemon_test {
     }
 
     /// Verifies that pressing `VK_E` with no clients tracked is a
-    /// no-op for the client list (and does not panic) while still
-    /// exiting control mode.
+    /// no-op for the client list (and does not panic) while leaving
+    /// the submenu open for the next press.
     #[test]
     fn test_submenu_no_panic_with_empty_clients() {
         let clients = Mutex::new(Clients::new());
@@ -1175,12 +1166,12 @@ mod daemon_test {
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
 
-        let mut mock_api = MockWindowsApi::new();
-        expect_quit_control_mode_console(&mut mock_api);
-
-        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_E));
+        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_E));
 
         assert!(clients.lock().unwrap().iter().next().is_none());
-        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
+        assert_eq!(
+            daemon.control_mode_state,
+            ControlModeState::EnableDisableSubmenu
+        );
     }
 }

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -990,4 +990,142 @@ mod daemon_test {
         toggle(&clients);
         assert_eq!(snapshot(&clients), initial);
     }
+
+    /// Collects every client's [`ClientState`] in insertion order.
+    fn snapshot_states(clients: &Clients) -> Vec<ClientState> {
+        return clients
+            .iter()
+            .map(|client| return *client.state_tx.borrow())
+            .collect();
+    }
+
+    /// Applies the `(pid, state)` updates the
+    /// `EnableDisableSubmenu` arms build, by writing through each
+    /// client's [`watch::Sender`].
+    ///
+    /// Mirrors the apply phase of
+    /// [`crate::daemon::Daemon::update_client_states`] without
+    /// standing up a full [`crate::daemon::Daemon`].
+    fn apply_first_client_updates(clients: &Clients, updates: Vec<(u32, ClientState)>) {
+        for (pid, state) in updates {
+            if let Some(client) = clients.get_by_pid(pid) {
+                client.state_tx.send_replace(state);
+            }
+        }
+    }
+
+    /// Builds the `(pid, ClientState::Active)` update list the
+    /// `EnableDisableSubmenu`'s `VK_E` arm produces.
+    fn enable_first_client_updates(clients: &Clients) -> Vec<(u32, ClientState)> {
+        return clients
+            .iter()
+            .next()
+            .map(|client| return vec![(client.process_id, ClientState::Active)])
+            .unwrap_or_default();
+    }
+
+    /// Builds the `(pid, ClientState::Disabled)` update list the
+    /// `EnableDisableSubmenu`'s `VK_D` arm produces.
+    fn disable_first_client_updates(clients: &Clients) -> Vec<(u32, ClientState)> {
+        return clients
+            .iter()
+            .next()
+            .map(|client| return vec![(client.process_id, ClientState::Disabled)])
+            .unwrap_or_default();
+    }
+
+    /// Builds the `(pid, flipped)` update list the
+    /// `EnableDisableSubmenu`'s `VK_T` arm produces by snapshotting
+    /// the current first-client state.
+    fn toggle_first_client_updates(clients: &Clients) -> Vec<(u32, ClientState)> {
+        return clients
+            .iter()
+            .next()
+            .map(|client| {
+                let flipped = match *client.state_tx.borrow() {
+                    ClientState::Active => ClientState::Disabled,
+                    ClientState::Disabled => ClientState::Active,
+                };
+                return vec![(client.process_id, flipped)];
+            })
+            .unwrap_or_default();
+    }
+
+    /// Verifies the `EnableDisableSubmenu`'s `VK_E` arm only enables
+    /// the first client and leaves the rest of the cluster untouched.
+    #[test]
+    fn test_first_window_enable_only_affects_first_client() {
+        let mut clients = Clients::new();
+        clients.push(make_client_with_state(1, ClientState::Disabled));
+        clients.push(make_client_with_state(2, ClientState::Disabled));
+        clients.push(make_client_with_state(3, ClientState::Disabled));
+
+        apply_first_client_updates(&clients, enable_first_client_updates(&clients));
+
+        assert_eq!(
+            snapshot_states(&clients),
+            vec![
+                ClientState::Active,
+                ClientState::Disabled,
+                ClientState::Disabled,
+            ]
+        );
+    }
+
+    /// Verifies the `EnableDisableSubmenu`'s `VK_D` arm only disables
+    /// the first client and leaves the rest of the cluster untouched.
+    #[test]
+    fn test_first_window_disable_only_affects_first_client() {
+        let mut clients = Clients::new();
+        clients.push(make_client_with_state(1, ClientState::Active));
+        clients.push(make_client_with_state(2, ClientState::Active));
+        clients.push(make_client_with_state(3, ClientState::Active));
+
+        apply_first_client_updates(&clients, disable_first_client_updates(&clients));
+
+        assert_eq!(
+            snapshot_states(&clients),
+            vec![
+                ClientState::Disabled,
+                ClientState::Active,
+                ClientState::Active,
+            ]
+        );
+    }
+
+    /// Verifies the `EnableDisableSubmenu`'s `VK_T` arm flips only the
+    /// first client and is its own inverse over two invocations.
+    #[test]
+    fn test_first_window_toggle_only_affects_first_client() {
+        let mut clients = Clients::new();
+        clients.push(make_client_with_state(1, ClientState::Active));
+        clients.push(make_client_with_state(2, ClientState::Disabled));
+        clients.push(make_client_with_state(3, ClientState::Active));
+
+        let initial = snapshot_states(&clients);
+
+        apply_first_client_updates(&clients, toggle_first_client_updates(&clients));
+        assert_eq!(
+            snapshot_states(&clients),
+            vec![
+                ClientState::Disabled,
+                ClientState::Disabled,
+                ClientState::Active,
+            ]
+        );
+
+        apply_first_client_updates(&clients, toggle_first_client_updates(&clients));
+        assert_eq!(snapshot_states(&clients), initial);
+    }
+
+    /// Verifies the submenu update builders are no-ops when the
+    /// client list is empty - i.e. the daemon never panics if the
+    /// user opens the submenu before any client has launched.
+    #[test]
+    fn test_first_window_submenu_updates_are_empty_for_empty_clients() {
+        let clients = Clients::new();
+        assert!(enable_first_client_updates(&clients).is_empty());
+        assert!(disable_first_client_updates(&clients).is_empty());
+        assert!(toggle_first_client_updates(&clients).is_empty());
+    }
 }

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -10,18 +10,26 @@ mod daemon_test {
         sync::{broadcast, watch},
     };
     use windows::Win32::Foundation::{HANDLE, HWND};
+    use windows::Win32::System::Console::{
+        CONSOLE_SCREEN_BUFFER_INFO, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0,
+    };
+    use windows::Win32::UI::Input::KeyboardAndMouse::{VIRTUAL_KEY, VK_D, VK_E, VK_T, VK_X};
 
     use crate::{
         daemon::{
             expand_hosts, named_pipe_server_routine, resolve_cluster_tags, Client, Clients,
-            HWNDWrapper,
+            ControlModeState, Daemon, HWNDWrapper,
         },
         protocol::{
             serialization::serialize_pid, ClientState, FRAMED_INPUT_RECORD_LENGTH,
             FRAMED_KEEP_ALIVE_LENGTH, FRAMED_STATE_CHANGE_LENGTH, SERIALIZED_INPUT_RECORD_0_LENGTH,
             SERIALIZED_PID_LENGTH, TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
         },
-        utils::{config::Cluster, constants::PIPE_NAME},
+        utils::{
+            config::{Cluster, DaemonConfig},
+            constants::PIPE_NAME,
+            windows::MockWindowsApi,
+        },
     };
 
     /// Send `pid` as a 4 byte little-endian sequence to the pipe server.
@@ -999,133 +1007,180 @@ mod daemon_test {
             .collect();
     }
 
-    /// Applies the `(pid, state)` updates the
-    /// `EnableDisableSubmenu` arms build, by writing through each
-    /// client's [`watch::Sender`].
-    ///
-    /// Mirrors the apply phase of
-    /// [`crate::daemon::Daemon::update_client_states`] without
-    /// standing up a full [`crate::daemon::Daemon`].
-    fn apply_first_client_updates(clients: &Clients, updates: Vec<(u32, ClientState)>) {
-        for (pid, state) in updates {
-            if let Some(client) = clients.get_by_pid(pid) {
-                client.state_tx.send_replace(state);
-            }
-        }
+    /// Builds a [`KEY_EVENT_RECORD`] for a key-down press with no
+    /// active modifier bits, mirroring the matcher used by the
+    /// submenu's `[e]`/`[d]`/`[t]` arms.
+    fn submenu_key_event(virtual_key: VIRTUAL_KEY) -> KEY_EVENT_RECORD {
+        return KEY_EVENT_RECORD {
+            bKeyDown: true.into(),
+            wRepeatCount: 1,
+            wVirtualKeyCode: virtual_key.0,
+            wVirtualScanCode: 0,
+            uChar: KEY_EVENT_RECORD_0 { UnicodeChar: 0 },
+            dwControlKeyState: 0,
+        };
     }
 
-    /// Builds the `(pid, ClientState::Active)` update list the
-    /// `EnableDisableSubmenu`'s `VK_E` arm produces.
-    fn enable_first_client_updates(clients: &Clients) -> Vec<(u32, ClientState)> {
-        return clients
-            .iter()
-            .next()
-            .map(|client| return vec![(client.process_id, ClientState::Active)])
-            .unwrap_or_default();
+    /// Registers the [`MockWindowsApi`] expectations required by
+    /// [`Daemon::quit_control_mode`] -> `print_instructions` ->
+    /// `clear_screen`. The daemon never blocks on these results in
+    /// tests, so any consistent stub is fine.
+    fn expect_quit_control_mode_console(api: &mut MockWindowsApi) {
+        api.expect_get_console_screen_buffer_info()
+            .returning(|| return Ok(CONSOLE_SCREEN_BUFFER_INFO::default()));
+        api.expect_scroll_console_screen_buffer()
+            .returning(|_, _, _| return Ok(()));
+        api.expect_set_console_cursor_position()
+            .returning(|_| return Ok(()));
     }
 
-    /// Builds the `(pid, ClientState::Disabled)` update list the
-    /// `EnableDisableSubmenu`'s `VK_D` arm produces.
-    fn disable_first_client_updates(clients: &Clients) -> Vec<(u32, ClientState)> {
-        return clients
-            .iter()
-            .next()
-            .map(|client| return vec![(client.process_id, ClientState::Disabled)])
-            .unwrap_or_default();
-    }
-
-    /// Builds the `(pid, flipped)` update list the
-    /// `EnableDisableSubmenu`'s `VK_T` arm produces by snapshotting
-    /// the current first-client state.
-    fn toggle_first_client_updates(clients: &Clients) -> Vec<(u32, ClientState)> {
-        return clients
-            .iter()
-            .next()
-            .map(|client| {
-                let flipped = match *client.state_tx.borrow() {
-                    ClientState::Active => ClientState::Disabled,
-                    ClientState::Disabled => ClientState::Active,
-                };
-                return vec![(client.process_id, flipped)];
-            })
-            .unwrap_or_default();
-    }
-
-    /// Verifies the `EnableDisableSubmenu`'s `VK_E` arm only enables
-    /// the first client and leaves the rest of the cluster untouched.
+    /// Verifies that `VK_E` in the enable/disable submenu enables only
+    /// the first client and exits control mode.
     #[test]
-    fn test_first_window_enable_only_affects_first_client() {
+    fn test_submenu_e_enables_only_first_client() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Disabled));
         clients.push(make_client_with_state(2, ClientState::Disabled));
         clients.push(make_client_with_state(3, ClientState::Disabled));
+        let clients = Mutex::new(clients);
 
-        apply_first_client_updates(&clients, enable_first_client_updates(&clients));
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+
+        let mut mock_api = MockWindowsApi::new();
+        expect_quit_control_mode_console(&mut mock_api);
+
+        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_E));
 
         assert_eq!(
-            snapshot_states(&clients),
+            snapshot_states(&clients.lock().unwrap()),
             vec![
                 ClientState::Active,
                 ClientState::Disabled,
                 ClientState::Disabled,
             ]
         );
+        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
     }
 
-    /// Verifies the `EnableDisableSubmenu`'s `VK_D` arm only disables
-    /// the first client and leaves the rest of the cluster untouched.
+    /// Verifies that `VK_D` in the enable/disable submenu disables
+    /// only the first client and exits control mode.
     #[test]
-    fn test_first_window_disable_only_affects_first_client() {
+    fn test_submenu_d_disables_only_first_client() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Active));
         clients.push(make_client_with_state(2, ClientState::Active));
         clients.push(make_client_with_state(3, ClientState::Active));
+        let clients = Mutex::new(clients);
 
-        apply_first_client_updates(&clients, disable_first_client_updates(&clients));
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+
+        let mut mock_api = MockWindowsApi::new();
+        expect_quit_control_mode_console(&mut mock_api);
+
+        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_D));
 
         assert_eq!(
-            snapshot_states(&clients),
+            snapshot_states(&clients.lock().unwrap()),
             vec![
                 ClientState::Disabled,
                 ClientState::Active,
                 ClientState::Active,
             ]
         );
+        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
     }
 
-    /// Verifies the `EnableDisableSubmenu`'s `VK_T` arm flips only the
-    /// first client and is its own inverse over two invocations.
+    /// Verifies that `VK_T` in the enable/disable submenu flips only
+    /// the first client's state and is its own inverse over two
+    /// invocations. Each invocation also exits control mode, so the
+    /// test re-enters the submenu before the second press.
     #[test]
-    fn test_first_window_toggle_only_affects_first_client() {
+    fn test_submenu_t_toggles_only_first_client() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Active));
         clients.push(make_client_with_state(2, ClientState::Disabled));
         clients.push(make_client_with_state(3, ClientState::Active));
+        let clients = Mutex::new(clients);
 
-        let initial = snapshot_states(&clients);
+        let initial = snapshot_states(&clients.lock().unwrap());
 
-        apply_first_client_updates(&clients, toggle_first_client_updates(&clients));
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+
+        let mut mock_api = MockWindowsApi::new();
+        expect_quit_control_mode_console(&mut mock_api);
+
+        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_T));
         assert_eq!(
-            snapshot_states(&clients),
+            snapshot_states(&clients.lock().unwrap()),
             vec![
                 ClientState::Disabled,
                 ClientState::Disabled,
                 ClientState::Active,
             ]
         );
+        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
 
-        apply_first_client_updates(&clients, toggle_first_client_updates(&clients));
-        assert_eq!(snapshot_states(&clients), initial);
+        daemon.control_mode_state = ControlModeState::EnableDisableSubmenu;
+        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_T));
+        assert_eq!(snapshot_states(&clients.lock().unwrap()), initial);
+        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
     }
 
-    /// Verifies the submenu update builders are no-ops when the
-    /// client list is empty - i.e. the daemon never panics if the
-    /// user opens the submenu before any client has launched.
+    /// Verifies that an unrecognised key in the enable/disable
+    /// submenu leaves every client state unchanged and keeps the
+    /// submenu open for the next press.
     #[test]
-    fn test_first_window_submenu_updates_are_empty_for_empty_clients() {
-        let clients = Clients::new();
-        assert!(enable_first_client_updates(&clients).is_empty());
-        assert!(disable_first_client_updates(&clients).is_empty());
-        assert!(toggle_first_client_updates(&clients).is_empty());
+    fn test_submenu_ignores_unmapped_key() {
+        let mut clients = Clients::new();
+        clients.push(make_client_with_state(1, ClientState::Active));
+        clients.push(make_client_with_state(2, ClientState::Disabled));
+        let clients = Mutex::new(clients);
+
+        let initial = snapshot_states(&clients.lock().unwrap());
+
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+
+        let mock_api = MockWindowsApi::new();
+
+        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_X));
+
+        assert_eq!(snapshot_states(&clients.lock().unwrap()), initial);
+        assert_eq!(
+            daemon.control_mode_state,
+            ControlModeState::EnableDisableSubmenu
+        );
+    }
+
+    /// Verifies that pressing `VK_E` with no clients tracked is a
+    /// no-op for the client list (and does not panic) while still
+    /// exiting control mode.
+    #[test]
+    fn test_submenu_no_panic_with_empty_clients() {
+        let clients = Mutex::new(Clients::new());
+
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+
+        let mut mock_api = MockWindowsApi::new();
+        expect_quit_control_mode_console(&mut mock_api);
+
+        daemon.handle_enable_disable_submenu_key(&mock_api, &clients, submenu_key_event(VK_E));
+
+        assert!(clients.lock().unwrap().iter().next().is_none());
+        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
     }
 }


### PR DESCRIPTION
Adds the `[e]nable/disable input` control mode.
Pressing `e` from the main control-mode menu now
opens a submenu offering `[e]nable`, `[d]isable`, and `[t]oggle`.

The first iteration scopes every submenu action to the first
client window so the new state machine and key bindings land
without committing to a window-selection UX. Later iterations
will replace the hardcoded `clients.iter().next()` with arrow /
hjkl navigation across the cluster, matching the csshX prompt
("Arrow keys, h,j,k,l - Change window selection").

GitHub: #12
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
