### PR TITLE
control mode: navigate the enable/disable submenu as a 2D grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ A collection containing daemon relevant configuration
 height = 200
 aspect_ratio_adjustement = -1.0
 console_color = 207
+submenu_edge_behavior = 'clamp'
 ```
 
 ##### `height`
@@ -167,6 +168,11 @@ BACKGROUND_RED:         64
 BACKGROUND_INTENSITY:   128
 ```
 e.g. white font on red background: 8+4+2+1+64+128 = `207`
+
+##### `submenu_edge_behavior`
+Selects what happens when an arrow / `hjkl` keystroke in the `[e]nable/disable input` submenu would move the highlight past the edge of the client grid.
+* `'clamp'` (default) - the highlight stays on the current cell.
+* `'wrap'` - the highlight wraps to the opposite edge of the same row (Left/Right) or column (Up/Down).
 
 ## Contributing
 csshW uses pre-commit githooks to enforce good code style.<br>

--- a/news/~submenu-2d-grid-nav.feature.md
+++ b/news/~submenu-2d-grid-nav.feature.md
@@ -1,0 +1,13 @@
+The `[e]nable/disable input` control-mode submenu now navigates the
+client tiles as a real 2D grid: arrow keys and `hjkl` move the
+highlight one cell in the requested direction, including across the
+partial-last-row boundary where cells span multiple upper-row columns.
+A Down + Up roundtrip returns to the starting cell because an anchor
+column is carried across vertical moves. When a client window has
+closed without a retile, surviving windows keep their on-screen
+positions and the navigation grid follows that visible layout - a
+vertical step into the gap snaps to the nearest surviving cell in the
+target row. The new `daemon.submenu_edge_behavior` key in
+`csshw-config.toml` selects what happens when the move would leave the
+grid: `clamp` (default, keeps the current selection) or `wrap` (wraps
+to the opposite edge of the same row or column).

