### PR TITLE
control mode: stop forwarding the Esc that exits control mode

### DIFF
--- a/news/197.bugfix.md
+++ b/news/197.bugfix.md
@@ -1,0 +1,3 @@
+Fixed control mode leaking the `Esc` keystroke to all connected
+clients when used to exit control mode. The keystroke is now
+consumed by the daemon and no longer broadcast.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -790,13 +790,14 @@ impl<'a> Daemon<'a> {
         }
     }
 
-    /// Returns whether control mode is active or not given the input_record.
+    /// Updates `self.control_mode_state` for the given input record and
+    /// reports whether control mode owned the keystroke.
     ///
-    /// For control mode to be active this function needs to be called
-    /// multiple times, as a key press translates to an input record and
-    /// the key combination that activates control mode has 2 keys:
-    /// `Ctrl + A`.
-    /// The current control mode state is stored in `self.control_mode_state`.
+    /// Entering control mode requires this function to be called twice
+    /// because the activating chord `Ctrl + A` produces two input
+    /// records (the modifier press and the `A` key). Once active, every
+    /// subsequent key - including the `Esc` that exits control mode -
+    /// is reported as consumed so callers do not forward it to clients.
     ///
     /// # Arguments
     ///

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -805,7 +805,10 @@ impl<'a> Daemon<'a> {
     ///
     /// # Returns
     ///
-    /// Whether or not control mode is active.
+    /// Whether the input record was consumed by control mode. Returns
+    /// `true` while control mode is active (including the `Esc`
+    /// keystroke that exits it), so callers must not forward such
+    /// records to clients.
     fn control_mode_is_active<W: WindowsApi>(
         &mut self,
         windows_api: &W,
@@ -817,7 +820,7 @@ impl<'a> Daemon<'a> {
         {
             if key_event.wVirtualKeyCode == VK_ESCAPE.0 {
                 self.quit_control_mode(windows_api);
-                return false;
+                return true;
             }
             return true;
         }

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -1305,4 +1305,56 @@ mod daemon_test {
             ControlModeState::EnableDisableSubmenu
         );
     }
+
+    /// Regression test for #197: when control mode is `Active` and the
+    /// user presses `Esc`, `control_mode_is_active` must report that the
+    /// keystroke was consumed (`true`) so that `handle_input_record`
+    /// suppresses the broadcast. Before the fix it returned `false`,
+    /// which leaked the `Esc` to every connected client.
+    #[test]
+    fn test_esc_in_active_state_is_consumed_and_resets_to_inactive() {
+        use crate::utils::windows::MockWindowsApi;
+        use windows::Win32::Foundation::BOOL;
+        use windows::Win32::System::Console::{CONSOLE_SCREEN_BUFFER_INFO, COORD, INPUT_RECORD_0};
+        use windows::Win32::UI::Input::KeyboardAndMouse::VK_ESCAPE;
+
+        // Arrange: a daemon already in `Active` control mode and a mock
+        // that stubs the console calls `quit_control_mode` makes via
+        // `print_instructions` -> `clear_screen`.
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon = Daemon::for_test(&config, &clusters, ControlModeState::Active);
+
+        let mut mock = MockWindowsApi::new();
+        mock.expect_get_console_screen_buffer_info().returning(|| {
+            return Ok(CONSOLE_SCREEN_BUFFER_INFO {
+                dwSize: COORD { X: 80, Y: 25 },
+                ..Default::default()
+            });
+        });
+        mock.expect_scroll_console_screen_buffer()
+            .returning(|_, _, _| return Ok(()));
+        mock.expect_set_console_cursor_position()
+            .returning(|_| return Ok(()));
+
+        let esc_input = INPUT_RECORD_0 {
+            KeyEvent: KEY_EVENT_RECORD {
+                bKeyDown: BOOL(1),
+                wRepeatCount: 1,
+                wVirtualKeyCode: VK_ESCAPE.0,
+                wVirtualScanCode: 0,
+                uChar: KEY_EVENT_RECORD_0 { UnicodeChar: 0 },
+                dwControlKeyState: 0,
+            },
+        };
+
+        // Act
+        let consumed = daemon.control_mode_is_active(&mock, esc_input);
+
+        // Assert: the `Esc` is reported as owned by control mode (so the
+        // caller will skip forwarding it) and the state machine is back
+        // to `Inactive`.
+        assert!(consumed);
+        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
+    }
 }


### PR DESCRIPTION
When control mode was Active and the user pressed Esc to leave it,
`control_mode_is_active` reset the state and returned `false`. The
caller `handle_input_record` gates client forwarding on that return
value, so the `false` made it fall through to the broadcast path and
the Esc keystroke was sent to every connected client. Control mode is
supposed to suppress client input entirely, so the leak contradicted
the feature's intent.

Return `true` from the Esc-exit branch instead so the caller treats
control mode as having owned the key. The downstream gated block then
matches no command arm and falls through its trailing `return`,
suppressing the broadcast.

Add a regression test that drives the function with a VK_ESCAPE input
record while the daemon is in Active control mode and asserts both the
new return value and the resulting `Inactive` state.

GitHub: #197
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
