### PR TITLE
docs: restructure README config options as scannable tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ submenu_edge_behavior = 'clamp'
 | <a id="console_color"></a>`console_color` | u16 | `207` (`8+4+2+1+64+128`) | Daemon console colors. Default paints white text on red. See [Console color encoding](#console-color-encoding). |
 | `submenu_edge_behavior` | enum | `'clamp'` | What happens when an arrow / `hjkl` keystroke in the submenu would move the highlight past the edge of the client grid. See [Submenu edge behavior](#submenu-edge-behavior). |
 
+### Aspect ratio
+`aspect_ratio_adjustement` configures whether the available screen space should rather be used horizontally or vertically.
+* `> 0.0` - aims for vertical rectangle shape. The larger the value, the more exaggerated the "verticality". Eventually the windows will all be columns.
+* `= 0.0` - aims for square shape.
+* `< 0.0` - aims for horizontal rectangle shape. The smaller the value, the more exaggerated the "horizontality". Eventually the windows will all be rows. `-1.0` is the sweetspot for mostly preserving a 16:9 ratio.
+
 ### Console color encoding
 Console-color options encode background and foreground attributes as a single integer.
 Available are all standard Windows color combinations ([windows docs](https://learn.microsoft.com/en-us/windows/console/console-screen-buffers#character-attributes)):
@@ -148,12 +154,6 @@ BACKGROUND_INTENSITY:   128
 
 ### Highlight overlay
 The highlight wins over [`disabled_console_color`](#disabled_console_color); pressing `[d]`/`[e]`/`[t]` on the selected window briefly flashes the underlying state color (~250ms) as action feedback before the highlight color is restored.
-
-### Aspect ratio
-`aspect_ratio_adjustement` configures whether the available screen space should rather be used horizontally or vertically.
-* `> 0.0` - aims for vertical rectangle shape. The larger the value, the more exaggerated the "verticality". Eventually the windows will all be columns.
-* `= 0.0` - aims for square shape.
-* `< 0.0` - aims for horizontal rectangle shape. The smaller the value, the more exaggerated the "horizontality". Eventually the windows will all be rows. `-1.0` is the sweetspot for mostly preserving a 16:9 ratio.
 
 ### Submenu edge behavior
 `submenu_edge_behavior` selects what happens when an arrow / `hjkl` keystroke in the `[e]nable/disable input` submenu would move the highlight past the edge of the client grid:

--- a/README.md
+++ b/README.md
@@ -92,47 +92,32 @@ clusters = [
 ```
 Clusters may be nested, but be aware of recursive clusters which are not checked for.
 
-#### `client`
-A collection containing client relevant configuration
-``` toml
+#### `[client]`
+A collection containing client relevant configuration.
+
+```toml
 [client]
 ssh_config_path = 'C:\Users\demo_user\.ssh\config'
 program = 'ssh'
-arguments = [
-    '-XY',
-    '{{USERNAME_AT_HOST}}',
-]
+arguments = ['-XY', '{{USERNAME_AT_HOST}}']
 username_host_placeholder = '{{USERNAME_AT_HOST}}'
 disabled_console_color = 135
 highlighted_console_color = 31
 ```
 
-##### `ssh_config_path`
-The full qualified path where your ssh configuration can be found.
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `ssh_config_path` | path | auto-detected | Full qualified path to your ssh config file. |
+| `program` | string | `'ssh'` | Executable used to establish ssh connections. |
+| `arguments` | list of strings | `['-XY', '{{USERNAME_AT_HOST}}']` | Additional arguments passed to `program`. |
+| `username_host_placeholder` | string | `'{{USERNAME_AT_HOST}}'` | Token in `arguments` replaced with `username@host`. |
+| <a id="disabled_console_color"></a>`disabled_console_color` | u16 | `135` | Colors used while a client is in the disabled state (input ignored). See [Console color encoding](#console-color-encoding). |
+| <a id="highlighted_console_color"></a>`highlighted_console_color` | u16 | `31` | Colors used while a client is the currently selected window in the control-mode `[e]nable/disable input` submenu. See [Console color encoding](#console-color-encoding) and [Highlight overlay](#highlight-overlay). |
 
-##### `program`
-Which executable will be used to establish ssh connections.
+#### `[daemon]`
+A collection containing daemon relevant configuration.
 
-##### `arguments`
-Additional arguments specified to the chosen program.
-
-##### `username_host_placeholder`
-Placeholder string that indicates where the `username@host` string should be inserted in the program arguments.
-
-##### `disabled_console_color`
-Configures the background and foreground colors used by a client console while the client is in the disabled state (input ignored).
-Uses the same encoding as the daemon [`console_color`](#console_color).
-The default `135` paints default-grey text on a muted dark-grey background: `FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | BACKGROUND_INTENSITY` = 4+2+1+128.
-
-##### `highlighted_console_color`
-Configures the background and foreground colors used by a client console while it is the currently selected window in the control-mode `[e]nable/disable input` submenu.
-The highlight overlay wins over [`disabled_console_color`](#disabled_console_color); pressing `[d]`/`[e]`/`[t]` on the selected window briefly flashes the underlying state color (~250ms) as action feedback before the highlight color is restored.
-Uses the same encoding as the daemon [`console_color`](#console_color).
-The default `31` paints bright-white text on a blue background: `FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY | BACKGROUND_BLUE` = 4+2+1+8+16.
-
-#### `daemon`
-A collection containing daemon relevant configuration
-``` toml
+```toml
 [daemon]
 height = 200
 aspect_ratio_adjustement = -1.0
@@ -140,23 +125,16 @@ console_color = 207
 submenu_edge_behavior = 'clamp'
 ```
 
-##### `height`
-The height of the daemon console.
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `height` | u16 | `200` | Height of the daemon console. |
+| `aspect_ratio_adjustement` | float | `-1.0` | Bias for vertical vs. horizontal layout of client windows. See [Aspect ratio](#aspect-ratio). |
+| <a id="console_color"></a>`console_color` | u16 | `207` | Daemon console colors. See [Console color encoding](#console-color-encoding). |
+| `submenu_edge_behavior` | enum | `'clamp'` | What happens when an arrow / `hjkl` keystroke in the submenu would move the highlight past the edge of the client grid. See [Submenu edge behavior](#submenu-edge-behavior). |
 
-##### `aspect_ratio_adjustment`
-Configures whether the available screen space should rather be used horizontally or vertically.
-* `> 0.0` - Aims for vertical rectangle shape.
-  The larger the value, the more exaggerated the "verticality".
-  Eventually the windows will all be columns.
-* `= 0.0` - Aims for square shape.
-* `< 0.0` - Aims for horizontal rectangle shape.
-  The smaller the value, the more exaggerated the "horizontality".
-  Eventually the windows will all be rows.
-  `-1.0` is the sweetspot for mostly preserving a 16:9 ratio.
-
-##### `console_color`
-Configures background and foreground colors used by the daemon console.
-Available are all standard windows color combinations ([windows docs](https://learn.microsoft.com/en-us/windows/console/console-screen-buffers#character-attributes)):
+#### Console color encoding
+Console-color options encode background and foreground attributes as a single integer.
+Available are all standard Windows color combinations ([windows docs](https://learn.microsoft.com/en-us/windows/console/console-screen-buffers#character-attributes)):
 ```
 FOREGROUND_BLUE:        1
 FOREGROUND_GREEN:       2
@@ -167,10 +145,22 @@ BACKGROUND_GREEN:       32
 BACKGROUND_RED:         64
 BACKGROUND_INTENSITY:   128
 ```
-e.g. white font on red background: 8+4+2+1+64+128 = `207`
+Worked defaults:
+* `console_color = 207` - white text on red: `8+4+2+1+64+128`.
+* `disabled_console_color = 135` - default-grey text on muted dark-grey: `4+2+1+128`.
+* `highlighted_console_color = 31` - bright-white text on blue: `4+2+1+8+16`.
 
-##### `submenu_edge_behavior`
-Selects what happens when an arrow / `hjkl` keystroke in the `[e]nable/disable input` submenu would move the highlight past the edge of the client grid.
+#### Aspect ratio
+`aspect_ratio_adjustement` configures whether the available screen space should rather be used horizontally or vertically.
+* `> 0.0` - aims for vertical rectangle shape. The larger the value, the more exaggerated the "verticality". Eventually the windows will all be columns.
+* `= 0.0` - aims for square shape.
+* `< 0.0` - aims for horizontal rectangle shape. The smaller the value, the more exaggerated the "horizontality". Eventually the windows will all be rows. `-1.0` is the sweetspot for mostly preserving a 16:9 ratio.
+
+#### Highlight overlay
+The highlight wins over [`disabled_console_color`](#disabled_console_color); pressing `[d]`/`[e]`/`[t]` on the selected window briefly flashes the underlying state color (~250ms) as action feedback before the highlight color is restored.
+
+#### Submenu edge behavior
+`submenu_edge_behavior` selects what happens when an arrow / `hjkl` keystroke in the `[e]nable/disable input` submenu would move the highlight past the edge of the client grid:
 * `'clamp'` (default) - the highlight stays on the current cell.
 * `'wrap'` - the highlight wraps to the opposite edge of the same row (Left/Right) or column (Up/Down).
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Example:
 
 We recommend using the [ssh_config](https://linux.die.net/man/5/ssh_config) for any configurations like default username etc.
 
-### Configuration
+## Configuration
 
 `csshw-config.toml` contains all relevant configurations and is located in the same directory as the executable.
 It is automatically created with default values if not present.
 
-#### `clusters`
+### `clusters`
 An array of clusters that can be used to alias a set of host names to a specific tag:
 ```toml
 clusters = [
@@ -92,7 +92,7 @@ clusters = [
 ```
 Clusters may be nested, but be aware of recursive clusters which are not checked for.
 
-#### `[client]`
+### `[client]`
 A collection containing client relevant configuration.
 
 ```toml
@@ -111,10 +111,10 @@ highlighted_console_color = 31
 | `program` | string | `'ssh'` | Executable used to establish ssh connections. |
 | `arguments` | list of strings | `['-XY', '{{USERNAME_AT_HOST}}']` | Additional arguments passed to `program`. |
 | `username_host_placeholder` | string | `'{{USERNAME_AT_HOST}}'` | Token in `arguments` replaced with `username@host`. |
-| <a id="disabled_console_color"></a>`disabled_console_color` | u16 | `135` | Colors used while a client is in the disabled state (input ignored). See [Console color encoding](#console-color-encoding). |
-| <a id="highlighted_console_color"></a>`highlighted_console_color` | u16 | `31` | Colors used while a client is the currently selected window in the control-mode `[e]nable/disable input` submenu. See [Console color encoding](#console-color-encoding) and [Highlight overlay](#highlight-overlay). |
+| <a id="disabled_console_color"></a>`disabled_console_color` | u16 | `135` (`4+2+1+128`) | Colors used while a client is in the disabled state (input ignored). Default paints default-grey text on muted dark-grey. See [Console color encoding](#console-color-encoding). |
+| <a id="highlighted_console_color"></a>`highlighted_console_color` | u16 | `31` (`4+2+1+8+16`) | Colors used while a client is the currently selected window in the control-mode `[e]nable/disable input` submenu. Default paints bright-white text on blue. See [Console color encoding](#console-color-encoding) and [Highlight overlay](#highlight-overlay). |
 
-#### `[daemon]`
+### `[daemon]`
 A collection containing daemon relevant configuration.
 
 ```toml
@@ -129,10 +129,10 @@ submenu_edge_behavior = 'clamp'
 |---|---|---|---|
 | `height` | u16 | `200` | Height of the daemon console. |
 | `aspect_ratio_adjustement` | float | `-1.0` | Bias for vertical vs. horizontal layout of client windows. See [Aspect ratio](#aspect-ratio). |
-| <a id="console_color"></a>`console_color` | u16 | `207` | Daemon console colors. See [Console color encoding](#console-color-encoding). |
+| <a id="console_color"></a>`console_color` | u16 | `207` (`8+4+2+1+64+128`) | Daemon console colors. Default paints white text on red. See [Console color encoding](#console-color-encoding). |
 | `submenu_edge_behavior` | enum | `'clamp'` | What happens when an arrow / `hjkl` keystroke in the submenu would move the highlight past the edge of the client grid. See [Submenu edge behavior](#submenu-edge-behavior). |
 
-#### Console color encoding
+### Console color encoding
 Console-color options encode background and foreground attributes as a single integer.
 Available are all standard Windows color combinations ([windows docs](https://learn.microsoft.com/en-us/windows/console/console-screen-buffers#character-attributes)):
 ```
@@ -145,21 +145,17 @@ BACKGROUND_GREEN:       32
 BACKGROUND_RED:         64
 BACKGROUND_INTENSITY:   128
 ```
-Worked defaults:
-* `console_color = 207` - white text on red: `8+4+2+1+64+128`.
-* `disabled_console_color = 135` - default-grey text on muted dark-grey: `4+2+1+128`.
-* `highlighted_console_color = 31` - bright-white text on blue: `4+2+1+8+16`.
 
-#### Aspect ratio
+### Highlight overlay
+The highlight wins over [`disabled_console_color`](#disabled_console_color); pressing `[d]`/`[e]`/`[t]` on the selected window briefly flashes the underlying state color (~250ms) as action feedback before the highlight color is restored.
+
+### Aspect ratio
 `aspect_ratio_adjustement` configures whether the available screen space should rather be used horizontally or vertically.
 * `> 0.0` - aims for vertical rectangle shape. The larger the value, the more exaggerated the "verticality". Eventually the windows will all be columns.
 * `= 0.0` - aims for square shape.
 * `< 0.0` - aims for horizontal rectangle shape. The smaller the value, the more exaggerated the "horizontality". Eventually the windows will all be rows. `-1.0` is the sweetspot for mostly preserving a 16:9 ratio.
 
-#### Highlight overlay
-The highlight wins over [`disabled_console_color`](#disabled_console_color); pressing `[d]`/`[e]`/`[t]` on the selected window briefly flashes the underlying state color (~250ms) as action feedback before the highlight color is restored.
-
-#### Submenu edge behavior
+### Submenu edge behavior
 `submenu_edge_behavior` selects what happens when an arrow / `hjkl` keystroke in the `[e]nable/disable input` submenu would move the highlight past the edge of the client grid:
 * `'clamp'` (default) - the highlight stays on the current cell.
 * `'wrap'` - the highlight wraps to the opposite edge of the same row (Left/Right) or column (Up/Down).


### PR DESCRIPTION
The Configuration section rendered each of the 9 TOML options as its
own h5 heading followed by 1-4 lines of prose, producing a wall of
headings whose visual weight outsized their content and cluttering
the GitHub table of contents.

Replace the per-option h5 headings with two quick-reference tables
(one per [client] / [daemon]) covering name, type, default, and a
one-line description. Lift the richer prose - color encoding, aspect
ratio behavior, highlight overlay, submenu edge behavior - into
shared subsections so it stays expressive where it needs to be and
out of the way where it does not.

Also fix a doc bug: the heading "aspect_ratio_adjustment" did not
match the actual config key "aspect_ratio_adjustement" (with typo),
so anyone copying the heading into their TOML file would silently
fall back to defaults. The table now uses the real key.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
