### PR TITLE
control mode: navigate the enable/disable submenu with arrows/hjkl

### DIFF
--- a/news/201.feature.md
+++ b/news/201.feature.md
@@ -1,0 +1,5 @@
+The `[e]nable/disable input` control-mode submenu now supports
+navigating between client windows with the arrow keys and the vim
+motions `h`, `j`, `k`, `l`. The submenu prompt shows which client
+is currently selected, and `[e]nable`, `[d]isable`, and `[t]oggle`
+operate on the selected client.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -51,7 +51,8 @@ use windows::Win32::System::Console::{
 };
 
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    VIRTUAL_KEY, VK_A, VK_C, VK_D, VK_E, VK_ESCAPE, VK_H, VK_N, VK_R, VK_T,
+    VIRTUAL_KEY, VK_A, VK_C, VK_D, VK_DOWN, VK_E, VK_ESCAPE, VK_H, VK_J, VK_K, VK_L, VK_LEFT, VK_N,
+    VK_R, VK_RIGHT, VK_T, VK_UP,
 };
 use windows::Win32::UI::WindowsAndMessaging::{SW_RESTORE, SW_SHOWMINIMIZED};
 use windows::Win32::{
@@ -116,8 +117,20 @@ enum EnableDisableSubmenuAction {
     Disable,
     /// `[t]` - flip the targeted client(s)' [`ClientState`].
     Toggle,
+    /// Arrow key or vim motion - move the submenu's selection cursor.
+    Navigate(NavigationDirection),
     /// Any other key while the submenu is open.
     NoOp,
+}
+
+/// Direction of a navigation keystroke inside the enable/disable
+/// submenu.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum NavigationDirection {
+    Up,
+    Down,
+    Left,
+    Right,
 }
 
 /// Classifies a top-level control-mode keystroke.
@@ -177,6 +190,12 @@ fn classify_enable_disable_submenu_key(
         (VK_E, 0) => EnableDisableSubmenuAction::Enable,
         (VK_D, 0) => EnableDisableSubmenuAction::Disable,
         (VK_T, 0) => EnableDisableSubmenuAction::Toggle,
+        (VK_UP, 0) | (VK_K, 0) => EnableDisableSubmenuAction::Navigate(NavigationDirection::Up),
+        (VK_DOWN, 0) | (VK_J, 0) => EnableDisableSubmenuAction::Navigate(NavigationDirection::Down),
+        (VK_LEFT, 0) | (VK_H, 0) => EnableDisableSubmenuAction::Navigate(NavigationDirection::Left),
+        (VK_RIGHT, 0) | (VK_L, 0) => {
+            EnableDisableSubmenuAction::Navigate(NavigationDirection::Right)
+        }
         _ => EnableDisableSubmenuAction::NoOp,
     };
 }
@@ -360,17 +379,13 @@ enum ControlModeState {
     /// Active control mode prevents any input records from being sent to clients.
     Active,
     /// The user opened the `[e]nable/disable input` submenu from
-    /// [`ControlModeState::Active`].
-    ///
-    /// While in this state, each non-`Esc` key is interpreted as a
-    /// submenu action (`[e]`, `[d]`, `[t]`) applied to the currently
-    /// selected client; unrecognised keys are ignored. The submenu
-    /// remains open after every key press and is left only via `Esc`,
-    /// which exits control mode entirely. The first iteration hardcodes
-    /// the selection to the first client; later iterations will
-    /// introduce navigation across the cluster. Like
-    /// [`ControlModeState::Active`], this state suppresses input
-    /// forwarding to clients.
+    /// [`ControlModeState::Active`]. Each non-`Esc` key is
+    /// interpreted as a submenu action (`[e]`, `[d]`, `[t]`, or a
+    /// navigation key) applied to the currently selected client;
+    /// unrecognised keys are ignored. The submenu remains open after
+    /// every key press and is left only via `Esc`, which exits
+    /// control mode entirely. Like [`ControlModeState::Active`],
+    /// this state suppresses input forwarding to clients.
     EnableDisableSubmenu,
 }
 
@@ -393,6 +408,10 @@ struct Daemon<'a> {
     clusters: &'a [Cluster],
     /// The current control mode state.
     control_mode_state: ControlModeState,