--- a/src/daemon/grid.rs
+++ b/src/daemon/grid.rs
@@ -210,7 +210,7 @@ impl ClientGrid {
         let current = self.cell(pid)?;
         return match direction {
             NavigationDirection::Left | NavigationDirection::Right => {
-                self.step_horizontal(current, direction, edge)
+                self.step_horizontal(current, anchor_col, direction, edge)
             }
             NavigationDirection::Up | NavigationDirection::Down => {
                 Some(self.step_vertical(current, anchor_col, direction, edge))
@@ -220,10 +220,13 @@ impl ClientGrid {
 
     /// Horizontal step within `current.row`. Returns `None` only when
     /// the row somehow contains no cells (cannot happen for a valid
-    /// `current` looked up from the grid).
+    /// `current` looked up from the grid). A clamped no-op preserves
+    /// the in-flight `anchor_col` so a subsequent vertical step still
+    /// targets the column the user originally carried over.
     fn step_horizontal(
         &self,
         current: &GridCell,
+        anchor_col: i32,
         direction: NavigationDirection,
         edge: EdgeBehavior,
     ) -> Option<(u32, i32)> {
@@ -238,9 +241,7 @@ impl ClientGrid {
             NavigationDirection::Left => {
                 if pos == 0 {
                     match edge {
-                        EdgeBehavior::Clamp => {
-                            return Some((current.pid, self.anchor_for(current)));
-                        }
+                        EdgeBehavior::Clamp => return Some((current.pid, anchor_col)),
                         EdgeBehavior::Wrap => *row_cells.last()?,
                     }
                 } else {
@@ -250,9 +251,7 @@ impl ClientGrid {
             NavigationDirection::Right => {
                 if pos + 1 >= row_cells.len() {
                     match edge {
-                        EdgeBehavior::Clamp => {
-                            return Some((current.pid, self.anchor_for(current)));
-                        }
+                        EdgeBehavior::Clamp => return Some((current.pid, anchor_col)),
                         EdgeBehavior::Wrap => *row_cells.first()?,
                     }
                 } else {

--- a/src/daemon/grid.rs
+++ b/src/daemon/grid.rs
@@ -36,7 +36,7 @@ pub(super) struct GridCell {
     pub pos_in_row: i32,
 }
 
-/// Spatial-grid view over a launch-ordered sequence of client PIDs.
+/// Spatial-grid view over the tracked client PIDs.
 pub(super) struct ClientGrid {
     /// Number of columns in the dense upper rows.
     pub cols: i32,
@@ -45,7 +45,7 @@ pub(super) struct ClientGrid {
     /// Cell count in the last row. `0` means the last row is also dense;
     /// otherwise `1..cols` last-row cells are stretched proportionally.
     last_row_count: i32,
-    /// Cells in launch order.
+    /// Cells sorted by `(row, col)` so the top-left cell is at index `0`.
     cells: Vec<GridCell>,
     /// PID lookup table.
     by_pid: HashMap<u32, usize>,
@@ -153,8 +153,9 @@ impl ClientGrid {
         return self.by_pid.get(&pid).map(|&i| return &self.cells[i]);
     }
 
-    /// First cell in launch order, or `None` for an empty grid.
-    pub(super) fn first_pid(&self) -> Option<u32> {
+    /// PID of the top-left cell, or `None` for an empty grid. Used to
+    /// re-anchor the submenu selection onto a sensible visual default.
+    pub(super) fn top_left_pid(&self) -> Option<u32> {
         return self.cells.first().map(|c| return c.pid);
     }
 
@@ -178,7 +179,7 @@ impl ClientGrid {
     /// # Returns
     ///
     /// The anchor column for the cell.
-    fn anchor_for(&self, cell: &GridCell) -> i32 {
+    pub(super) fn anchor_for(&self, cell: &GridCell) -> i32 {
         if cell.row == self.rows - 1 && self.last_row_count != 0 {
             return ((2 * cell.pos_in_row + 1) * self.cols) / (2 * self.last_row_count);
         }

--- a/src/daemon/grid.rs
+++ b/src/daemon/grid.rs
@@ -1,0 +1,333 @@
+//! Spatial grid model of the client windows.
+//!
+//! The tiler in [`super`] arranges `n` client windows on a grid of
+//! `cols * rows` cells, with the final row possibly stretched to span
+//! the full width when `n % cols != 0`. This module mirrors that layout
+//! as a pure data structure so the enable/disable submenu can navigate
+//! the cells spatially with arrow keys and `hjkl`.
+
+#![deny(clippy::implicit_return)]
+#![allow(clippy::needless_return, clippy::doc_overindented_list_items)]
+
+use std::cmp::max;
+use std::collections::HashMap;
+
+use super::NavigationDirection;
+use crate::utils::config::EdgeBehavior;
+
+/// One client window's position on the spatial grid.
+///
+/// `col` is the leftmost upper-grid column the cell projects onto and
+/// `col_span` is how many upper-grid columns it spans. Rows `0..rows-2`
+/// are dense (`col_span == 1`); cells in a partial last row are stretched
+/// (`col_span >= 1`).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(super) struct GridCell {
+    /// Process id of the client owning this cell.
+    pub pid: u32,
+    /// 0-based row index.
+    pub row: i32,
+    /// Leftmost upper-grid column the cell projects onto.
+    pub col: i32,
+    /// Number of upper-grid columns the cell projects onto. Always
+    /// `>= 1`; only `> 1` for partial-last-row cells.
+    pub col_span: i32,
+    /// 0-based position within the row, used for vertical roundtrips.
+    pub pos_in_row: i32,
+}
+
+/// Spatial-grid view over a launch-ordered sequence of client PIDs.
+pub(super) struct ClientGrid {
+    /// Number of columns in the dense upper rows.
+    pub cols: i32,
+    /// Total number of rows (`>= 1` whenever there is at least one cell).
+    pub rows: i32,
+    /// Cell count in the last row. `0` means the last row is also dense;
+    /// otherwise `1..cols` last-row cells are stretched proportionally.
+    last_row_count: i32,
+    /// Cells in launch order.
+    cells: Vec<GridCell>,
+    /// PID lookup table.
+    by_pid: HashMap<u32, usize>,
+}
+
+/// Compute the grid dimensions for `n` clients on a workspace with the
+/// given aspect ratio.
+///
+/// Must match the formula used by the tiler in
+/// [`super::determine_client_spatial_attributes`] so layout and
+/// navigation stay in sync.
+///
+/// # Arguments
+///
+/// * `n`           - Number of client windows.
+/// * `aspect`      - `workspace_width / workspace_height` (including
+///                   frame padding) of the available area.
+/// * `aspect_adj`  - The `aspect_ratio_adjustement` daemon config.
+///
+/// # Returns
+///
+/// `(cols, rows)`, each clamped to a minimum of `1`.
+pub(super) fn grid_dimensions(n: i32, aspect: f64, aspect_adj: f64) -> (i32, i32) {
+    let cols = max(((n as f64).sqrt() * (aspect + aspect_adj)) as i32, 1);
+    let rows = max((n as f64 / cols as f64).ceil() as i32, 1);
+    return (cols, rows);
+}
+
+impl ClientGrid {
+    /// Build the grid from `(pid, tile_index)` pairs and the dimensions
+    /// returned by [`grid_dimensions`] for the same `layout_n`.
+    ///
+    /// `tile_index` is the position each client was assigned the last
+    /// time the tiler positioned its window. Surviving clients keep
+    /// their `tile_index` across closures, so passing them here together
+    /// with the layout's original `layout_n` produces a grid whose cells
+    /// land at the same `(row, col)` the user sees on screen - with
+    /// gaps where a window was closed but no retile has happened yet.
+    ///
+    /// # Arguments
+    ///
+    /// * `cells`     - `(pid, tile_index)` pairs for every surviving
+    ///                 client.
+    /// * `layout_n`  - The `number_of_consoles` the on-screen layout was
+    ///                 last computed with. Used to derive the
+    ///                 partial-last-row stretch.
+    /// * `cols`      - Columns from [`grid_dimensions`] for `layout_n`.
+    /// * `rows`      - Rows from [`grid_dimensions`] for `layout_n`.
+    ///
+    /// # Returns
+    ///
+    /// A populated [`ClientGrid`].
+    pub(super) fn from_tiled_pids(
+        cells: &[(u32, usize)],
+        layout_n: i32,
+        cols: i32,
+        rows: i32,
+    ) -> Self {
+        let last_row_count = if cols > 0 { layout_n % cols } else { 0 };
+        let mut grid_cells = Vec::with_capacity(cells.len());
+        for &(pid, tile_index) in cells {
+            let idx = tile_index as i32;
+            let row = if cols > 0 { idx / cols } else { 0 };
+            let pos_in_row = if cols > 0 { idx % cols } else { 0 };
+            let (col, col_span) = if row == rows - 1 && last_row_count != 0 {
+                let left = (pos_in_row * cols) / last_row_count;
+                let right = ((pos_in_row + 1) * cols - 1) / last_row_count;
+                (left, right - left + 1)
+            } else {
+                (pos_in_row, 1)
+            };
+            grid_cells.push(GridCell {
+                pid,
+                row,
+                col,
+                col_span,
+                pos_in_row,
+            });
+        }
+        grid_cells.sort_by_key(|c| return (c.row, c.col));
+        let by_pid = grid_cells
+            .iter()
+            .enumerate()
+            .map(|(i, c)| return (c.pid, i))
+            .collect();
+        return ClientGrid {
+            cols,
+            rows,
+            last_row_count,
+            cells: grid_cells,
+            by_pid,
+        };
+    }
+
+    /// Look up the cell owned by `pid`.
+    ///
+    /// # Arguments
+    ///
+    /// * `pid` - Process id to look up.
+    ///
+    /// # Returns
+    ///
+    /// `Some(&GridCell)` when present, `None` otherwise.
+    pub(super) fn cell(&self, pid: u32) -> Option<&GridCell> {
+        return self.by_pid.get(&pid).map(|&i| return &self.cells[i]);
+    }
+
+    /// First cell in launch order, or `None` for an empty grid.
+    pub(super) fn first_pid(&self) -> Option<u32> {
+        return self.cells.first().map(|c| return c.pid);
+    }
+
+    /// `true` when the grid has no cells.
+    pub(super) fn is_empty(&self) -> bool {
+        return self.cells.is_empty();
+    }
+
+    /// Compute the anchor column for a cell. Horizontal moves overwrite
+    /// the in-flight anchor with the destination cell's anchor.
+    ///
+    /// Upper-row cells: their `col` (each cell occupies exactly one
+    /// upper-grid column). Partial-last-row cells: the upper-grid column
+    /// containing the cell's x-midpoint. The latter makes a Down + Up
+    /// roundtrip return to the original cell from any starting point.
+    ///
+    /// # Arguments
+    ///
+    /// * `cell` - The destination cell.
+    ///
+    /// # Returns
+    ///
+    /// The anchor column for the cell.
+    fn anchor_for(&self, cell: &GridCell) -> i32 {
+        if cell.row == self.rows - 1 && self.last_row_count != 0 {
+            return ((2 * cell.pos_in_row + 1) * self.cols) / (2 * self.last_row_count);
+        }
+        return cell.col;
+    }
+
+    /// Compute the next selection after one navigation keystroke.
+    ///
+    /// # Arguments
+    ///
+    /// * `pid`        - Currently highlighted PID.
+    /// * `anchor_col` - Anchor column carried from earlier moves.
+    /// * `direction`  - Direction of the keystroke.
+    /// * `edge`       - Behavior when the move would leave the grid.
+    ///
+    /// # Returns
+    ///
+    /// `Some((new_pid, new_anchor_col))` on a successful step.
+    /// `None` when `pid` is not present in this grid (caller should
+    /// re-anchor).
+    pub(super) fn step(
+        &self,
+        pid: u32,
+        anchor_col: i32,
+        direction: NavigationDirection,
+        edge: EdgeBehavior,
+    ) -> Option<(u32, i32)> {
+        let current = self.cell(pid)?;
+        return match direction {
+            NavigationDirection::Left | NavigationDirection::Right => {
+                self.step_horizontal(current, direction, edge)
+            }
+            NavigationDirection::Up | NavigationDirection::Down => {
+                Some(self.step_vertical(current, anchor_col, direction, edge))
+            }
+        };
+    }
+
+    /// Horizontal step within `current.row`. Returns `None` only when
+    /// the row somehow contains no cells (cannot happen for a valid
+    /// `current` looked up from the grid).
+    fn step_horizontal(
+        &self,
+        current: &GridCell,
+        direction: NavigationDirection,
+        edge: EdgeBehavior,
+    ) -> Option<(u32, i32)> {
+        let mut row_cells: Vec<&GridCell> = self
+            .cells
+            .iter()
+            .filter(|c| return c.row == current.row)
+            .collect();
+        row_cells.sort_by_key(|c| return c.col);
+        let pos = row_cells.iter().position(|c| return c.pid == current.pid)?;
+        let next = match direction {
+            NavigationDirection::Left => {
+                if pos == 0 {
+                    match edge {
+                        EdgeBehavior::Clamp => {
+                            return Some((current.pid, self.anchor_for(current)));
+                        }
+                        EdgeBehavior::Wrap => *row_cells.last()?,
+                    }
+                } else {
+                    row_cells[pos - 1]
+                }
+            }
+            NavigationDirection::Right => {
+                if pos + 1 >= row_cells.len() {
+                    match edge {
+                        EdgeBehavior::Clamp => {
+                            return Some((current.pid, self.anchor_for(current)));
+                        }
+                        EdgeBehavior::Wrap => *row_cells.first()?,
+                    }
+                } else {
+                    row_cells[pos + 1]
+                }
+            }
+            _ => return None,
+        };
+        return Some((next.pid, self.anchor_for(next)));
+    }
+
+    /// Vertical step into the target row, preserving the in-flight
+    /// `anchor_col`.
+    fn step_vertical(
+        &self,
+        current: &GridCell,
+        anchor_col: i32,
+        direction: NavigationDirection,
+        edge: EdgeBehavior,
+    ) -> (u32, i32) {
+        let target_row = match direction {
+            NavigationDirection::Up => {
+                if current.row == 0 {
+                    match edge {
+                        EdgeBehavior::Clamp => return (current.pid, anchor_col),
+                        EdgeBehavior::Wrap => self.rows - 1,
+                    }
+                } else {
+                    current.row - 1
+                }
+            }
+            NavigationDirection::Down => {
+                if current.row + 1 >= self.rows {
+                    match edge {
+                        EdgeBehavior::Clamp => return (current.pid, anchor_col),
+                        EdgeBehavior::Wrap => 0,
+                    }
+                } else {
+                    current.row + 1
+                }
+            }
+            _ => return (current.pid, anchor_col),
+        };
+        let row_cells: Vec<&GridCell> = self
+            .cells
+            .iter()
+            .filter(|c| return c.row == target_row)
+            .collect();
+        if row_cells.is_empty() {
+            return (current.pid, anchor_col);
+        }
+        let is_partial_last_row = target_row == self.rows - 1 && self.last_row_count != 0;
+        let best = row_cells
+            .into_iter()
+            .min_by_key(|c| {
+                return (
+                    self.anchor_distance(c, anchor_col, is_partial_last_row),
+                    c.col,
+                );
+            })
+            .expect("row_cells just checked non-empty");
+        return (best.pid, anchor_col);
+    }
+
+    /// Spatial distance between a cell and an anchor column, used to
+    /// pick the target on a vertical step. Dense rows reduce to
+    /// `|c.col - anchor|`; partial-last-row cells use their stretched
+    /// x-extent so the cell whose midpoint is closest to the anchor's
+    /// centerline wins. The result is in arbitrary integer units valid
+    /// only for comparisons within the same row.
+    fn anchor_distance(&self, cell: &GridCell, anchor_col: i32, is_partial_last_row: bool) -> i64 {
+        if is_partial_last_row {
+            let cell_mid = (2 * cell.pos_in_row as i64 + 1) * self.cols as i64;
+            let anchor_mid = (2 * anchor_col as i64 + 1) * self.last_row_count as i64;
+            return (cell_mid - anchor_mid).abs();
+        }
+        return (2 * cell.col as i64 - 2 * anchor_col as i64).abs();
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::needless_return, clippy::doc_overindented_list_items)]
 #![warn(missing_docs)]
 
-use std::cmp::max;
 use std::collections::HashMap;
 use std::{
     io,
@@ -21,7 +20,7 @@ use crate::protocol::{
     SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH, TAG_HIGHLIGHT, TAG_INPUT_RECORD,
     TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
 };
-use crate::utils::config::{Cluster, DaemonConfig};
+use crate::utils::config::{Cluster, DaemonConfig, EdgeBehavior};
 use crate::utils::debug::StringRepr;
 use crate::utils::windows::{clear_screen, set_console_color, WindowsApi};
 use crate::{
@@ -60,8 +59,10 @@ use windows::Win32::{
     System::{Console::ENABLE_PROCESSED_INPUT, Threading::PROCESS_QUERY_INFORMATION},
 };
 
+use self::grid::{grid_dimensions, ClientGrid};
 use self::workspace::WorkspaceArea;
 
+mod grid;
 mod workspace;
 
 /// The capacity of the broadcast channel used
@@ -226,6 +227,11 @@ struct Client {
     /// the client is the daemon's currently selected submenu client.
     /// Visual only; input gating uses [`Client::state_sender`].
     highlight_sender: watch::Sender<bool>,
+    /// Index passed to [`arrange_client_window`] when this client's
+    /// on-screen position was last computed. Survives
+    /// [`Clients::retain`] so the submenu navigation grid keeps
+    /// matching the visible layout until the next retile.
+    tile_index: usize,
 }
 
 unsafe impl Send for Client {}
@@ -242,6 +248,13 @@ struct Clients {
     list: Vec<Client>,
     /// Maps a client's process id to its index in [`list`](Clients::list).
     pid_index: HashMap<u32, usize>,
+    /// `number_of_consoles` value the current on-screen layout was
+    /// computed with. Drives [`grid_dimensions`] for the submenu nav.
+    /// Updated when the tiler positions windows
+    /// ([`Clients::reset_tile_layout`]); preserved across
+    /// [`Clients::retain`] so a closed-but-not-retiled window leaves
+    /// a visible gap in the grid too.
+    layout_n: usize,
 }
 
 impl Clients {
@@ -250,6 +263,7 @@ impl Clients {
         return Clients {
             list: Vec::new(),
             pid_index: HashMap::new(),
+            layout_n: 0,
         };
     }
 
@@ -264,15 +278,43 @@ impl Clients {
     ///
     /// Panics if a client with the same process id is already present, as
     /// duplicate PIDs indicate broken daemon bookkeeping.
-    fn push(&mut self, client: Client) {
+    fn push(&mut self, mut client: Client) {
         let index = self.list.len();
         assert!(
             !self.pid_index.contains_key(&client.process_id),
             "Duplicate client PID {} - daemon bookkeeping broken",
             client.process_id,
         );
+        // Push assumes the new client occupies the next cell in a dense
+        // layout - matching what the tiler does at initial launch and
+        // right after `[c]reate`. `retain` leaves these values alone so
+        // closed-but-not-retiled gaps stay visible to the navigation
+        // grid. The next retile renumbers everything dense again.
+        client.tile_index = index;
         self.pid_index.insert(client.process_id, index);
         self.list.push(client);
+        self.layout_n = self.list.len();
+    }
+
+    /// Reassigns dense [`Client::tile_index`] values to `valid_pids` in
+    /// the supplied order and snapshots the new [`Clients::layout_n`].
+    ///
+    /// Called by [`Daemon::rearrange_client_windows`] right before it
+    /// re-positions the actual windows on screen, so navigation reads
+    /// the same layout the tiler just applied.
+    ///
+    /// # Arguments
+    ///
+    /// * `valid_pids` - PIDs of the clients that will be tiled, in the
+    ///                  order they will be passed to
+    ///                  [`arrange_client_window`].
+    fn reset_tile_layout(&mut self, valid_pids: &[u32]) {
+        for (index, pid) in valid_pids.iter().enumerate() {
+            if let Some(&list_index) = self.pid_index.get(pid) {
+                self.list[list_index].tile_index = index;
+            }
+        }
+        self.layout_n = valid_pids.len();
     }
 
     /// Returns a reference to the client with the given process id, if any.
@@ -289,10 +331,6 @@ impl Clients {
             .pid_index
             .get(&pid)
             .map(|&index| return &self.list[index]);
-    }
-
-    fn index_of_pid(&self, pid: u32) -> Option<usize> {
-        return self.pid_index.get(&pid).copied();
     }
 
     /// Retains only the clients for which the predicate returns `true`,
@@ -391,7 +429,17 @@ enum ControlModeState {
     /// control mode entirely. `highlighted_pid` is the currently selected
     /// client (`None` when the cluster is empty); tracking by PID survives
     /// background-monitor `retain`s while the submenu is open.
-    EnableDisableSubmenu { highlighted_pid: Option<u32> },
+    ///
+    /// `anchor_col` is the upper-grid column carried across vertical
+    /// moves so a Down + Up roundtrip across the partial-last-row
+    /// boundary returns to the start cell. `None` while
+    /// `highlighted_pid` is `None`.
+    EnableDisableSubmenu {
+        /// PID of the highlighted client, or `None` for an empty cluster.
+        highlighted_pid: Option<u32>,
+        /// Anchor upper-grid column carried across vertical moves.
+        anchor_col: Option<i32>,
+    },
 }
 
 /// The daemon is responsible to launch a client for
@@ -422,37 +470,77 @@ struct Daemon<'a> {
     debug: bool,
 }
 
-/// Compute the PID of the client one step from `current_pid` in
-/// `direction`, clamped to `clients`. Re-anchors on the first surviving
-/// client when `current_pid` is no longer present (retained out while
-/// the submenu was open).
+/// Compute the next submenu selection given a grid step.
+///
+/// Re-anchors on the first surviving client when `current_pid` is no
+/// longer present (retained out while the submenu was open).
 ///
 /// # Arguments
 ///
-/// * `clients`     - Currently tracked clients.
+/// * `grid`        - Spatial grid view over the currently tracked clients.
 /// * `current_pid` - PID currently highlighted, or `None`.
+/// * `anchor_col`  - Anchor column carried from earlier moves.
 /// * `direction`   - Direction the navigation keystroke encoded.
+/// * `edge`        - Behavior when the move would leave the grid.
 ///
 /// # Returns
 ///
-/// The PID to highlight next, or `None` for an empty cluster.
-fn next_submenu_pid(
-    clients: &Clients,
+/// `(new_pid, new_anchor_col)` to apply, or `(None, None)` for an empty
+/// cluster.
+fn next_submenu_selection(
+    grid: &ClientGrid,
     current_pid: Option<u32>,
+    anchor_col: Option<i32>,
     direction: NavigationDirection,
-) -> Option<u32> {
-    if clients.is_empty() {
-        return None;
+    edge: EdgeBehavior,
+) -> (Option<u32>, Option<i32>) {
+    if grid.is_empty() {
+        return (None, None);
     }
-    let Some(current_index) = current_pid.and_then(|pid| return clients.index_of_pid(pid)) else {
-        return clients.first().map(|c| return c.process_id);
+    let current_pid = match current_pid.and_then(|pid| return grid.cell(pid)) {
+        Some(cell) => cell.pid,
+        None => {
+            let first = grid.first_pid();
+            let first_anchor = first
+                .and_then(|pid| return grid.cell(pid))
+                .map(|c| return c.col);
+            return (first, first_anchor);
+        }
     };
-    let last = clients.len() - 1;
-    let next_index = match direction {
-        NavigationDirection::Up | NavigationDirection::Left => current_index.saturating_sub(1),
-        NavigationDirection::Down | NavigationDirection::Right => (current_index + 1).min(last),
+    let anchor = anchor_col.unwrap_or_else(|| {
+        return grid.cell(current_pid).map(|c| return c.col).unwrap_or(0);
+    });
+    return match grid.step(current_pid, anchor, direction, edge) {
+        Some((pid, new_anchor)) => (Some(pid), Some(new_anchor)),
+        None => (Some(current_pid), Some(anchor)),
     };
-    return clients.get(next_index).map(|c| return c.process_id);
+}
+
+/// Build a [`ClientGrid`] from `clients` and `workspace_area` using the
+/// same aspect-ratio expression the tiler uses.
+///
+/// # Arguments
+///
+/// * `clients`                   - Currently tracked clients in launch order.
+/// * `workspace_area`            - Available workspace minus the daemon console.
+/// * `aspect_ratio_adjustment`   - The `aspect_ratio_adjustement` daemon config.
+///
+/// # Returns
+///
+/// A populated [`ClientGrid`].
+fn build_client_grid(
+    clients: &Clients,
+    workspace_area: &workspace::WorkspaceArea,
+    aspect_ratio_adjustment: f64,
+) -> ClientGrid {
+    let aspect = workspace_aspect_ratio(workspace_area);
+    let layout_n = clients.layout_n as i32;
+    let (cols, rows) = grid_dimensions(layout_n, aspect, aspect_ratio_adjustment);
+    let cells: Vec<(u32, usize)> = clients
+        .iter()
+        .map(|c| return (c.process_id, c.tile_index))
+        .collect();
+    return ClientGrid::from_tiled_pids(&cells, layout_n, cols, rows);
 }
 
 impl<'a> Daemon<'a> {
@@ -717,7 +805,12 @@ impl<'a> Daemon<'a> {
                 self.control_mode_state,
                 ControlModeState::EnableDisableSubmenu { .. }
             ) {
-                self.handle_enable_disable_submenu_key(windows_api, clients, key_event);
+                self.handle_enable_disable_submenu_key(
+                    windows_api,
+                    clients,
+                    workspace_area,
+                    key_event,
+                );
                 return;
             }
             match classify_control_mode_key(
@@ -727,17 +820,26 @@ impl<'a> Daemon<'a> {
                 ControlModeAction::Retile => {
                     self.rearrange_client_windows(
                         windows_api,
-                        &clients.lock().unwrap(),
+                        &mut clients.lock().unwrap(),
                         workspace_area,
                     );
                     self.arrange_daemon_console(windows_api, workspace_area);
                 }
                 ControlModeAction::OpenEnableDisableSubmenu => {
                     let clients_guard = clients.lock().unwrap();
-                    let next_pid = clients_guard.first().map(|c| return c.process_id);
+                    let grid = build_client_grid(
+                        &clients_guard,
+                        workspace_area,
+                        self.config.aspect_ratio_adjustement,
+                    );
+                    let next_pid = grid.first_pid();
+                    let anchor_col = next_pid
+                        .and_then(|p| return grid.cell(p))
+                        .map(|c| return c.col);
                     self.apply_submenu_highlight(&clients_guard, None, next_pid);
                     self.control_mode_state = ControlModeState::EnableDisableSubmenu {
                         highlighted_pid: next_pid,
+                        anchor_col,
                     };
                     self.render_enable_disable_submenu(windows_api);
                 }
@@ -810,7 +912,7 @@ impl<'a> Daemon<'a> {
                     toggle_processed_input_mode(windows_api); // Re-disable processed input mode.
                     self.rearrange_client_windows(
                         windows_api,
-                        &clients.lock().unwrap(),
+                        &mut clients.lock().unwrap(),
                         workspace_area,
                     );
                     self.arrange_daemon_console(windows_api, workspace_area);
@@ -891,8 +993,9 @@ impl<'a> Daemon<'a> {
             )
         {
             if key_event.wVirtualKeyCode == VK_ESCAPE.0 {
-                if let ControlModeState::EnableDisableSubmenu { highlighted_pid } =
-                    self.control_mode_state
+                if let ControlModeState::EnableDisableSubmenu {
+                    highlighted_pid, ..
+                } = self.control_mode_state
                 {
                     let clients_guard = clients.lock().unwrap();
                     self.apply_submenu_highlight(&clients_guard, highlighted_pid, None);
@@ -950,26 +1053,28 @@ impl<'a> Daemon<'a> {
     fn rearrange_client_windows<W: WindowsApi>(
         &self,
         windows_api: &W,
-        clients: &[Client],
+        clients: &mut Clients,
         workspace_area: &workspace::WorkspaceArea,
     ) {
-        let mut valid_clients = Vec::new();
+        let mut valid_layout: Vec<(u32, HWND)> = Vec::new();
         for client in clients.iter() {
             let exit_code = match windows_api.get_exit_code(client.process_handle) {
                 Ok(code) => code,
                 Err(_) => continue, // Process handle is invalid, skip client
             };
             if exit_code == STILL_ACTIVE.0 as u32 && windows_api.is_window(client.window_handle) {
-                valid_clients.push(client);
+                valid_layout.push((client.process_id, client.window_handle));
             }
         }
-        for (index, client) in valid_clients.iter().enumerate() {
+        let valid_pids: Vec<u32> = valid_layout.iter().map(|(pid, _)| return *pid).collect();
+        clients.reset_tile_layout(&valid_pids);
+        for (index, (_, window_handle)) in valid_layout.iter().enumerate() {
             arrange_client_window(
                 windows_api,
-                &client.window_handle,
+                window_handle,
                 workspace_area,
                 index,
-                valid_clients.len(),
+                valid_layout.len(),
                 self.config.aspect_ratio_adjustement,
             )
         }
@@ -993,9 +1098,13 @@ impl<'a> Daemon<'a> {
         &mut self,
         windows_api: &W,
         clients: &Mutex<Clients>,
+        workspace_area: &workspace::WorkspaceArea,
         key_event: KEY_EVENT_RECORD,
     ) {
-        let ControlModeState::EnableDisableSubmenu { highlighted_pid } = self.control_mode_state
+        let ControlModeState::EnableDisableSubmenu {
+            highlighted_pid,
+            anchor_col,
+        } = self.control_mode_state
         else {
             return;
         };
@@ -1035,10 +1144,22 @@ impl<'a> Daemon<'a> {
             }
             EnableDisableSubmenuAction::Navigate(direction) => {
                 let clients_guard = clients.lock().unwrap();
-                let next_pid = next_submenu_pid(&clients_guard, highlighted_pid, direction);
+                let grid = build_client_grid(
+                    &clients_guard,
+                    workspace_area,
+                    self.config.aspect_ratio_adjustement,
+                );
+                let (next_pid, next_anchor) = next_submenu_selection(
+                    &grid,
+                    highlighted_pid,
+                    anchor_col,
+                    direction,
+                    self.config.submenu_edge_behavior,
+                );
                 self.apply_submenu_highlight(&clients_guard, highlighted_pid, next_pid);
                 self.control_mode_state = ControlModeState::EnableDisableSubmenu {
                     highlighted_pid: next_pid,
+                    anchor_col: next_anchor,
                 };
                 self.render_enable_disable_submenu(windows_api);
             }
@@ -1315,6 +1436,9 @@ async fn launch_clients<W: WindowsApi + 'static + Clone>(
                     process_id,
                     state_sender,
                     highlight_sender,
+                    // Placeholder - `Clients::push` overwrites with the
+                    // dense `list.len()`-based tile index.
+                    tile_index: 0,
                 },
             );
         });
@@ -1742,6 +1866,24 @@ fn arrange_client_window<W: WindowsApi>(
         });
 }
 
+/// Return the workspace area's aspect ratio (width / height) including
+/// the frame padding the tiler accounts for.
+///
+/// # Arguments
+///
+/// * `workspace_area` - Available workspace minus the daemon console.
+///
+/// # Returns
+///
+/// Aspect ratio as a `f64` for use by both the tiler and the navigation
+/// grid.
+fn workspace_aspect_ratio(workspace_area: &workspace::WorkspaceArea) -> f64 {
+    return (workspace_area.width + (workspace_area.x_fixed_frame + workspace_area.x_size_frame) * 2)
+        as f64
+        / (workspace_area.height + (workspace_area.y_fixed_frame + workspace_area.y_size_frame) * 2)
+            as f64;
+}
+
 /// Calculates the position and dimensions for a client window given its index,
 /// the total number of clients and the `aspect_ratio_adjustment` daemon configuration.
 ///
@@ -1766,20 +1908,9 @@ fn determine_client_spatial_attributes(
     workspace_area: &workspace::WorkspaceArea,
     aspect_ratio_adjustment: f64,
 ) -> (i32, i32, i32, i32) {
-    let aspect_ratio = (workspace_area.width
-        + (workspace_area.x_fixed_frame + workspace_area.x_size_frame) * 2)
-        as f64
-        / (workspace_area.height + (workspace_area.y_fixed_frame + workspace_area.y_size_frame) * 2)
-            as f64;
-
-    let grid_columns = max(
-        ((number_of_consoles as f64).sqrt() * (aspect_ratio + aspect_ratio_adjustment)) as i32,
-        1,
-    );
-    let grid_rows = max(
-        (number_of_consoles as f64 / grid_columns as f64).ceil() as i32,
-        1,
-    );
+    let aspect_ratio = workspace_aspect_ratio(workspace_area);
+    let (grid_columns, grid_rows) =
+        grid_dimensions(number_of_consoles, aspect_ratio, aspect_ratio_adjustment);
 
     let grid_column_index = index % grid_columns;
     let grid_row_index = index / grid_columns;
@@ -1915,6 +2046,7 @@ fn defer_windows<W: WindowsApi>(windows_api: &W, clients: &[Client], daemon_hand
         process_id: 0,
         state_sender: watch::channel(ClientState::Active).0,
         highlight_sender: watch::channel(false).0,
+        tile_index: 0,
     }]) {
         let placement = match windows_api.get_window_placement(client.window_handle) {
             Ok(placement) => placement,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -303,12 +303,25 @@ impl Clients {
     /// re-positions the actual windows on screen, so navigation reads
     /// the same layout the tiler just applied.
     ///
+    /// Invariant: `valid_pids` must cover every PID currently tracked
+    /// in `self.list`. Passing a strict subset (e.g. a liveness-filtered
+    /// list) would shrink `layout_n` while leaving stale `tile_index >=
+    /// layout_n` values on the excluded clients, breaking the
+    /// [`ClientGrid`] built from this collection. Drop dead clients
+    /// via [`Clients::retain`] before retiling.
+    ///
     /// # Arguments
     ///
     /// * `valid_pids` - PIDs of the clients that will be tiled, in the
     ///                  order they will be passed to
     ///                  [`arrange_client_window`].
     fn reset_tile_layout(&mut self, valid_pids: &[u32]) {
+        debug_assert_eq!(
+            valid_pids.len(),
+            self.list.len(),
+            "reset_tile_layout must receive every tracked client; \
+             call Clients::retain to drop dead entries first",
+        );
         for (index, pid) in valid_pids.iter().enumerate() {
             if let Some(&list_index) = self.pid_index.get(pid) {
                 self.list[list_index].tile_index = index;
@@ -500,15 +513,18 @@ fn next_submenu_selection(
     let current_pid = match current_pid.and_then(|pid| return grid.cell(pid)) {
         Some(cell) => cell.pid,
         None => {
-            let first = grid.first_pid();
+            let first = grid.top_left_pid();
             let first_anchor = first
                 .and_then(|pid| return grid.cell(pid))
-                .map(|c| return c.col);
+                .map(|c| return grid.anchor_for(c));
             return (first, first_anchor);
         }
     };
     let anchor = anchor_col.unwrap_or_else(|| {
-        return grid.cell(current_pid).map(|c| return c.col).unwrap_or(0);
+        return grid
+            .cell(current_pid)
+            .map(|c| return grid.anchor_for(c))
+            .unwrap_or(0);
     });
     return match grid.step(current_pid, anchor, direction, edge) {
         Some((pid, new_anchor)) => (Some(pid), Some(new_anchor)),
@@ -832,10 +848,10 @@ impl<'a> Daemon<'a> {
                         workspace_area,
                         self.config.aspect_ratio_adjustement,
                     );
-                    let next_pid = grid.first_pid();
+                    let next_pid = grid.top_left_pid();
                     let anchor_col = next_pid
                         .and_then(|p| return grid.cell(p))
-                        .map(|c| return c.col);
+                        .map(|c| return grid.anchor_for(c));
                     self.apply_submenu_highlight(&clients_guard, None, next_pid);
                     self.control_mode_state = ControlModeState::EnableDisableSubmenu {
                         highlighted_pid: next_pid,
@@ -1056,16 +1072,18 @@ impl<'a> Daemon<'a> {
         clients: &mut Clients,
         workspace_area: &workspace::WorkspaceArea,
     ) {
-        let mut valid_layout: Vec<(u32, HWND)> = Vec::new();
-        for client in clients.iter() {
+        clients.retain(|client| {
             let exit_code = match windows_api.get_exit_code(client.process_handle) {
                 Ok(code) => code,
-                Err(_) => continue, // Process handle is invalid, skip client
+                Err(_) => return false,
             };
-            if exit_code == STILL_ACTIVE.0 as u32 && windows_api.is_window(client.window_handle) {
-                valid_layout.push((client.process_id, client.window_handle));
-            }
-        }
+            return exit_code == STILL_ACTIVE.0 as u32
+                && windows_api.is_window(client.window_handle);
+        });
+        let valid_layout: Vec<(u32, HWND)> = clients
+            .iter()
+            .map(|c| return (c.process_id, c.window_handle))
+            .collect();
         let valid_pids: Vec<u32> = valid_layout.iter().map(|(pid, _)| return *pid).collect();
         clients.reset_tile_layout(&valid_pids);
         for (index, (_, window_handle)) in valid_layout.iter().enumerate() {

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -1658,6 +1658,40 @@ mod daemon_test {
         );
     }
 
+    /// Regression: a clamped horizontal no-op must preserve the
+    /// in-flight anchor column. A prior vertical snap into a gap can
+    /// leave `anchor_col` pointing at a different column than the
+    /// current cell; re-aligning the anchor to the current cell on a
+    /// clamped Left/Right keypress would silently break the "anchor
+    /// carried across vertical moves" invariant the next Up/Down
+    /// relies on.
+    #[test]
+    fn test_next_submenu_selection_horizontal_clamp_preserves_anchor() {
+        let grid = dense_3x2_grid();
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(1),
+                Some(2),
+                NavigationDirection::Left,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(1), Some(2)),
+            "Left clamp keeps the stale anchor, not the cell's own column",
+        );
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(3),
+                Some(0),
+                NavigationDirection::Right,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(3), Some(0)),
+            "Right clamp keeps the stale anchor, not the cell's own column",
+        );
+    }
+
     /// Verifies vertical stepping (Up/Down) clamps at the top/bottom row
     /// when `EdgeBehavior::Clamp` is set.
     #[test]

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -23,9 +23,11 @@ mod daemon_test {
     use crate::{
         daemon::{
             classify_control_mode_key, classify_enable_disable_submenu_key, expand_hosts,
-            named_pipe_server_routine, next_submenu_pid, resolve_cluster_tags, Client, Clients,
-            ControlModeAction, ControlModeState, Daemon, EnableDisableSubmenuAction, HWNDWrapper,
-            NavigationDirection,
+            grid::{grid_dimensions, ClientGrid},
+            named_pipe_server_routine, next_submenu_selection, resolve_cluster_tags,
+            workspace::WorkspaceArea,
+            Client, Clients, ControlModeAction, ControlModeState, Daemon,
+            EnableDisableSubmenuAction, HWNDWrapper, NavigationDirection,
         },
         protocol::{
             serialization::serialize_pid, ClientState, FRAMED_HIGHLIGHT_LENGTH,
@@ -34,10 +36,25 @@ mod daemon_test {
             TAG_INPUT_RECORD, TAG_KEEP_ALIVE, TAG_STATE_CHANGE,
         },
         utils::{
-            config::{Cluster, DaemonConfig},
+            config::{Cluster, DaemonConfig, EdgeBehavior},
             constants::PIPE_NAME,
         },
     };
+
+    /// Stable 16:9 workspace fixture used by the submenu dispatch tests so
+    /// `grid_dimensions` is deterministic regardless of host monitor size.
+    fn test_workspace_area() -> WorkspaceArea {
+        return WorkspaceArea {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            x_fixed_frame: 0,
+            y_fixed_frame: 0,
+            x_size_frame: 0,
+            y_size_frame: 0,
+        };
+    }
 
     /// Send `pid` as a 4 byte little-endian sequence to the pipe server.
     ///
@@ -69,6 +86,7 @@ mod daemon_test {
             process_id: pid,
             state_sender: watch::channel(ClientState::Active).0,
             highlight_sender: watch::channel(false).0,
+            tile_index: 0,
         });
         return Arc::new(Mutex::new(clients));
     }
@@ -612,6 +630,7 @@ mod daemon_test {
             process_id: pid,
             state_sender: state_sender.clone(),
             highlight_sender: watch::channel(false).0,
+            tile_index: 0,
         });
         return (Arc::new(Mutex::new(clients)), state_sender);
     }
@@ -911,6 +930,7 @@ mod daemon_test {
                 process_id: pid,
                 state_sender: watch::channel(ClientState::Active).0,
                 highlight_sender: watch::channel(false).0,
+                tile_index: 0,
             };
         };
         clients.push(make_client(1000));
@@ -930,6 +950,7 @@ mod daemon_test {
             process_id: 1000,
             state_sender: watch::channel(ClientState::Active).0,
             highlight_sender: watch::channel(false).0,
+            tile_index: 0,
         };
         let client_b = Client {
             hostname: "host-b".to_owned(),
@@ -938,6 +959,7 @@ mod daemon_test {
             process_id: 2000,
             state_sender: watch::channel(ClientState::Active).0,
             highlight_sender: watch::channel(false).0,
+            tile_index: 0,
         };
         let client_c = Client {
             hostname: "host-c".to_owned(),
@@ -946,6 +968,7 @@ mod daemon_test {
             process_id: 3000,
             state_sender: watch::channel(ClientState::Active).0,
             highlight_sender: watch::channel(false).0,
+            tile_index: 0,
         };
 
         clients.push(client_a);
@@ -983,6 +1006,8 @@ mod daemon_test {
             process_id: pid,
             state_sender: watch::channel(state).0,
             highlight_sender: watch::channel(false).0,
+            // Overwritten by `Clients::push` to its dense list-position.
+            tile_index: 0,
         };
     }
 
@@ -1140,12 +1165,14 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_no_calls(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_E),
         );
 
@@ -1183,12 +1210,14 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_no_calls(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_D),
         );
 
@@ -1227,12 +1256,14 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_no_calls(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_T),
         );
         assert_eq!(
@@ -1254,6 +1285,7 @@ mod daemon_test {
         daemon.handle_enable_disable_submenu_key(
             &mock_no_calls(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_T),
         );
         assert_eq!(snapshot_states(&clients.lock().unwrap()), initial);
@@ -1282,12 +1314,14 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_no_calls(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_X),
         );
 
@@ -1314,12 +1348,14 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: None,
+                anchor_col: None,
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_no_calls(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_E),
         );
 
@@ -1462,12 +1498,14 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_no_calls(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event_with_state(VK_E, CAPSLOCK_ON | NUMLOCK_ON | ENHANCED_KEY),
         );
 
@@ -1548,6 +1586,7 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(3),
+                anchor_col: Some(0),
             },
         );
 
@@ -1569,68 +1608,130 @@ mod daemon_test {
         assert_eq!(daemon.control_mode_state, ControlModeState::Inactive);
     }
 
-    /// Verifies that `next_submenu_pid` advances by one on
-    /// `Down`/`Right` and clamps at the last surviving client.
-    #[test]
-    fn test_next_submenu_pid_down_right_clamp_at_last() {
-        let mut clients = Clients::new();
-        clients.push(make_client_with_state(1, ClientState::Active));
-        clients.push(make_client_with_state(2, ClientState::Active));
-        clients.push(make_client_with_state(3, ClientState::Active));
-
-        assert_eq!(
-            next_submenu_pid(&clients, Some(1), NavigationDirection::Down),
-            Some(2)
-        );
-        assert_eq!(
-            next_submenu_pid(&clients, Some(2), NavigationDirection::Right),
-            Some(3)
-        );
-        // Clamp at the last client - no wrap.
-        assert_eq!(
-            next_submenu_pid(&clients, Some(3), NavigationDirection::Down),
-            Some(3)
-        );
-        assert_eq!(
-            next_submenu_pid(&clients, Some(3), NavigationDirection::Right),
-            Some(3)
+    /// Returns the dense 3x2 grid `[1,2,3 / 4,5,6]` used by the basic
+    /// horizontal/vertical step tests.
+    fn dense_3x2_grid() -> ClientGrid {
+        return ClientGrid::from_tiled_pids(
+            &[(1, 0), (2, 1), (3, 2), (4, 3), (5, 4), (6, 5)],
+            6,
+            3,
+            2,
         );
     }
 
-    /// Verifies that `next_submenu_pid` steps back by one on
-    /// `Up`/`Left` and clamps at the first surviving client rather
-    /// than wrapping.
+    /// Verifies horizontal stepping (Left/Right) clamps at the row edges
+    /// when `EdgeBehavior::Clamp` is set.
     #[test]
-    fn test_next_submenu_pid_up_left_clamp_at_first() {
-        let mut clients = Clients::new();
-        clients.push(make_client_with_state(1, ClientState::Active));
-        clients.push(make_client_with_state(2, ClientState::Active));
-        clients.push(make_client_with_state(3, ClientState::Active));
-
+    fn test_next_submenu_selection_horizontal_clamp() {
+        let grid = dense_3x2_grid();
         assert_eq!(
-            next_submenu_pid(&clients, Some(3), NavigationDirection::Up),
-            Some(2)
+            next_submenu_selection(
+                &grid,
+                Some(1),
+                Some(0),
+                NavigationDirection::Right,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(2), Some(1)),
         );
         assert_eq!(
-            next_submenu_pid(&clients, Some(2), NavigationDirection::Left),
-            Some(1)
+            next_submenu_selection(
+                &grid,
+                Some(3),
+                Some(2),
+                NavigationDirection::Right,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(3), Some(2)),
+            "Right at the right edge clamps in place",
         );
-        // Clamp at the first client - no wrap.
         assert_eq!(
-            next_submenu_pid(&clients, Some(1), NavigationDirection::Up),
-            Some(1)
-        );
-        assert_eq!(
-            next_submenu_pid(&clients, Some(1), NavigationDirection::Left),
-            Some(1)
+            next_submenu_selection(
+                &grid,
+                Some(1),
+                Some(0),
+                NavigationDirection::Left,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(1), Some(0)),
+            "Left at the left edge clamps in place",
         );
     }
 
-    /// Verifies that `next_submenu_pid` returns `None` for an empty
-    /// cluster regardless of direction.
+    /// Verifies vertical stepping (Up/Down) clamps at the top/bottom row
+    /// when `EdgeBehavior::Clamp` is set.
     #[test]
-    fn test_next_submenu_pid_empty_clients_returns_none() {
-        let clients = Clients::new();
+    fn test_next_submenu_selection_vertical_clamp() {
+        let grid = dense_3x2_grid();
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(2),
+                Some(1),
+                NavigationDirection::Down,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(5), Some(1)),
+            "Down preserves the anchor column",
+        );
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(5),
+                Some(1),
+                NavigationDirection::Down,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(5), Some(1)),
+            "Down at the bottom row clamps in place",
+        );
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(1),
+                Some(0),
+                NavigationDirection::Up,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(1), Some(0)),
+            "Up at the top row clamps in place",
+        );
+    }
+
+    /// Verifies wrap edge behavior wraps horizontally within a row and
+    /// vertically within a column.
+    #[test]
+    fn test_next_submenu_selection_wrap() {
+        let grid = dense_3x2_grid();
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(3),
+                Some(2),
+                NavigationDirection::Right,
+                EdgeBehavior::Wrap,
+            ),
+            (Some(1), Some(0)),
+            "Right at the right edge wraps to the leftmost of the same row",
+        );
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(1),
+                Some(0),
+                NavigationDirection::Up,
+                EdgeBehavior::Wrap,
+            ),
+            (Some(4), Some(0)),
+            "Up at the top row wraps to the bottom of the same column",
+        );
+    }
+
+    /// Verifies an empty grid returns `(None, None)` regardless of
+    /// direction.
+    #[test]
+    fn test_next_submenu_selection_empty_grid_returns_none() {
+        let grid = ClientGrid::from_tiled_pids(&[], 0, 1, 1);
 
         for direction in [
             NavigationDirection::Up,
@@ -1638,9 +1739,182 @@ mod daemon_test {
             NavigationDirection::Left,
             NavigationDirection::Right,
         ] {
-            assert_eq!(next_submenu_pid(&clients, None, direction), None);
-            assert_eq!(next_submenu_pid(&clients, Some(1), direction), None);
+            assert_eq!(
+                next_submenu_selection(&grid, None, None, direction, EdgeBehavior::Clamp,),
+                (None, None),
+            );
+            assert_eq!(
+                next_submenu_selection(&grid, Some(1), Some(0), direction, EdgeBehavior::Clamp,),
+                (None, None),
+            );
         }
+    }
+
+    /// Verifies that a Down+Up roundtrip across the partial-last-row
+    /// boundary returns to the starting cell from every upper-row
+    /// column. With 7 cells laid out as 4 cols x 2 rows (last row has 3
+    /// cells stretched to span the full width), Down lands on the
+    /// last-row cell whose x-extent contains the anchor column's
+    /// centerline, and Up returns to the original column because the
+    /// anchor is preserved across the vertical step.
+    #[test]
+    fn test_grid_down_up_roundtrip_partial_last_row() {
+        let grid = ClientGrid::from_tiled_pids(
+            &[
+                (10, 0),
+                (20, 1),
+                (30, 2),
+                (40, 3),
+                (50, 4),
+                (60, 5),
+                (70, 6),
+            ],
+            7,
+            4,
+            2,
+        );
+
+        for start in [10u32, 20, 30, 40] {
+            let start_col = grid.cell(start).unwrap().col;
+            let (mid_pid, mid_anchor) = next_submenu_selection(
+                &grid,
+                Some(start),
+                Some(start_col),
+                NavigationDirection::Down,
+                EdgeBehavior::Clamp,
+            );
+            let (round_pid, _) = next_submenu_selection(
+                &grid,
+                mid_pid,
+                mid_anchor,
+                NavigationDirection::Up,
+                EdgeBehavior::Clamp,
+            );
+            assert_eq!(
+                round_pid,
+                Some(start),
+                "Down+Up from upper-row col {start_col} must return to PID {start}",
+            );
+        }
+    }
+
+    /// Verifies that re-anchoring kicks in when `current_pid` is gone
+    /// from the grid (the case the background `retain` produces) and
+    /// returns the first surviving cell with a fresh anchor.
+    #[test]
+    fn test_next_submenu_selection_reanchors_on_missing_pid() {
+        let grid = ClientGrid::from_tiled_pids(&[(1, 0), (2, 1), (3, 2)], 3, 3, 1);
+
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(999),
+                Some(2),
+                NavigationDirection::Up,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(1), Some(0)),
+            "missing PID must re-anchor on the first surviving cell with anchor reset to its col",
+        );
+    }
+
+    /// Verifies the grid-dimension formula stays in sync with the
+    /// tiler. The tiler is the spec.
+    #[test]
+    fn test_grid_dimensions_matches_tiler_formula() {
+        // aspect ratio 1.78 ~ 16:9, adjustment 0.0 (square-ish).
+        assert_eq!(grid_dimensions(7, 1.78, 0.0), (4, 2));
+        assert_eq!(grid_dimensions(9, 1.78, 0.0), (5, 2));
+        assert_eq!(grid_dimensions(1, 1.78, 0.0), (1, 1));
+    }
+
+    /// Regression: when a client window closes without a retile, the
+    /// surviving windows do not move on screen. The navigation grid
+    /// must therefore preserve their original tile indices and the
+    /// layout's original `n`, so that horizontal navigation across the
+    /// gap matches what the user sees.
+    #[test]
+    fn test_grid_preserves_layout_after_retain() {
+        // 6 cells laid out 3x2; client 1 closes without retile.
+        let grid = ClientGrid::from_tiled_pids(&[(2, 1), (3, 2), (4, 3), (5, 4), (6, 5)], 6, 3, 2);
+
+        // Client 2 keeps its original cell (row 0, col 1).
+        let cell_2 = grid.cell(2).unwrap();
+        assert_eq!((cell_2.row, cell_2.col), (0, 1));
+
+        // Right from client 2 lands on client 3 at (row 0, col 2), not
+        // on client 4 across the row boundary.
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(2),
+                Some(1),
+                NavigationDirection::Right,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(3), Some(2)),
+        );
+        // And Right from client 3 clamps in place (row 0 still has no
+        // surviving cell at col 3).
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(3),
+                Some(2),
+                NavigationDirection::Right,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(3), Some(2)),
+        );
+    }
+
+    /// Vertical step into a row whose anchor-column cell has been
+    /// closed lands on the nearest surviving cell in that row.
+    #[test]
+    fn test_grid_vertical_snap_into_gap() {
+        // 6 cells laid out 3x2; close client 5 (row 1, col 1).
+        let grid = ClientGrid::from_tiled_pids(&[(1, 0), (2, 1), (3, 2), (4, 3), (6, 5)], 6, 3, 2);
+
+        // Down from client 2 (anchor col=1) would target row 1 col 1,
+        // but that cell is gone. Snap to nearest surviving cell in row
+        // 1: client 4 (col 0, distance 1) wins the tiebreak against
+        // client 6 (col 2, distance 1) by having the smaller col.
+        assert_eq!(
+            next_submenu_selection(
+                &grid,
+                Some(2),
+                Some(1),
+                NavigationDirection::Down,
+                EdgeBehavior::Clamp,
+            ),
+            (Some(4), Some(1)),
+            "Down into a gap snaps to nearest by col, tiebreak left",
+        );
+    }
+
+    /// `Clients::reset_tile_layout` makes the grid match a freshly
+    /// retiled screen: dense `tile_index` values and an updated
+    /// `layout_n`.
+    #[test]
+    fn test_clients_reset_tile_layout_dense_renumber() {
+        let mut clients = Clients::new();
+        for pid in [10u32, 20, 30, 40, 50, 60] {
+            clients.push(make_client_with_state(pid, ClientState::Active));
+        }
+        // Drop two clients without retile.
+        clients.retain(|c| return c.process_id != 20 && c.process_id != 50);
+        // The surviving clients keep their original tile_index.
+        let pre_retile: Vec<usize> = clients.iter().map(|c| return c.tile_index).collect();
+        assert_eq!(pre_retile, vec![0, 2, 3, 5]);
+        assert_eq!(clients.layout_n, 6);
+
+        // Simulate a retile.
+        let surviving_pids: Vec<u32> = clients.iter().map(|c| return c.process_id).collect();
+        clients.reset_tile_layout(&surviving_pids);
+
+        let post_retile: Vec<usize> = clients.iter().map(|c| return c.tile_index).collect();
+        assert_eq!(post_retile, vec![0, 1, 2, 3]);
+        assert_eq!(clients.layout_n, 4);
     }
 
     /// Verifies that the dispatch arm for `Navigate(Down)` calls
@@ -1661,19 +1935,22 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_with_clear_screen(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_DOWN),
         );
 
         assert_eq!(
             daemon.control_mode_state,
             ControlModeState::EnableDisableSubmenu {
-                highlighted_pid: Some(2)
+                highlighted_pid: Some(2),
+                anchor_col: Some(0),
             }
         );
     }
@@ -1696,12 +1973,14 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(2),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_no_calls(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_E),
         );
 
@@ -1771,19 +2050,22 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_with_clear_screen(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_DOWN),
         );
 
         assert_eq!(
             daemon.control_mode_state,
             ControlModeState::EnableDisableSubmenu {
-                highlighted_pid: Some(2)
+                highlighted_pid: Some(2),
+                anchor_col: Some(0),
             }
         );
         assert_eq!(
@@ -1812,6 +2094,7 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(2),
+                anchor_col: Some(0),
             },
         );
 
@@ -1856,6 +2139,7 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
         );
 
@@ -1900,6 +2184,7 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(2),
+                anchor_col: Some(0),
             },
         );
 
@@ -1944,19 +2229,22 @@ mod daemon_test {
             &clusters,
             ControlModeState::EnableDisableSubmenu {
                 highlighted_pid: Some(3),
+                anchor_col: Some(0),
             },
         );
 
         daemon.handle_enable_disable_submenu_key(
             &mock_with_clear_screen(),
             &clients,
+            &test_workspace_area(),
             submenu_key_event(VK_UP),
         );
 
         assert_eq!(
             daemon.control_mode_state,
             ControlModeState::EnableDisableSubmenu {
-                highlighted_pid: Some(1)
+                highlighted_pid: Some(1),
+                anchor_col: Some(0),
             },
             "Up navigation from a stale PID must re-anchor on the surviving client",
         );

--- a/src/tests/utils/test_config.rs
+++ b/src/tests/utils/test_config.rs
@@ -5,6 +5,7 @@
 
 use crate::utils::config::{
     ClientConfig, ClientConfigOpt, Cluster, Config, ConfigOpt, DaemonConfig, DaemonConfigOpt,
+    EdgeBehavior,
 };
 
 /// Test module for ClientConfig functionality.
@@ -196,12 +197,14 @@ mod daemon_config_test {
             height: 300,
             aspect_ratio_adjustement: 0.5,
             console_color: 15, // White on black
+            submenu_edge_behavior: EdgeBehavior::Wrap,
         };
 
         let config_opt: DaemonConfigOpt = DaemonConfigOpt {
             height: Some(daemon_config.height),
             aspect_ratio_adjustement: Some(daemon_config.aspect_ratio_adjustement),
             console_color: Some(daemon_config.console_color),
+            submenu_edge_behavior: Some(daemon_config.submenu_edge_behavior),
         };
         let converted_back: DaemonConfig = config_opt.into();
 
@@ -211,6 +214,10 @@ mod daemon_config_test {
             daemon_config.aspect_ratio_adjustement
         );
         assert_eq!(converted_back.console_color, daemon_config.console_color);
+        assert_eq!(
+            converted_back.submenu_edge_behavior,
+            daemon_config.submenu_edge_behavior
+        );
     }
 
     #[test]
@@ -219,6 +226,7 @@ mod daemon_config_test {
             height: Some(150),
             aspect_ratio_adjustement: None,
             console_color: Some(112),
+            submenu_edge_behavior: None,
         };
 
         let daemon_config: DaemonConfig = config_opt.into();
@@ -230,6 +238,30 @@ mod daemon_config_test {
             default_config.aspect_ratio_adjustement
         ); // Should use default
         assert_eq!(daemon_config.console_color, 112);
+        assert_eq!(
+            daemon_config.submenu_edge_behavior,
+            default_config.submenu_edge_behavior
+        );
+    }
+
+    #[test]
+    fn test_daemon_config_default_submenu_edge_behavior_is_clamp() {
+        assert_eq!(
+            DaemonConfig::default().submenu_edge_behavior,
+            EdgeBehavior::Clamp
+        );
+    }
+
+    #[test]
+    fn test_daemon_config_opt_wrap_round_trip() {
+        let config_opt = DaemonConfigOpt {
+            height: None,
+            aspect_ratio_adjustement: None,
+            console_color: None,
+            submenu_edge_behavior: Some(EdgeBehavior::Wrap),
+        };
+        let daemon_config: DaemonConfig = config_opt.into();
+        assert_eq!(daemon_config.submenu_edge_behavior, EdgeBehavior::Wrap);
     }
 }
 
@@ -356,6 +388,7 @@ mod config_test {
                 height: 250,
                 aspect_ratio_adjustement: 0.5,
                 console_color: 15,
+                submenu_edge_behavior: EdgeBehavior::Clamp,
             },
         };
 
@@ -375,6 +408,7 @@ mod config_test {
                 height: Some(original_config.daemon.height),
                 aspect_ratio_adjustement: Some(original_config.daemon.aspect_ratio_adjustement),
                 console_color: Some(original_config.daemon.console_color),
+                submenu_edge_behavior: Some(original_config.daemon.submenu_edge_behavior),
             }),
         };
         let converted_back: Config = config_opt.into();
@@ -406,6 +440,7 @@ mod config_test {
                 height: Some(300),
                 aspect_ratio_adjustement: None, // Should use default
                 console_color: Some(112),
+                submenu_edge_behavior: None,
             }),
         };
 
