### PR TITLE
control mode: mask dwControlKeyState before key dispatch

### DIFF
--- a/news/196.bugfix.md
+++ b/news/196.bugfix.md
@@ -1,0 +1,5 @@
+Fixed control-mode keys silently doing nothing when CapsLock, NumLock,
+or any other lock toggle was engaged. The dispatch now masks
+`dwControlKeyState` down to the actual modifier bits (Ctrl/Alt/Shift)
+before matching, so all control mode options (e.g. `[c]reate window(s)`)
+work regardless of lock state.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -46,8 +46,8 @@ use tokio::{
     task::JoinHandle,
 };
 use windows::Win32::System::Console::{
-    CONSOLE_CHARACTER_ATTRIBUTES, INPUT_RECORD_0, KEY_EVENT_RECORD, LEFT_CTRL_PRESSED,
-    RIGHT_CTRL_PRESSED,
+    CONSOLE_CHARACTER_ATTRIBUTES, INPUT_RECORD_0, KEY_EVENT_RECORD, LEFT_ALT_PRESSED,
+    LEFT_CTRL_PRESSED, RIGHT_ALT_PRESSED, RIGHT_CTRL_PRESSED, SHIFT_PRESSED,
 };
 
 use windows::Win32::UI::Input::KeyboardAndMouse::{
@@ -67,6 +67,119 @@ mod workspace;
 /// to send the input records read from the console input buffer
 /// to the named pipe servers connected to each client in parallel.
 const SENDER_CAPACITY: usize = 1024 * 1024;
+
+/// Bits in `KEY_EVENT_RECORD::dwControlKeyState` that represent
+/// "real" modifier keys (Ctrl / Alt / Shift) as opposed to lock
+/// toggles (`CAPSLOCK_ON`, `NUMLOCK_ON`, `SCROLLLOCK_ON`) or the
+/// `ENHANCED_KEY` flag.
+///
+/// Control-mode key classification ANDs `dwControlKeyState` with
+/// this mask before matching; otherwise an enabled CapsLock or
+/// NumLock would make `dwControlKeyState` non-zero and silently
+/// skip every `(VK_*, 0)` arm.
+const MODIFIER_MASK: u32 =
+    LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED | SHIFT_PRESSED;
+
+/// Top-level control-mode action a keystroke classifies into.
+///
+/// Extracted from [`Daemon::handle_input_record`]'s dispatch match
+/// so the classification - including the [`MODIFIER_MASK`] step -
+/// can be regression tested without instantiating a full
+/// [`Daemon`].
+#[derive(Debug, PartialEq, Eq)]
+enum ControlModeAction {
+    /// `[r]` - rearrange every client window.
+    Retile,
+    /// `[e]` - open the enable/disable input submenu.
+    OpenEnableDisableSubmenu,
+    /// `[t]` - flip each client's [`ClientState`].
+    ToggleEnabled,
+    /// `[n]` - force every client back to [`ClientState::Active`].
+    EnableAll,
+    /// `[c]` - prompt for new hostnames and launch additional clients.
+    CreateWindows,
+    /// `[h]` - copy the active clients' hostnames to the clipboard.
+    CopyHostnames,
+    /// Any other key in the active control-mode prompt.
+    NoOp,
+}
+
+/// Enable/disable-submenu action a keystroke classifies into.
+///
+/// Extracted from [`Daemon::handle_enable_disable_submenu_key`]'s
+/// dispatch match for the same reason as [`ControlModeAction`].
+#[derive(Debug, PartialEq, Eq)]
+enum EnableDisableSubmenuAction {
+    /// `[e]` - force the targeted client(s) to [`ClientState::Active`].
+    Enable,
+    /// `[d]` - force the targeted client(s) to [`ClientState::Disabled`].
+    Disable,
+    /// `[t]` - flip the targeted client(s)' [`ClientState`].
+    Toggle,
+    /// Any other key while the submenu is open.
+    NoOp,
+}
+
+/// Classifies a top-level control-mode keystroke.
+///
+/// `control_key_state` is ANDed with [`MODIFIER_MASK`] so lock
+/// toggles (`CAPSLOCK_ON`, `NUMLOCK_ON`, `SCROLLLOCK_ON`) and the
+/// `ENHANCED_KEY` flag never bleed into the match - the
+/// `(VK_*, 0)` arms must still fire while any of those bits are
+/// set. Any "real" modifier bit (Ctrl / Alt / Shift) survives the
+/// mask and falls through to [`ControlModeAction::NoOp`].
+///
+/// # Arguments
+///
+/// * `virtual_key`       - The pressed key's [`VIRTUAL_KEY`].
+/// * `control_key_state` - The raw `dwControlKeyState` field from
+///                         the [`KEY_EVENT_RECORD`].
+///
+/// # Returns
+///
+/// The [`ControlModeAction`] the dispatch should execute.
+fn classify_control_mode_key(
+    virtual_key: VIRTUAL_KEY,
+    control_key_state: u32,
+) -> ControlModeAction {
+    return match (virtual_key, control_key_state & MODIFIER_MASK) {
+        (VK_R, 0) => ControlModeAction::Retile,
+        (VK_E, 0) => ControlModeAction::OpenEnableDisableSubmenu,
+        (VK_T, 0) => ControlModeAction::ToggleEnabled,
+        (VK_N, 0) => ControlModeAction::EnableAll,
+        (VK_C, 0) => ControlModeAction::CreateWindows,
+        (VK_H, 0) => ControlModeAction::CopyHostnames,
+        _ => ControlModeAction::NoOp,
+    };
+}
+
+/// Classifies an enable/disable-submenu keystroke.
+///
+/// See [`classify_control_mode_key`] for the [`MODIFIER_MASK`]
+/// rationale; the same lock-state / `ENHANCED_KEY` masking applies
+/// to the submenu so its `[e]`, `[d]`, `[t]` bindings keep working
+/// regardless of lock state.
+///
+/// # Arguments
+///
+/// * `virtual_key`       - The pressed key's [`VIRTUAL_KEY`].
+/// * `control_key_state` - The raw `dwControlKeyState` field from
+///                         the [`KEY_EVENT_RECORD`].
+///
+/// # Returns
+///
+/// The [`EnableDisableSubmenuAction`] the dispatch should execute.
+fn classify_enable_disable_submenu_key(
+    virtual_key: VIRTUAL_KEY,
+    control_key_state: u32,
+) -> EnableDisableSubmenuAction {
+    return match (virtual_key, control_key_state & MODIFIER_MASK) {
+        (VK_E, 0) => EnableDisableSubmenuAction::Enable,
+        (VK_D, 0) => EnableDisableSubmenuAction::Disable,
+        (VK_T, 0) => EnableDisableSubmenuAction::Toggle,
+        _ => EnableDisableSubmenuAction::NoOp,
+    };
+}
 
 /// Representation of a client
 #[derive(Clone)]
@@ -547,11 +660,11 @@ impl<'a> Daemon<'a> {
                 self.handle_enable_disable_submenu_key(clients, key_event);
                 return;
             }
-            match (
+            match classify_control_mode_key(
                 VIRTUAL_KEY(key_event.wVirtualKeyCode),
                 key_event.dwControlKeyState,
             ) {
-                (VK_R, 0) => {
+                ControlModeAction::Retile => {
                     self.rearrange_client_windows(
                         windows_api,
                         &clients.lock().unwrap(),
@@ -559,13 +672,13 @@ impl<'a> Daemon<'a> {
                     );
                     self.arrange_daemon_console(windows_api, workspace_area);
                 }
-                (VK_E, 0) => {
+                ControlModeAction::OpenEnableDisableSubmenu => {
                     clear_screen(windows_api);
                     println!("Enable/Disable input (first window) (Esc to exit)");
                     println!("[e]nable, [d]isable, [t]oggle");
                     self.control_mode_state = ControlModeState::EnableDisableSubmenu;
                 }
-                (VK_T, 0) => {
+                ControlModeAction::ToggleEnabled => {
                     // Snapshot before flipping so each client toggles relative
                     // to its own pre-loop state, not to writes this loop has
                     // already made.
@@ -583,7 +696,7 @@ impl<'a> Daemon<'a> {
                     });
                     self.quit_control_mode(windows_api);
                 }
-                (VK_N, 0) => {
+                ControlModeAction::EnableAll => {
                     self.update_client_states(clients, |clients_guard| {
                         return clients_guard
                             .iter()
@@ -592,7 +705,7 @@ impl<'a> Daemon<'a> {
                     });
                     self.quit_control_mode(windows_api);
                 }
-                (VK_C, 0) => {
+                ControlModeAction::CreateWindows => {
                     clear_screen(windows_api);
                     // TODO: make ESC abort
                     println!("Hostname(s) or cluster tag(s): (leave empty to abort)");
@@ -644,7 +757,7 @@ impl<'a> Daemon<'a> {
                     let _ = windows_api.focus_window_with_automation(daemon_window);
                     self.quit_control_mode(windows_api);
                 }
-                (VK_H, 0) => {
+                ControlModeAction::CopyHostnames => {
                     let mut active_hostnames: Vec<String> = vec![];
                     for client in clients.lock().unwrap().iter() {
                         if windows_api.is_window(client.window_handle) {
@@ -654,7 +767,7 @@ impl<'a> Daemon<'a> {
                     cli_clipboard::set_contents(active_hostnames.join(" ")).unwrap();
                     self.quit_control_mode(windows_api);
                 }
-                _ => {}
+                ControlModeAction::NoOp => {}
             }
             return;
         }
@@ -802,11 +915,11 @@ impl<'a> Daemon<'a> {
         clients: &Mutex<Clients>,
         key_event: KEY_EVENT_RECORD,
     ) {
-        match (
+        match classify_enable_disable_submenu_key(
             VIRTUAL_KEY(key_event.wVirtualKeyCode),
             key_event.dwControlKeyState,
         ) {
-            (VK_E, 0) => {
+            EnableDisableSubmenuAction::Enable => {
                 self.update_client_states(clients, |clients_guard| {
                     return clients_guard
                         .iter()
@@ -817,7 +930,7 @@ impl<'a> Daemon<'a> {
                         .unwrap_or_default();
                 });
             }
-            (VK_D, 0) => {
+            EnableDisableSubmenuAction::Disable => {
                 self.update_client_states(clients, |clients_guard| {
                     return clients_guard
                         .iter()
@@ -828,7 +941,7 @@ impl<'a> Daemon<'a> {
                         .unwrap_or_default();
                 });
             }
-            (VK_T, 0) => {
+            EnableDisableSubmenuAction::Toggle => {
                 // Snapshot before flipping so the first client toggles
                 // relative to its own pre-action state.
                 self.update_client_states(clients, |clients_guard| {
@@ -845,7 +958,7 @@ impl<'a> Daemon<'a> {
                         .unwrap_or_default();
                 });
             }
-            _ => {}
+            EnableDisableSubmenuAction::NoOp => {}
         }
     }
 

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -10,13 +10,20 @@ mod daemon_test {
         sync::{broadcast, watch},
     };
     use windows::Win32::Foundation::{HANDLE, HWND};
-    use windows::Win32::System::Console::{KEY_EVENT_RECORD, KEY_EVENT_RECORD_0};
-    use windows::Win32::UI::Input::KeyboardAndMouse::{VIRTUAL_KEY, VK_D, VK_E, VK_T, VK_X};
+    use windows::Win32::System::Console::{
+        CAPSLOCK_ON, ENHANCED_KEY, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0, LEFT_ALT_PRESSED,
+        LEFT_CTRL_PRESSED, NUMLOCK_ON, RIGHT_ALT_PRESSED, RIGHT_CTRL_PRESSED, SCROLLLOCK_ON,
+        SHIFT_PRESSED,
+    };
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        VIRTUAL_KEY, VK_C, VK_D, VK_E, VK_H, VK_N, VK_R, VK_T, VK_X,
+    };
 
     use crate::{
         daemon::{
-            expand_hosts, named_pipe_server_routine, resolve_cluster_tags, Client, Clients,
-            ControlModeState, Daemon, HWNDWrapper,
+            classify_control_mode_key, classify_enable_disable_submenu_key, expand_hosts,
+            named_pipe_server_routine, resolve_cluster_tags, Client, Clients, ControlModeAction,
+            ControlModeState, Daemon, EnableDisableSubmenuAction, HWNDWrapper,
         },
         protocol::{
             serialization::serialize_pid, ClientState, FRAMED_INPUT_RECORD_LENGTH,
@@ -1008,13 +1015,23 @@ mod daemon_test {
     /// active modifier bits, mirroring the matcher used by the
     /// submenu's `[e]`/`[d]`/`[t]` arms.
     fn submenu_key_event(virtual_key: VIRTUAL_KEY) -> KEY_EVENT_RECORD {
+        return submenu_key_event_with_state(virtual_key, 0);
+    }
+
+    /// Same as [`submenu_key_event`] but with a caller-supplied
+    /// `dwControlKeyState`. Used by the GH #196 regression to drive
+    /// the submenu with lock-state bits engaged.
+    fn submenu_key_event_with_state(
+        virtual_key: VIRTUAL_KEY,
+        control_key_state: u32,
+    ) -> KEY_EVENT_RECORD {
         return KEY_EVENT_RECORD {
             bKeyDown: true.into(),
             wRepeatCount: 1,
             wVirtualKeyCode: virtual_key.0,
             wVirtualScanCode: 0,
             uChar: KEY_EVENT_RECORD_0 { UnicodeChar: 0 },
-            dwControlKeyState: 0,
+            dwControlKeyState: control_key_state,
         };
     }
 
@@ -1169,6 +1186,120 @@ mod daemon_test {
         daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_E));
 
         assert!(clients.lock().unwrap().iter().next().is_none());
+        assert_eq!(
+            daemon.control_mode_state,
+            ControlModeState::EnableDisableSubmenu
+        );
+    }
+
+    /// Regression for GH #196: control-mode dispatch must ignore
+    /// lock toggles (`CAPSLOCK_ON`, `NUMLOCK_ON`, `SCROLLLOCK_ON`)
+    /// and the `ENHANCED_KEY` flag when matching `(VK_*, 0)` arms.
+    /// Those bits live in `dwControlKeyState` alongside the real
+    /// modifier bits (Ctrl/Alt/Shift), and an enabled CapsLock
+    /// previously made the entire field non-zero, silently skipping
+    /// every action.
+    ///
+    /// Conversely, any real modifier bit must survive the masking
+    /// so combos like Shift+R do not collapse into the plain-R arm.
+    #[test]
+    fn test_control_mode_classifiers_ignore_lock_state_and_enhanced_key() {
+        let benign_states = [
+            0,
+            CAPSLOCK_ON,
+            NUMLOCK_ON,
+            SCROLLLOCK_ON,
+            ENHANCED_KEY,
+            CAPSLOCK_ON | NUMLOCK_ON | SCROLLLOCK_ON | ENHANCED_KEY,
+        ];
+        let main_expected = [
+            (VK_R, ControlModeAction::Retile),
+            (VK_E, ControlModeAction::OpenEnableDisableSubmenu),
+            (VK_T, ControlModeAction::ToggleEnabled),
+            (VK_N, ControlModeAction::EnableAll),
+            (VK_C, ControlModeAction::CreateWindows),
+            (VK_H, ControlModeAction::CopyHostnames),
+        ];
+        let submenu_expected = [
+            (VK_E, EnableDisableSubmenuAction::Enable),
+            (VK_D, EnableDisableSubmenuAction::Disable),
+            (VK_T, EnableDisableSubmenuAction::Toggle),
+        ];
+
+        for state in benign_states {
+            for (vk, action) in &main_expected {
+                assert_eq!(
+                    &classify_control_mode_key(*vk, state),
+                    action,
+                    "main menu: VK {vk:?} with state 0x{state:08X} must classify as {action:?}",
+                );
+            }
+            for (vk, action) in &submenu_expected {
+                assert_eq!(
+                    &classify_enable_disable_submenu_key(*vk, state),
+                    action,
+                    "submenu: VK {vk:?} with state 0x{state:08X} must classify as {action:?}",
+                );
+            }
+        }
+
+        let modifier_states = [
+            LEFT_CTRL_PRESSED,
+            RIGHT_CTRL_PRESSED,
+            LEFT_ALT_PRESSED,
+            RIGHT_ALT_PRESSED,
+            SHIFT_PRESSED,
+            LEFT_CTRL_PRESSED | CAPSLOCK_ON,
+            SHIFT_PRESSED | NUMLOCK_ON | ENHANCED_KEY,
+        ];
+        for state in modifier_states {
+            for (vk, _) in &main_expected {
+                assert_eq!(
+                    classify_control_mode_key(*vk, state),
+                    ControlModeAction::NoOp,
+                    "main menu: VK {vk:?} with modifier state 0x{state:08X} must NOT fire the plain-key arm",
+                );
+            }
+            for (vk, _) in &submenu_expected {
+                assert_eq!(
+                    classify_enable_disable_submenu_key(*vk, state),
+                    EnableDisableSubmenuAction::NoOp,
+                    "submenu: VK {vk:?} with modifier state 0x{state:08X} must NOT fire the plain-key arm",
+                );
+            }
+        }
+    }
+
+    /// End-to-end regression for GH #196 at the dispatch level: when
+    /// CapsLock (or any other lock toggle) is engaged, pressing
+    /// `[e]` in the enable/disable submenu must still enable the
+    /// first client. Before the [`MODIFIER_MASK`][1] fix, the
+    /// non-zero `dwControlKeyState` would skip the `(VK_E, 0)` arm
+    /// and the press would silently do nothing.
+    ///
+    /// [1]: crate::daemon
+    #[test]
+    fn test_submenu_dispatch_ignores_lock_state_bits() {
+        let mut clients = Clients::new();
+        clients.push(make_client_with_state(1, ClientState::Disabled));
+        clients.push(make_client_with_state(2, ClientState::Disabled));
+        let clients = Mutex::new(clients);
+
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+
+        daemon.handle_enable_disable_submenu_key(
+            &clients,
+            submenu_key_event_with_state(VK_E, CAPSLOCK_ON | NUMLOCK_ON | ENHANCED_KEY),
+        );
+
+        assert_eq!(
+            snapshot_states(&clients.lock().unwrap()),
+            vec![ClientState::Active, ClientState::Disabled],
+            "VK_E with lock-state bits set must still enable the first client",
+        );
         assert_eq!(
             daemon.control_mode_state,
             ControlModeState::EnableDisableSubmenu


### PR DESCRIPTION
The control-mode dispatch in `Daemon::handle_input_record` compared
`dwControlKeyState` directly against `0` to match unmodified
keystrokes. Because `dwControlKeyState` mixes "real" modifier bits
(Ctrl/Alt/Shift) with lock toggles (`CAPSLOCK_ON`, `NUMLOCK_ON`,
`SCROLLLOCK_ON`) and the `ENHANCED_KEY` flag, an enabled CapsLock
made the field non-zero and silently skipped every `(VK_*, 0)` arm,
so `[c]reate window(s)`, `[r]etile`, `[t]oggle enabled`,
`e[n]able all`, and copy active `[h]ostname(s)` did nothing.

Introduce a `MODIFIER_MASK` constant covering only the Ctrl/Alt/Shift
bits and AND `dwControlKeyState` with it before the match. The arm
patterns stay unchanged - they keep meaning "no modifier". Add a
regression test pinning the mask's behaviour against lock-only states
and against states that carry a real modifier bit.

`control_mode_is_active` already used bitwise AND for the Ctrl + A
entry detection and is unaffected.

GitHub: #196
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