+    /// Index into [`Clients::list`] of the client currently selected
+    /// in the [`ControlModeState::EnableDisableSubmenu`] prompt.
+    /// `None` outside the submenu and whenever the cluster is empty.
+    submenu_selected_index: Option<usize>,
     /// If debug mode is enabled on the daemon it will also be enabled on all
     /// clients.
     debug: bool,
@@ -418,6 +437,7 @@ impl<'a> Daemon<'a> {
             config,
             clusters,
             control_mode_state,
+            submenu_selected_index: None,
             debug: false,
         };
     }
@@ -657,7 +677,7 @@ impl<'a> Daemon<'a> {
                 return;
             }
             if self.control_mode_state == ControlModeState::EnableDisableSubmenu {
-                self.handle_enable_disable_submenu_key(clients, key_event);
+                self.handle_enable_disable_submenu_key(windows_api, clients, key_event);
                 return;
             }
             match classify_control_mode_key(
@@ -673,10 +693,14 @@ impl<'a> Daemon<'a> {
                     self.arrange_daemon_console(windows_api, workspace_area);
                 }
                 ControlModeAction::OpenEnableDisableSubmenu => {
-                    clear_screen(windows_api);
-                    println!("Enable/Disable input (first window) (Esc to exit)");
-                    println!("[e]nable, [d]isable, [t]oggle");
+                    let clients_guard = clients.lock().unwrap();
+                    self.submenu_selected_index = if clients_guard.is_empty() {
+                        None
+                    } else {
+                        Some(0)
+                    };
                     self.control_mode_state = ControlModeState::EnableDisableSubmenu;
+                    self.render_enable_disable_submenu(windows_api, &clients_guard);
                 }
                 ControlModeAction::ToggleEnabled => {
                     // Snapshot before flipping so each client toggles relative
@@ -835,11 +859,13 @@ impl<'a> Daemon<'a> {
         return false;
     }
 
-    /// Prints the default daemon instructions to the daemon console and
-    /// sets `self.control_mode_state` to inactive.
+    /// Prints the default daemon instructions to the daemon console,
+    /// sets `self.control_mode_state` to inactive, and clears the
+    /// submenu selection cursor.
     fn quit_control_mode<W: WindowsApi>(&mut self, windows_api: &W) {
         self.print_instructions(windows_api);
         self.control_mode_state = ControlModeState::Inactive;
+        self.submenu_selected_index = None;
     }
 
     /// Clears the console screen and prints the default daemon instructions.
@@ -894,28 +920,23 @@ impl<'a> Daemon<'a> {
         }
     }
 
-    /// Dispatch a key press received while the daemon is in the
-    /// [`ControlModeState::EnableDisableSubmenu`] state.
-    ///
-    /// Matches the submenu's `[e]nable`, `[d]isable`, and `[t]oggle`
-    /// bindings; any other key is ignored. The submenu stays open
-    /// after every key press (recognised or not) so subsequent
-    /// actions can be issued without having to re-enter the submenu
-    /// between them. The submenu is left only via `ESC`, which is
-    /// handled by the caller. The first iteration scopes every
-    /// action to the first client window; later iterations will
-    /// introduce navigation across the cluster, at which point
-    /// keeping the submenu open lets the user move between clients
-    /// and toggle them in sequence.
+    /// Dispatches a key press received while the daemon is in the
+    /// [`ControlModeState::EnableDisableSubmenu`] state. `[e]/[d]/[t]`
+    /// act on the currently selected client; `Navigate` moves the
+    /// selection and redraws the prompt. The submenu is left via
+    /// `ESC`, which is handled by the caller.
     ///
     /// # Arguments
     ///
-    /// * `clients`   - Shared client collection. Empty lists are a
-    ///                 no-op for `[e]`/`[d]`/`[t]`.
-    /// * `key_event` - The key-down [`KEY_EVENT_RECORD`] dispatched
-    ///                 from `handle_input_record`.
-    fn handle_enable_disable_submenu_key(
+    /// * `windows_api` - Windows API implementation used by the
+    ///                   render helper when redrawing after navigation.
+    /// * `clients`     - Shared client collection. Empty lists are a
+    ///                   no-op for every action.
+    /// * `key_event`   - The key-down [`KEY_EVENT_RECORD`] dispatched
+    ///                   from `handle_input_record`.
+    fn handle_enable_disable_submenu_key<W: WindowsApi>(
         &mut self,
+        windows_api: &W,
         clients: &Mutex<Clients>,
         key_event: KEY_EVENT_RECORD,
     ) {
@@ -924,34 +945,28 @@ impl<'a> Daemon<'a> {
             key_event.dwControlKeyState,
         ) {
             EnableDisableSubmenuAction::Enable => {
+                let selected = self.submenu_selected_index;
                 self.update_client_states(clients, |clients_guard| {
-                    return clients_guard
-                        .iter()
-                        .next()
-                        .map(|client| {
-                            return vec![(client.process_id, ClientState::Active)];
-                        })
+                    return selected
+                        .and_then(|idx| return clients_guard.get(idx))
+                        .map(|client| return vec![(client.process_id, ClientState::Active)])
                         .unwrap_or_default();
                 });
             }
             EnableDisableSubmenuAction::Disable => {
+                let selected = self.submenu_selected_index;
                 self.update_client_states(clients, |clients_guard| {
-                    return clients_guard
-                        .iter()
-                        .next()
-                        .map(|client| {
-                            return vec![(client.process_id, ClientState::Disabled)];
-                        })
+                    return selected
+                        .and_then(|idx| return clients_guard.get(idx))
+                        .map(|client| return vec![(client.process_id, ClientState::Disabled)])
                         .unwrap_or_default();
                 });
             }
             EnableDisableSubmenuAction::Toggle => {
-                // Snapshot before flipping so the first client toggles
-                // relative to its own pre-action state.
+                let selected = self.submenu_selected_index;
                 self.update_client_states(clients, |clients_guard| {
-                    return clients_guard
-                        .iter()
-                        .next()
+                    return selected
+                        .and_then(|idx| return clients_guard.get(idx))
                         .map(|client| {
                             let flipped = match *client.state_tx.borrow() {
                                 ClientState::Active => ClientState::Disabled,
@@ -962,8 +977,67 @@ impl<'a> Daemon<'a> {
                         .unwrap_or_default();
                 });
             }
+            EnableDisableSubmenuAction::Navigate(direction) => {
+                let clients_guard = clients.lock().unwrap();
+                self.move_submenu_selection(direction, clients_guard.len());
+                self.render_enable_disable_submenu(windows_api, &clients_guard);
+            }
             EnableDisableSubmenuAction::NoOp => {}
         }
+    }
+
+    /// Redraws the enable/disable submenu prompt, showing the
+    /// currently selected client as `[idx/total] hostname`.
+    ///
+    /// # Arguments
+    ///
+    /// * `windows_api`   - Windows API used to clear the console.
+    /// * `clients_guard` - Locked client collection, used to look up
+    ///                     the selected client's hostname and the
+    ///                     total count for the `[idx/total]` display.
+    fn render_enable_disable_submenu<W: WindowsApi>(
+        &self,
+        windows_api: &W,
+        clients_guard: &Clients,
+    ) {
+        clear_screen(windows_api);
+        println!("Enable/Disable input (Esc to exit)");
+        match self.submenu_selected_index {
+            Some(idx) if idx < clients_guard.len() => {
+                let client = &clients_guard[idx];
+                println!(
+                    "Selected: [{}/{}] {}",
+                    idx + 1,
+                    clients_guard.len(),
+                    client.hostname,
+                );
+            }
+            _ => println!("Selected: (no clients)"),
+        }
+        println!("[e]nable, [d]isable, [t]oggle, arrows/hjkl to move");
+    }
+
+    /// Moves [`Daemon::submenu_selected_index`] one step back
+    /// (Up/Left) or forward (Down/Right), clamped to `[0, len - 1]`.
+    /// Clears the selection when `len` is `0`.
+    ///
+    /// # Arguments
+    ///
+    /// * `direction` - Direction the navigation keystroke encoded.
+    /// * `len`       - Current number of tracked clients.
+    fn move_submenu_selection(&mut self, direction: NavigationDirection, len: usize) {
+        if len == 0 {
+            self.submenu_selected_index = None;
+            return;
+        }
+        let Some(current) = self.submenu_selected_index else {
+            return;
+        };
+        let next = match direction {
+            NavigationDirection::Up | NavigationDirection::Left => current.saturating_sub(1),
+            NavigationDirection::Down | NavigationDirection::Right => (current + 1).min(len - 1),
+        };
+        self.submenu_selected_index = Some(next);
     }
 
     /// Apply a batch of [`ClientState`] updates while holding the
@@ -1813,6 +1887,7 @@ pub async fn main<W: WindowsApi + Clone + 'static>(
         config,
         clusters,
         control_mode_state: ControlModeState::Inactive,
+        submenu_selected_index: None,
         debug,
     };
     daemon.launch(windows_api).await;

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -16,14 +16,15 @@ mod daemon_test {
         SHIFT_PRESSED,
     };
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        VIRTUAL_KEY, VK_C, VK_D, VK_E, VK_H, VK_N, VK_R, VK_T, VK_X,
+        VIRTUAL_KEY, VK_C, VK_D, VK_DOWN, VK_E, VK_H, VK_J, VK_K, VK_L, VK_LEFT, VK_N, VK_R,
+        VK_RIGHT, VK_T, VK_UP, VK_X,
     };
 
     use crate::{
         daemon::{
             classify_control_mode_key, classify_enable_disable_submenu_key, expand_hosts,
             named_pipe_server_routine, resolve_cluster_tags, Client, Clients, ControlModeAction,
-            ControlModeState, Daemon, EnableDisableSubmenuAction, HWNDWrapper,
+            ControlModeState, Daemon, EnableDisableSubmenuAction, HWNDWrapper, NavigationDirection,
         },
         protocol::{
             serialization::serialize_pid, ClientState, FRAMED_INPUT_RECORD_LENGTH,
@@ -1035,12 +1036,46 @@ mod daemon_test {
         };
     }
 
+    /// Builds a fresh [`MockWindowsApi`] with no expectations set.
+    ///
+    /// Suitable for submenu dispatch tests that exercise only the
+    /// `[e]`/`[d]`/`[t]` arms (which never touch the Windows API).
+    /// Tests that drive the `Navigate` arm must additionally stub the
+    /// console calls performed by [`crate::utils::windows::clear_screen`]
+    /// (see `mock_with_clear_screen`).
+    fn mock_no_calls() -> crate::utils::windows::MockWindowsApi {
+        return crate::utils::windows::MockWindowsApi::new();
+    }
+
+    /// Builds a [`MockWindowsApi`] that satisfies the console calls
+    /// [`crate::utils::windows::clear_screen`] performs when the
+    /// submenu renderer redraws after a navigation keystroke.
+    ///
+    /// Mirrors the mock setup used by
+    /// `test_esc_in_active_state_is_consumed_and_resets_to_inactive`.
+    fn mock_with_clear_screen() -> crate::utils::windows::MockWindowsApi {
+        use windows::Win32::System::Console::{CONSOLE_SCREEN_BUFFER_INFO, COORD};
+        let mut mock = crate::utils::windows::MockWindowsApi::new();
+        mock.expect_get_console_screen_buffer_info().returning(|| {
+            return Ok(CONSOLE_SCREEN_BUFFER_INFO {
+                dwSize: COORD { X: 80, Y: 25 },
+                ..Default::default()
+            });
+        });
+        mock.expect_scroll_console_screen_buffer()
+            .returning(|_, _, _| return Ok(()));
+        mock.expect_set_console_cursor_position()
+            .returning(|_| return Ok(()));
+        return mock;
+    }
+
     /// Verifies that `VK_E` in the enable/disable submenu enables
-    /// only the first client and keeps the submenu open so the user
-    /// can chain further enable/disable/toggle actions across
-    /// clients without re-entering the submenu.
+    /// only the currently selected client (index 0 here) and keeps
+    /// the submenu open so the user can chain further
+    /// enable/disable/toggle actions across clients without
+    /// re-entering the submenu.
     #[test]
-    fn test_submenu_e_enables_only_first_client_and_stays_open() {
+    fn test_submenu_e_enables_only_selected_client_and_stays_open() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Disabled));
         clients.push(make_client_with_state(2, ClientState::Disabled));
@@ -1051,8 +1086,13 @@ mod daemon_test {
         let clusters: Vec<Cluster> = Vec::new();
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(0);
 
-        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_E));
+        daemon.handle_enable_disable_submenu_key(
+            &mock_no_calls(),
+            &clients,
+            submenu_key_event(VK_E),
+        );
 
         assert_eq!(
             snapshot_states(&clients.lock().unwrap()),
@@ -1069,11 +1109,12 @@ mod daemon_test {
     }
 
     /// Verifies that `VK_D` in the enable/disable submenu disables
-    /// only the first client and keeps the submenu open so the user
-    /// can chain further enable/disable/toggle actions across
-    /// clients without re-entering the submenu.
+    /// only the currently selected client (index 0 here) and keeps
+    /// the submenu open so the user can chain further
+    /// enable/disable/toggle actions across clients without
+    /// re-entering the submenu.
     #[test]
-    fn test_submenu_d_disables_only_first_client_and_stays_open() {
+    fn test_submenu_d_disables_only_selected_client_and_stays_open() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Active));
         clients.push(make_client_with_state(2, ClientState::Active));
@@ -1084,8 +1125,13 @@ mod daemon_test {
         let clusters: Vec<Cluster> = Vec::new();
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(0);
 
-        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_D));
+        daemon.handle_enable_disable_submenu_key(
+            &mock_no_calls(),
+            &clients,
+            submenu_key_event(VK_D),
+        );
 
         assert_eq!(
             snapshot_states(&clients.lock().unwrap()),
@@ -1102,11 +1148,11 @@ mod daemon_test {
     }
 
     /// Verifies that `VK_T` in the enable/disable submenu flips only
-    /// the first client's state, keeps the submenu open after the
-    /// flip, and is its own inverse over two consecutive presses
-    /// without needing to re-enter the submenu in between.
+    /// the currently selected client's state, keeps the submenu open
+    /// after the flip, and is its own inverse over two consecutive
+    /// presses without needing to re-enter the submenu in between.
     #[test]
-    fn test_submenu_t_toggles_only_first_client_and_stays_open() {
+    fn test_submenu_t_toggles_only_selected_client_and_stays_open() {
         let mut clients = Clients::new();
         clients.push(make_client_with_state(1, ClientState::Active));
         clients.push(make_client_with_state(2, ClientState::Disabled));
@@ -1119,8 +1165,13 @@ mod daemon_test {
         let clusters: Vec<Cluster> = Vec::new();
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(0);
 
-        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_T));
+        daemon.handle_enable_disable_submenu_key(
+            &mock_no_calls(),
+            &clients,
+            submenu_key_event(VK_T),
+        );
         assert_eq!(
             snapshot_states(&clients.lock().unwrap()),
             vec![
@@ -1137,7 +1188,11 @@ mod daemon_test {
         // Second press without re-entering the submenu: the submenu
         // must still be open from the first press, and the toggle is
         // its own inverse.
-        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_T));
+        daemon.handle_enable_disable_submenu_key(
+            &mock_no_calls(),
+            &clients,
+            submenu_key_event(VK_T),
+        );
         assert_eq!(snapshot_states(&clients.lock().unwrap()), initial);
         assert_eq!(
             daemon.control_mode_state,
@@ -1161,8 +1216,13 @@ mod daemon_test {
         let clusters: Vec<Cluster> = Vec::new();
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(0);
 
-        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_X));
+        daemon.handle_enable_disable_submenu_key(
+            &mock_no_calls(),
+            &clients,
+            submenu_key_event(VK_X),
+        );
 
         assert_eq!(snapshot_states(&clients.lock().unwrap()), initial);
         assert_eq!(
@@ -1182,8 +1242,15 @@ mod daemon_test {
         let clusters: Vec<Cluster> = Vec::new();
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        // Submenu entry on an empty cluster leaves the selection at
+        // `None`; the dispatch must not panic.
+        daemon.submenu_selected_index = None;
 
-        daemon.handle_enable_disable_submenu_key(&clients, submenu_key_event(VK_E));
+        daemon.handle_enable_disable_submenu_key(
+            &mock_no_calls(),
+            &clients,
+            submenu_key_event(VK_E),
+        );
 
         assert!(clients.lock().unwrap().iter().next().is_none());
         assert_eq!(
@@ -1224,6 +1291,38 @@ mod daemon_test {
             (VK_E, EnableDisableSubmenuAction::Enable),
             (VK_D, EnableDisableSubmenuAction::Disable),
             (VK_T, EnableDisableSubmenuAction::Toggle),
+            (
+                VK_UP,
+                EnableDisableSubmenuAction::Navigate(NavigationDirection::Up),
+            ),
+            (
+                VK_K,
+                EnableDisableSubmenuAction::Navigate(NavigationDirection::Up),
+            ),
+            (
+                VK_DOWN,
+                EnableDisableSubmenuAction::Navigate(NavigationDirection::Down),
+            ),
+            (
+                VK_J,
+                EnableDisableSubmenuAction::Navigate(NavigationDirection::Down),
+            ),
+            (
+                VK_LEFT,
+                EnableDisableSubmenuAction::Navigate(NavigationDirection::Left),
+            ),
+            (
+                VK_H,
+                EnableDisableSubmenuAction::Navigate(NavigationDirection::Left),
+            ),
+            (
+                VK_RIGHT,
+                EnableDisableSubmenuAction::Navigate(NavigationDirection::Right),
+            ),
+            (
+                VK_L,
+                EnableDisableSubmenuAction::Navigate(NavigationDirection::Right),
+            ),
         ];
 
         for state in benign_states {
@@ -1289,8 +1388,10 @@ mod daemon_test {
         let clusters: Vec<Cluster> = Vec::new();
         let mut daemon =
             Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(0);
 
         daemon.handle_enable_disable_submenu_key(
+            &mock_no_calls(),
             &clients,
             submenu_key_event_with_state(VK_E, CAPSLOCK_ON | NUMLOCK_ON | ENHANCED_KEY),
         );
@@ -1298,7 +1399,7 @@ mod daemon_test {
         assert_eq!(
             snapshot_states(&clients.lock().unwrap()),
             vec![ClientState::Active, ClientState::Disabled],
-            "VK_E with lock-state bits set must still enable the first client",
+            "VK_E with lock-state bits set must still enable the selected client",
         );
         assert_eq!(
             daemon.control_mode_state,
@@ -1356,5 +1457,164 @@ mod daemon_test {
         // to `Inactive`.
         assert!(consumed);
         assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
+    }
+
+    /// Verifies that `quit_control_mode` clears
+    /// `submenu_selected_index` so the selection cursor never
+    /// outlives a control-mode session.
+    #[test]
+    fn test_quit_control_mode_clears_submenu_selection() {
+        use crate::utils::windows::MockWindowsApi;
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(2);
+
+        let mut mock = MockWindowsApi::new();
+        mock.expect_get_console_screen_buffer_info().returning(|| {
+            use windows::Win32::System::Console::{CONSOLE_SCREEN_BUFFER_INFO, COORD};
+            return Ok(CONSOLE_SCREEN_BUFFER_INFO {
+                dwSize: COORD { X: 80, Y: 25 },
+                ..Default::default()
+            });
+        });
+        mock.expect_scroll_console_screen_buffer()
+            .returning(|_, _, _| return Ok(()));
+        mock.expect_set_console_cursor_position()
+            .returning(|_| return Ok(()));
+
+        daemon.quit_control_mode(&mock);
+
+        assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
+        assert_eq!(daemon.submenu_selected_index, None);
+    }
+
+    /// Verifies that `move_submenu_selection` advances the cursor by
+    /// one position on `Down`/`Right` and clamps at `len - 1`.
+    #[test]
+    fn test_move_submenu_selection_down_right_clamp_at_last() {
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(0);
+
+        daemon.move_submenu_selection(NavigationDirection::Down, 3);
+        assert_eq!(daemon.submenu_selected_index, Some(1));
+        daemon.move_submenu_selection(NavigationDirection::Right, 3);
+        assert_eq!(daemon.submenu_selected_index, Some(2));
+        // Clamp at the last client - no wrap.
+        daemon.move_submenu_selection(NavigationDirection::Down, 3);
+        assert_eq!(daemon.submenu_selected_index, Some(2));
+        daemon.move_submenu_selection(NavigationDirection::Right, 3);
+        assert_eq!(daemon.submenu_selected_index, Some(2));
+    }
+
+    /// Verifies that `move_submenu_selection` steps back by one on
+    /// `Up`/`Left` and clamps at `0` rather than wrapping.
+    #[test]
+    fn test_move_submenu_selection_up_left_clamp_at_zero() {
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(2);
+
+        daemon.move_submenu_selection(NavigationDirection::Up, 3);
+        assert_eq!(daemon.submenu_selected_index, Some(1));
+        daemon.move_submenu_selection(NavigationDirection::Left, 3);
+        assert_eq!(daemon.submenu_selected_index, Some(0));
+        // Clamp at zero - no wrap.
+        daemon.move_submenu_selection(NavigationDirection::Up, 3);
+        assert_eq!(daemon.submenu_selected_index, Some(0));
+        daemon.move_submenu_selection(NavigationDirection::Left, 3);
+        assert_eq!(daemon.submenu_selected_index, Some(0));
+    }
+
+    /// Verifies that `move_submenu_selection` is a no-op when the
+    /// cluster is empty: the selection is cleared and stays `None`
+    /// across every direction.
+    #[test]
+    fn test_move_submenu_selection_empty_clients_stays_none() {
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = None;
+
+        for direction in [
+            NavigationDirection::Up,
+            NavigationDirection::Down,
+            NavigationDirection::Left,
+            NavigationDirection::Right,
+        ] {
+            daemon.move_submenu_selection(direction, 0);
+            assert_eq!(daemon.submenu_selected_index, None);
+        }
+    }
+
+    /// Verifies that the dispatch arm for `Navigate(Down)` calls
+    /// through `move_submenu_selection` and triggers a re-render
+    /// (which performs the console calls stubbed on the mock).
+    #[test]
+    fn test_submenu_navigate_down_advances_selection_via_dispatch() {
+        let mut clients = Clients::new();
+        clients.push(make_client_with_state(1, ClientState::Active));
+        clients.push(make_client_with_state(2, ClientState::Active));
+        clients.push(make_client_with_state(3, ClientState::Active));
+        let clients = Mutex::new(clients);
+
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(0);
+
+        daemon.handle_enable_disable_submenu_key(
+            &mock_with_clear_screen(),
+            &clients,
+            submenu_key_event(VK_DOWN),
+        );
+
+        assert_eq!(daemon.submenu_selected_index, Some(1));
+        assert_eq!(
+            daemon.control_mode_state,
+            ControlModeState::EnableDisableSubmenu
+        );
+    }
+
+    /// Verifies that `VK_E` targets the *selected* client rather
+    /// than always the first one - the regression the navigation
+    /// feature is designed to enable.
+    #[test]
+    fn test_submenu_e_targets_non_zero_selected_index() {
+        let mut clients = Clients::new();
+        clients.push(make_client_with_state(1, ClientState::Disabled));
+        clients.push(make_client_with_state(2, ClientState::Disabled));
+        clients.push(make_client_with_state(3, ClientState::Disabled));
+        let clients = Mutex::new(clients);
+
+        let config = DaemonConfig::default();
+        let clusters: Vec<Cluster> = Vec::new();
+        let mut daemon =
+            Daemon::for_test(&config, &clusters, ControlModeState::EnableDisableSubmenu);
+        daemon.submenu_selected_index = Some(1);
+
+        daemon.handle_enable_disable_submenu_key(
+            &mock_no_calls(),
+            &clients,
+            submenu_key_event(VK_E),
+        );
+
+        assert_eq!(
+            snapshot_states(&clients.lock().unwrap()),
+            vec![
+                ClientState::Disabled,
+                ClientState::Active,
+                ClientState::Disabled,
+            ],
+            "VK_E with selection at index 1 must enable only client 1",
+        );
     }
 }


### PR DESCRIPTION
The `[e]nable/disable input` submenu used to hardcode every action to
`clients.iter().next()`, leaving the rest of the cluster unreachable
without exiting the submenu and re-entering control mode. With this
change the arrow keys and the vim motions `h`, `j`, `k`, `l` move a
selection cursor across the cluster, the submenu prompt shows which
client is currently selected, and `[e]nable`, `[d]isable`, and
`[t]oggle` operate on that selected client.

GitHub: #201
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