@@ -495,6 +530,7 @@ mod config_integration_test {
                 height: 180,
                 aspect_ratio_adjustement: -0.8,
                 console_color: 240,
+                submenu_edge_behavior: EdgeBehavior::Wrap,
             },
         };
 
@@ -513,6 +549,7 @@ mod config_integration_test {
                 height: Some(original.daemon.height),
                 aspect_ratio_adjustement: Some(original.daemon.aspect_ratio_adjustement),
                 console_color: Some(original.daemon.console_color),
+                submenu_edge_behavior: Some(original.daemon.submenu_edge_behavior),
             }),
         };
         let roundtrip: Config = config_opt.into();
@@ -551,6 +588,10 @@ mod config_integration_test {
         assert_eq!(
             roundtrip.daemon.console_color,
             original.daemon.console_color
+        );
+        assert_eq!(
+            roundtrip.daemon.submenu_edge_behavior,
+            original.daemon.submenu_edge_behavior
         );
     }
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -329,7 +329,7 @@ impl Default for DaemonConfig {
     ///
     /// `DaemonConfig` with the following values:
     /// * `height`                      - `200`
-    /// * `aspect_ratio_adjustment`    - `-1.0`
+    /// * `aspect_ratio_adjustement`   - `-1.0`
     /// * `console_color`               - `207`
     /// * `submenu_edge_behavior`       - `clamp`
     fn default() -> Self {

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -7,6 +7,24 @@ use windows::Win32::System::Console::{
     FOREGROUND_INTENSITY, FOREGROUND_RED,
 };
 
+/// Behavior when an arrow / `hjkl` keystroke would move the
+/// enable/disable submenu's selection past the edge of the client grid.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeBehavior {
+    /// Keep the current selection on edge keystrokes (default).
+    Clamp,
+    /// Wrap to the opposite edge of the same row (Left/Right) or column
+    /// (Up/Down).
+    Wrap,
+}
+
+impl Default for EdgeBehavior {
+    fn default() -> Self {
+        return EdgeBehavior::Clamp;
+    }
+}
+
 /// Default console color applied when a client is in the
 /// `Disabled` state.
 ///
@@ -295,6 +313,13 @@ pub struct DaemonConfig {
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows/console/console-screen-buffers#character-attributes
     pub console_color: u16,
+    /// Behavior when an arrow / `hjkl` keystroke would move the
+    /// enable/disable submenu's selection past the edge of the client grid.
+    ///
+    /// * `clamp` (default) - keep the current selection.
+    /// * `wrap` - wrap to the opposite edge of the same row (Left/Right)
+    ///   or column (Up/Down).
+    pub submenu_edge_behavior: EdgeBehavior,
 }
 
 impl Default for DaemonConfig {
@@ -306,6 +331,7 @@ impl Default for DaemonConfig {
     /// * `height`                      - `200`
     /// * `aspect_ratio_adjustment`    - `-1.0`
     /// * `console_color`               - `207`
+    /// * `submenu_edge_behavior`       - `clamp`
     fn default() -> Self {
         return DaemonConfig {
             height: 200,
@@ -317,6 +343,7 @@ impl Default for DaemonConfig {
                 | BACKGROUND_INTENSITY
                 | BACKGROUND_RED)
                 .0,
+            submenu_edge_behavior: EdgeBehavior::default(),
         };
     }
 }
@@ -331,6 +358,8 @@ pub struct DaemonConfigOpt {
     pub aspect_ratio_adjustement: Option<f64>,
     #[allow(missing_docs)]
     pub console_color: Option<u16>,
+    #[allow(missing_docs)]
+    pub submenu_edge_behavior: Option<EdgeBehavior>,
 }
 
 impl Default for DaemonConfigOpt {
@@ -349,6 +378,9 @@ impl From<DaemonConfigOpt> for DaemonConfig {
                 .aspect_ratio_adjustement
                 .unwrap_or(default.aspect_ratio_adjustement),
             console_color: val.console_color.unwrap_or(default.console_color),
+            submenu_edge_behavior: val
+                .submenu_edge_behavior
+                .unwrap_or(default.submenu_edge_behavior),
         };
     }
 }
@@ -360,6 +392,7 @@ impl From<DaemonConfig> for DaemonConfigOpt {
             height: Some(val.height),
             aspect_ratio_adjustement: Some(val.aspect_ratio_adjustement),
             console_color: Some(val.console_color),
+            submenu_edge_behavior: Some(val.submenu_edge_behavior),
         };
     }
 }


### PR DESCRIPTION
The submenu''s arrow / hjkl bindings now move the highlight one cell
in the requested direction on a real grid view of the client tiles
instead of stepping linearly through the launch-order list. A new
`ClientGrid` data structure mirrors the tiler''s layout (same
`cols/rows` formula factored into `grid_dimensions`), including the
partial-last-row stretch where one cell projects onto multiple
upper-row columns. Vertical moves carry an anchor column so a
Down + Up roundtrip returns to the starting cell from any column.

When a client window closes without a retile, the surviving windows
keep their on-screen positions. Track each client''s `tile_index`
(assigned by `Clients::push`, preserved across `retain`, renumbered
by `rearrange_client_windows` via the new
`Clients::reset_tile_layout`) and the `Clients::layout_n` the
on-screen layout was last computed with, so the navigation grid
follows the visible layout rather than recomputing dimensions from
the post-retain list length. A vertical step into the closed cell''s
column snaps to the nearest surviving cell in the target row.

Edge behavior at the grid boundary is configurable via the new
`daemon.submenu_edge_behavior` key in `csshw-config.toml`:
`clamp` (default, keeps the current selection) or `wrap` (wraps to
the opposite edge of the same row or column).

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
