### PR TITLE
client: make the disabled-state console color configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ arguments = [
     '{{USERNAME_AT_HOST}}',
 ]
 username_host_placeholder = '{{USERNAME_AT_HOST}}'
+disabled_console_color = 135
 ```
 
 ##### `ssh_config_path`
@@ -116,6 +117,11 @@ Additional arguments specified to the chosen program.
 
 ##### `username_host_placeholder`
 Placeholder string that indicates where the `username@host` string should be inserted in the program arguments.
+
+##### `disabled_console_color`
+Configures the background and foreground colors used by a client console while the client is in the disabled state (input ignored).
+Uses the same encoding as the daemon [`console_color`](#console_color).
+The default `135` paints default-grey text on a muted dark-grey background: `FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | BACKGROUND_INTENSITY` = 4+2+1+128.
 
 #### `daemon`
 A collection containing daemon relevant configuration

--- a/news/200.feature.md
+++ b/news/200.feature.md
@@ -1,0 +1,4 @@
+The console color applied to a client window while the client is in the
+disabled state is now configurable via the new `client.disabled_console_color`
+key in `csshw-config.toml`. Configs that omit the key keep the previous
+default-grey-on-dark-grey appearance.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -19,9 +19,8 @@ use tokio::process::{Child, Command};
 use tokio::sync::watch;
 use tokio::{io::Interest, net::windows::named_pipe::ClientOptions};
 use windows::Win32::System::Console::{
-    BACKGROUND_INTENSITY, CONSOLE_CHARACTER_ATTRIBUTES, FOREGROUND_BLUE, FOREGROUND_GREEN,
-    FOREGROUND_RED, INPUT_RECORD, INPUT_RECORD_0, KEY_EVENT, KEY_EVENT_RECORD, LEFT_ALT_PRESSED,
-    RIGHT_ALT_PRESSED, SHIFT_PRESSED,
+    CONSOLE_CHARACTER_ATTRIBUTES, INPUT_RECORD, INPUT_RECORD_0, KEY_EVENT, KEY_EVENT_RECORD,
+    LEFT_ALT_PRESSED, RIGHT_ALT_PRESSED, SHIFT_PRESSED,
 };
 
 use crate::{
@@ -61,18 +60,6 @@ enum ReadWriteResult {
     Disconnect,
 }
 
-/// Console attributes applied while the client is in
-/// [`ClientState::Disabled`].
-///
-/// The default-grey foreground (red+green+blue, no intensity) on a
-/// `BACKGROUND_INTENSITY`-only background paints the window as light text on
-/// a muted dark-grey background - a clear "this client is greyed out" cue
-/// that mirrors the daemon's existing reuse of `set_console_color` while
-/// staying visually distinct from the daemon's bright-red palette.
-const DISABLED_CONSOLE_ATTRIBUTES: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARACTER_ATTRIBUTES(
-    FOREGROUND_RED.0 | FOREGROUND_GREEN.0 | FOREGROUND_BLUE.0 | BACKGROUND_INTENSITY.0,
-);
-
 /// Repaint the console to reflect a [`ClientState`] transition.
 ///
 /// Called from the visuals task whenever the watch channel observes a new
@@ -90,11 +77,15 @@ const DISABLED_CONSOLE_ATTRIBUTES: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARAC
 /// * `original_attrs`  - Console attributes captured at startup. Used to
 ///                       restore the pristine appearance when transitioning
 ///                       back to [`ClientState::Active`].
+/// * `disabled_attrs`  - Console attributes applied while the client is in
+///                       [`ClientState::Disabled`]. Sourced from
+///                       [`ClientConfig::disabled_console_color`].
 fn apply_state_visuals(
     api: &dyn WindowsApi,
     prev: ClientState,
     next: ClientState,
     original_attrs: Option<CONSOLE_CHARACTER_ATTRIBUTES>,
+    disabled_attrs: CONSOLE_CHARACTER_ATTRIBUTES,
 ) {
     if prev == next {
         return;
@@ -104,7 +95,7 @@ fn apply_state_visuals(
     };
     let attrs = match next {
         ClientState::Active => original,
-        ClientState::Disabled => DISABLED_CONSOLE_ATTRIBUTES,
+        ClientState::Disabled => disabled_attrs,
     };
     set_console_color(api, attrs);
 }
@@ -575,13 +566,14 @@ pub async fn main(
     // Disabled. Decoupling the redraw from `read_write_loop` keeps named-pipe
     // I/O off the critical path of the (potentially slow) per-row
     // `fill_console_output_attribute` calls inside `set_console_color`.
+    let disabled_attrs = CONSOLE_CHARACTER_ATTRIBUTES(config.disabled_console_color);
     let visuals_task = {
         let mut state_rx = state_rx;
         async move {
             let mut prev = *state_rx.borrow_and_update();
             while state_rx.changed().await.is_ok() {
                 let next = *state_rx.borrow_and_update();
-                apply_state_visuals(api, prev, next, original_attrs);
+                apply_state_visuals(api, prev, next, original_attrs, disabled_attrs);
                 prev = next;
             }
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -65,39 +65,39 @@ enum ReadWriteResult {
 /// Called from the visuals task whenever the watch channel observes a new
 /// state. Does nothing when `prev == next` (the watch channel notifies on
 /// every send, including no-op replays) and also does nothing when
-/// `original_attrs` is `None` - that signals the initial buffer-info read
-/// at startup failed, in which case we degrade gracefully and leave the
-/// console untouched.
+/// `original_console_color` is `None` - that signals the initial
+/// buffer-info read at startup failed, in which case we degrade
+/// gracefully and leave the console untouched.
 ///
 /// # Arguments
 ///
-/// * `api`             - The Windows API implementation to use.
-/// * `prev`            - State applied on the previous invocation.
-/// * `next`            - State just observed on the watch channel.
-/// * `original_attrs`  - Console attributes captured at startup. Used to
-///                       restore the pristine appearance when transitioning
-///                       back to [`ClientState::Active`].
-/// * `disabled_attrs`  - Console attributes applied while the client is in
-///                       [`ClientState::Disabled`]. Sourced from
-///                       [`ClientConfig::disabled_console_color`].
+/// * `api`                     - The Windows API implementation to use.
+/// * `prev`                    - State applied on the previous invocation.
+/// * `next`                    - State just observed on the watch channel.
+/// * `original_console_color`  - Console color captured at startup. Used to
+///                               restore the pristine appearance when
+///                               transitioning back to [`ClientState::Active`].
+/// * `disabled_console_color`  - Console color applied while the client is in
+///                               [`ClientState::Disabled`]. Sourced from
+///                               [`ClientConfig::disabled_console_color`].
 fn apply_state_visuals(
     api: &dyn WindowsApi,
     prev: ClientState,
     next: ClientState,
-    original_attrs: Option<CONSOLE_CHARACTER_ATTRIBUTES>,
-    disabled_attrs: CONSOLE_CHARACTER_ATTRIBUTES,
+    original_console_color: Option<CONSOLE_CHARACTER_ATTRIBUTES>,
+    disabled_console_color: CONSOLE_CHARACTER_ATTRIBUTES,
 ) {
     if prev == next {
         return;
     }
-    let Some(original) = original_attrs else {
+    let Some(original) = original_console_color else {
         return;
     };
-    let attrs = match next {
+    let color = match next {
         ClientState::Active => original,
-        ClientState::Disabled => disabled_attrs,
+        ClientState::Disabled => disabled_console_color,
     };
-    set_console_color(api, attrs);
+    set_console_color(api, color);
 }
 
 /// Write the given [INPUT_RECORD_0] to the console input buffer using the provided API.
@@ -495,16 +495,16 @@ pub async fn main(
     cli_port: Option<u16>,
     config: &ClientConfig,
 ) {
-    // Capture the console's original attributes before anything (title task,
+    // Capture the console's original color before anything (title task,
     // SSH child) gets a chance to write output. This snapshot is what the
     // visuals task reverts to on a `Disabled -> Active` transition.
-    let original_attrs: Option<CONSOLE_CHARACTER_ATTRIBUTES> = match api
+    let original_console_color: Option<CONSOLE_CHARACTER_ATTRIBUTES> = match api
         .get_console_screen_buffer_info()
     {
         Ok(info) => Some(info.wAttributes),
         Err(err) => {
             warn!(
-                "Failed to capture original console attributes; disabled-state visuals will be skipped: {}",
+                "Failed to capture original console color; disabled-state visuals will be skipped: {}",
                 err
             );
             None
@@ -566,14 +566,20 @@ pub async fn main(
     // Disabled. Decoupling the redraw from `read_write_loop` keeps named-pipe
     // I/O off the critical path of the (potentially slow) per-row
     // `fill_console_output_attribute` calls inside `set_console_color`.
-    let disabled_attrs = CONSOLE_CHARACTER_ATTRIBUTES(config.disabled_console_color);
+    let disabled_console_color = CONSOLE_CHARACTER_ATTRIBUTES(config.disabled_console_color);
     let visuals_task = {
         let mut state_rx = state_rx;
         async move {
             let mut prev = *state_rx.borrow_and_update();
             while state_rx.changed().await.is_ok() {
                 let next = *state_rx.borrow_and_update();
-                apply_state_visuals(api, prev, next, original_attrs, disabled_attrs);
+                apply_state_visuals(
+                    api,
+                    prev,
+                    next,
+                    original_console_color,
+                    disabled_console_color,
+                );
                 prev = next;
             }
         }

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -12,7 +12,6 @@ use windows::Win32::UI::Input::KeyboardAndMouse::VK_C;
 use crate::client::{
     apply_state_visuals, build_ssh_arguments, is_alt_shift_c_combination, read_write_loop,
     resolve_username, send_pid_handshake, write_console_input, ReadWriteResult,
-    DISABLED_CONSOLE_ATTRIBUTES,
 };
 use crate::protocol::serialization::{serialize_client_state, serialize_input_record_0};
 use crate::protocol::{ClientState, TAG_INPUT_RECORD, TAG_STATE_CHANGE};
@@ -42,6 +41,7 @@ fn create_test_client_config(ssh_config_path: String) -> ClientConfig {
         program: TEST_SSH_PROGRAM.to_string(),
         arguments: vec!["-XY".to_string(), TEST_PLACEHOLDER.to_string()],
         username_host_placeholder: TEST_PLACEHOLDER.to_string(),
+        disabled_console_color: ClientConfig::default().disabled_console_color,
     };
 }
 
@@ -223,6 +223,7 @@ fn test_build_ssh_arguments() {
             "-X".to_string(),
         ],
         username_host_placeholder: TEST_PLACEHOLDER.to_string(),
+        disabled_console_color: ClientConfig::default().disabled_console_color,
     };
 
     let test_cases = [
@@ -655,12 +656,13 @@ fn buffer_info(rows: i16) -> CONSOLE_SCREEN_BUFFER_INFO {
 #[test]
 fn test_apply_state_visuals_active_to_disabled_repaints_with_disabled_palette() {
     let original = CONSOLE_CHARACTER_ATTRIBUTES(0x07);
+    let disabled = CONSOLE_CHARACTER_ATTRIBUTES(0x87);
     let rows: i16 = 25;
 
     let mut mock_api = MockWindowsApi::new();
     mock_api
         .expect_set_console_text_attribute()
-        .with(mockall::predicate::eq(DISABLED_CONSOLE_ATTRIBUTES))
+        .with(mockall::predicate::eq(disabled))
         .times(1)
         .returning(|_| return Ok(()));
     mock_api
@@ -681,6 +683,7 @@ fn test_apply_state_visuals_active_to_disabled_repaints_with_disabled_palette() 
         ClientState::Active,
         ClientState::Disabled,
         Some(original),
+        disabled,
     );
 }
 
@@ -712,12 +715,14 @@ fn test_apply_state_visuals_disabled_to_active_restores_original_attrs() {
         ClientState::Disabled,
         ClientState::Active,
         Some(original),
+        CONSOLE_CHARACTER_ATTRIBUTES(0x87),
     );
 }
 
 #[test]
 fn test_apply_state_visuals_no_op_when_state_unchanged() {
     let original = CONSOLE_CHARACTER_ATTRIBUTES(0x07);
+    let disabled = CONSOLE_CHARACTER_ATTRIBUTES(0x87);
 
     // No expectations set: any call to the API would cause the mockall
     // strict-mock to fail, proving the no-transition branch is silent.
@@ -728,12 +733,14 @@ fn test_apply_state_visuals_no_op_when_state_unchanged() {
         ClientState::Active,
         ClientState::Active,
         Some(original),
+        disabled,
     );
     apply_state_visuals(
         &mock_api,
         ClientState::Disabled,
         ClientState::Disabled,
         Some(original),
+        disabled,
     );
 }
 
@@ -743,9 +750,22 @@ fn test_apply_state_visuals_skipped_when_original_attrs_unavailable() {
     // gracefully and leave the console untouched even on a real
     // transition.
     let mock_api = MockWindowsApi::new();
+    let disabled = CONSOLE_CHARACTER_ATTRIBUTES(0x87);
 
-    apply_state_visuals(&mock_api, ClientState::Active, ClientState::Disabled, None);
-    apply_state_visuals(&mock_api, ClientState::Disabled, ClientState::Active, None);
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Active,
+        ClientState::Disabled,
+        None,
+        disabled,
+    );
+    apply_state_visuals(
+        &mock_api,
+        ClientState::Disabled,
+        ClientState::Active,
+        None,
+        disabled,
+    );
 }
 
 #[tokio::test]

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -688,7 +688,7 @@ fn test_apply_state_visuals_active_to_disabled_repaints_with_disabled_palette() 
 }
 
 #[test]
-fn test_apply_state_visuals_disabled_to_active_restores_original_attrs() {
+fn test_apply_state_visuals_disabled_to_active_restores_original_console_color() {
     let original = CONSOLE_CHARACTER_ATTRIBUTES(0x5A);
     let rows: i16 = 30;
 
@@ -745,8 +745,8 @@ fn test_apply_state_visuals_no_op_when_state_unchanged() {
 }
 
 #[test]
-fn test_apply_state_visuals_skipped_when_original_attrs_unavailable() {
-    // When startup failed to capture the original attributes we degrade
+fn test_apply_state_visuals_skipped_when_original_console_color_unavailable() {
+    // When startup failed to capture the original console color we degrade
     // gracefully and leave the console untouched even on a real
     // transition.
     let mock_api = MockWindowsApi::new();

--- a/src/tests/utils/test_config.rs
+++ b/src/tests/utils/test_config.rs
@@ -35,6 +35,17 @@ mod client_config_test {
             client_config.username_host_placeholder,
             default_config.username_host_placeholder
         );
+        assert_eq!(
+            client_config.disabled_console_color,
+            default_config.disabled_console_color
+        );
+    }
+
+    #[test]
+    fn test_client_config_default_disabled_console_color() {
+        // 4 (FOREGROUND_RED) + 2 (FOREGROUND_GREEN) + 1 (FOREGROUND_BLUE)
+        // + 128 (BACKGROUND_INTENSITY) = 135
+        assert_eq!(ClientConfig::default().disabled_console_color, 135);
     }
 
     #[test]
@@ -44,6 +55,7 @@ mod client_config_test {
             program: "openssh".to_string(),
             arguments: vec!["-v".to_string(), "{{USER_HOST}}".to_string()],
             username_host_placeholder: "{{USER_HOST}}".to_string(),
+            disabled_console_color: 240,
         };
 
         let config_opt: ClientConfigOpt = ClientConfigOpt {
@@ -51,6 +63,7 @@ mod client_config_test {
             program: Some(client_config.program.clone()),
             arguments: Some(client_config.arguments.clone()),
             username_host_placeholder: Some(client_config.username_host_placeholder.clone()),
+            disabled_console_color: Some(client_config.disabled_console_color),
         };
         let converted_back: ClientConfig = config_opt.into();
 
@@ -64,6 +77,10 @@ mod client_config_test {
             converted_back.username_host_placeholder,
             client_config.username_host_placeholder
         );
+        assert_eq!(
+            converted_back.disabled_console_color,
+            client_config.disabled_console_color
+        );
     }
 
     #[test]
@@ -73,6 +90,7 @@ mod client_config_test {
             program: None,
             arguments: Some(vec!["-X".to_string(), "{{HOST}}".to_string()]),
             username_host_placeholder: None,
+            disabled_console_color: Some(112),
         };
 
         let client_config: ClientConfig = config_opt.into();
@@ -85,6 +103,26 @@ mod client_config_test {
             client_config.username_host_placeholder,
             default_config.username_host_placeholder
         ); // Should use default
+        assert_eq!(client_config.disabled_console_color, 112);
+    }
+
+    #[test]
+    fn test_client_config_opt_disabled_console_color_default_applied() {
+        let config_opt = ClientConfigOpt {
+            ssh_config_path: None,
+            program: None,
+            arguments: None,
+            username_host_placeholder: None,
+            disabled_console_color: None,
+        };
+
+        let client_config: ClientConfig = config_opt.into();
+        let default_config = ClientConfig::default();
+
+        assert_eq!(
+            client_config.disabled_console_color,
+            default_config.disabled_console_color
+        );
     }
 
     #[test]
@@ -94,12 +132,14 @@ mod client_config_test {
             program: "putty".to_string(),
             arguments: vec!["-ssh".to_string(), "{{TARGET}}".to_string()],
             username_host_placeholder: "{{TARGET}}".to_string(),
+            disabled_console_color: 15,
         };
 
         assert_eq!(config.ssh_config_path, "D:\\ssh\\config");
         assert_eq!(config.program, "putty");
         assert_eq!(config.arguments, vec!["-ssh", "{{TARGET}}"]);
         assert_eq!(config.username_host_placeholder, "{{TARGET}}");
+        assert_eq!(config.disabled_console_color, 15);
     }
 }
 
@@ -280,6 +320,7 @@ mod config_test {
                 program: "custom-ssh".to_string(),
                 arguments: vec!["-custom".to_string()],
                 username_host_placeholder: "{{CUSTOM}}".to_string(),
+                disabled_console_color: 240,
             },
             daemon: DaemonConfig {
                 height: 250,
@@ -297,6 +338,7 @@ mod config_test {
                 username_host_placeholder: Some(
                     original_config.client.username_host_placeholder.clone(),
                 ),
+                disabled_console_color: Some(original_config.client.disabled_console_color),
             }),
             daemon: Some(DaemonConfigOpt {
                 height: Some(original_config.daemon.height),
@@ -415,6 +457,7 @@ mod config_integration_test {
                     "{{USER_HOST}}".to_string(),
                 ],
                 username_host_placeholder: "{{USER_HOST}}".to_string(),
+                disabled_console_color: 23,
             },
             daemon: DaemonConfig {
                 height: 180,
@@ -431,6 +474,7 @@ mod config_integration_test {
                 program: Some(original.client.program.clone()),
                 arguments: Some(original.client.arguments.clone()),
                 username_host_placeholder: Some(original.client.username_host_placeholder.clone()),
+                disabled_console_color: Some(original.client.disabled_console_color),
             }),
             daemon: Some(DaemonConfigOpt {
                 height: Some(original.daemon.height),
@@ -456,6 +500,10 @@ mod config_integration_test {
         assert_eq!(
             roundtrip.client.username_host_placeholder,
             original.client.username_host_placeholder
+        );
+        assert_eq!(
+            roundtrip.client.disabled_console_color,
+            original.client.disabled_console_color
         );
 
         assert_eq!(roundtrip.daemon.height, original.daemon.height);
@@ -489,6 +537,7 @@ mod config_integration_test {
                     "{{TARGET}}".to_string(),
                 ],
                 username_host_placeholder: "{{TARGET}}".to_string(),
+                disabled_console_color: ClientConfig::default().disabled_console_color,
             },
             daemon: DaemonConfig::default(),
         };

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -7,7 +7,7 @@ use windows::Win32::System::Console::{
     FOREGROUND_RED,
 };
 
-/// Default console attribute bits applied when a client is in the
+/// Default console color applied when a client is in the
 /// `Disabled` state.
 ///
 /// Default-grey foreground (red+green+blue, no intensity) on a

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -114,7 +114,7 @@ pub struct ClientConfig {
     /// when the client is in the `Disabled` state.
     ///
     /// Uses the same encoding as [`DaemonConfig::console_color`].
-    /// All [standard windows color combinations][1] are available:
+    /// All [standard Windows color combinations][1] are available:
     ///
     /// FOREGROUND_BLUE:        1   \
     /// FOREGROUND_GREEN:       2   \
@@ -143,7 +143,7 @@ impl Default for ClientConfig {
     /// * `ssh_config_path`             - `%USERPROFILE%\.ssh\config`
     /// * `program`                     - `ssh`
     /// * `arguments`                   - `-XY {{USERNAME_AT_HOST}}`
-    /// * `usernamt_host_placeholder`   - `{{USERNAME_AT_HOST}}`
+    /// * `username_host_placeholder`   - `{{USERNAME_AT_HOST}}`
     /// * `disabled_console_color`      - `135`
     ///
     /// Note: %USERPROFILE% actually is resolved by us, so the actual value
@@ -238,7 +238,7 @@ pub struct DaemonConfig {
     pub aspect_ratio_adjustement: f64,
     /// Controls back- and foreground colors of the daemon console window.
     ///
-    /// All [standard windows color combinations][1] are available:
+    /// All [standard Windows color combinations][1] are available:
     ///
     /// FOREGROUND_BLUE:        1   \
     /// FOREGROUND_GREEN:       2   \

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -7,6 +7,16 @@ use windows::Win32::System::Console::{
     FOREGROUND_RED,
 };
 
+/// Default console attribute bits applied when a client is in the
+/// `Disabled` state.
+///
+/// Default-grey foreground (red+green+blue, no intensity) on a
+/// `BACKGROUND_INTENSITY`-only background paints the window as light text on
+/// a muted dark-grey background - a clear "this client is greyed out" cue
+/// that stays visually distinct from the daemon's bright-red palette.
+const DEFAULT_DISABLED_CONSOLE_COLOR: u16 =
+    FOREGROUND_RED.0 | FOREGROUND_GREEN.0 | FOREGROUND_BLUE.0 | BACKGROUND_INTENSITY.0;
+
 /// Placeholder for the `<username>@<host>` argument to the chosen SSH program.
 const DEFAULT_USERNAME_HOST_PLACEHOLDER: &str = "{{USERNAME_AT_HOST}}";
 
@@ -100,6 +110,28 @@ pub struct ClientConfig {
     ///
     /// `'{{USERNAME_AT_HOST}}'`
     pub username_host_placeholder: String,
+    /// Controls back- and foreground colors of the client console window
+    /// when the client is in the `Disabled` state.
+    ///
+    /// Uses the same encoding as [`DaemonConfig::console_color`].
+    /// All [standard windows color combinations][1] are available:
+    ///
+    /// FOREGROUND_BLUE:        1   \
+    /// FOREGROUND_GREEN:       2   \
+    /// FOREGROUND_RED:         4   \
+    /// FOREGROUND_INTENSITY:   8   \
+    /// BACKGROUND_BLUE:        16  \
+    /// BACKGROUND_GREEN:       32  \
+    /// BACKGROUND_RED:         64  \
+    /// BACKGROUND_INTENSITY:   128 \
+    ///
+    /// # Example
+    ///
+    /// Default-grey font on muted dark-grey background:
+    /// 4 + 2 + 1 + 128 = `135`
+    ///
+    /// [1]: https://learn.microsoft.com/en-us/windows/console/console-screen-buffers#character-attributes
+    pub disabled_console_color: u16,
 }
 
 impl Default for ClientConfig {
@@ -112,6 +144,7 @@ impl Default for ClientConfig {
     /// * `program`                     - `ssh`
     /// * `arguments`                   - `-XY {{USERNAME_AT_HOST}}`
     /// * `usernamt_host_placeholder`   - `{{USERNAME_AT_HOST}}`
+    /// * `disabled_console_color`      - `135`
     ///
     /// Note: %USERPROFILE% actually is resolved by us, so the actual value
     ///       is whatever the environment variable at runtime points to.
@@ -124,6 +157,7 @@ impl Default for ClientConfig {
                 DEFAULT_USERNAME_HOST_PLACEHOLDER.to_string(),
             ],
             username_host_placeholder: DEFAULT_USERNAME_HOST_PLACEHOLDER.to_string(),
+            disabled_console_color: DEFAULT_DISABLED_CONSOLE_COLOR,
         };
     }
 }
@@ -140,6 +174,8 @@ pub struct ClientConfigOpt {
     pub arguments: Option<Vec<String>>,
     #[allow(missing_docs)]
     pub username_host_placeholder: Option<String>,
+    #[allow(missing_docs)]
+    pub disabled_console_color: Option<u16>,
 }
 
 impl Default for ClientConfigOpt {
@@ -159,6 +195,9 @@ impl From<ClientConfigOpt> for ClientConfig {
             username_host_placeholder: val
                 .username_host_placeholder
                 .unwrap_or(default.username_host_placeholder),
+            disabled_console_color: val
+                .disabled_console_color
+                .unwrap_or(default.disabled_console_color),
         };
     }
 }
@@ -171,6 +210,7 @@ impl From<ClientConfig> for ClientConfigOpt {
             program: Some(val.program),
             arguments: Some(val.arguments),
             username_host_placeholder: Some(val.username_host_placeholder),
+            disabled_console_color: Some(val.disabled_console_color),
         };
     }
 }


### PR DESCRIPTION
Previously the console attributes applied while a client is in
`ClientState::Disabled` were hard-coded to a default-grey foreground
on a `BACKGROUND_INTENSITY`-only background. Users who dislike that
palette - or whose terminal theme makes it hard to distinguish from
the active state - had no way to change it.

With this change `ClientConfig` gains a `disabled_console_color: u16`
field that mirrors the encoding of `DaemonConfig::console_color`
(standard Windows character-attribute bit flags). The visuals task
reads the value at startup and passes it through to
`apply_state_visuals`, replacing the former module-level constant.

The default (`135` = FOREGROUND_RED | FOREGROUND_GREEN |
FOREGROUND_BLUE | BACKGROUND_INTENSITY) preserves the existing
appearance, and the `ConfigOpt` fallback path keeps older config
files - which omit the new key - working unchanged.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
