### PR TITLE
Apply conhost stale-cells workaround on Win11 too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,14 +127,14 @@ Add a `//` comment only for:
 Never paraphrase the next line, narrate steps (`// Step 1: ...`,
 `// First, ... // Then, ...`), add banner dividers (`// ----- Helpers -----`),
 or commit commented-out code. Canonical examples to study:
-`src/utils/windows.rs:934-937` (Win10/11 divergence),
+`src/utils/windows.rs:934-942` (conhost stale-cells workaround),
 `src/daemon/mod.rs:706-708` (async ordering invariant),
 `src/client/mod.rs:409-411` (protocol contract).
 
 ```rust
 // GOOD - cites a platform quirk and explains the workaround.
-// Win10 conhost leaves the bottom row stale after a bulk attribute fill
-// until something forces a redraw; Win11+ Terminal repaints on its own.
+// conhost leaves the bottom row stale after a bulk attribute fill until
+// something forces a redraw; invalidate to force one.
 nudge_cursor(handle)?;
 
 // BAD - paraphrases the call.

--- a/news/~conhost-stale-cells-on-win11.bugfix.md
+++ b/news/~conhost-stale-cells-on-win11.bugfix.md
@@ -1,6 +1,0 @@
-Extend the Windows 10 visual-glitch fix from #189 to Windows 11. csshw
-forces `conhost.exe` as the host terminal on every supported Windows
-version, and the bottom-row / rightmost-column stale-cells bug after a
-bulk attribute fill reproduces on the conhost shipped with Win11 too.
-The post-fill `InvalidateRect` workaround is now always issued instead
-of being gated on `is_windows_10`.

--- a/news/~conhost-stale-cells-on-win11.bugfix.md
+++ b/news/~conhost-stale-cells-on-win11.bugfix.md
@@ -1,0 +1,6 @@
+Extend the Windows 10 visual-glitch fix from #189 to Windows 11. csshw
+forces `conhost.exe` as the host terminal on every supported Windows
+version, and the bottom-row / rightmost-column stale-cells bug after a
+bulk attribute fill reproduces on the conhost shipped with Win11 too.
+The post-fill `InvalidateRect` workaround is now always issued instead
+of being gated on `is_windows_10`.

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -846,10 +846,6 @@ fn test_get_flash_color_disabled_no_original_returns_none() {
 
 /// Builds a [`MockWindowsApi`] that satisfies one full
 /// [`crate::utils::windows::set_console_color`] call.
-///
-/// Returns a Win11 OS version so the post-fill invalidate is gated
-/// off (already covered by the dedicated `set_console_color` tests
-/// in `src/tests/utils/test_windows.rs`).
 fn mock_for_one_set_console_color() -> MockWindowsApi {
     use windows::Win32::System::Console::{CONSOLE_SCREEN_BUFFER_INFO, COORD};
     let mut mock = MockWindowsApi::new();
@@ -866,8 +862,9 @@ fn mock_for_one_set_console_color() -> MockWindowsApi {
     mock.expect_fill_console_output_attribute()
         .times(25)
         .returning(|_, _, _| return Ok(80));
-    mock.expect_get_os_version()
-        .returning(|| return "10.0.22631".to_string());
+    mock.expect_invalidate_console_window()
+        .times(1)
+        .returning(|| return Ok(()));
     return mock;
 }
 
@@ -940,8 +937,9 @@ fn mock_for_n_set_console_color_calls(n: usize) -> MockWindowsApi {
         .returning(move || return Ok(buffer_info));
     mock.expect_fill_console_output_attribute()
         .returning(|_, _, _| return Ok(80));
-    mock.expect_get_os_version()
-        .returning(|| return "10.0.22631".to_string());
+    mock.expect_invalidate_console_window()
+        .times(n)
+        .returning(|| return Ok(()));
     return mock;
 }
 

--- a/src/tests/utils/test_windows.rs
+++ b/src/tests/utils/test_windows.rs
@@ -168,7 +168,9 @@ mod console_color_test {
     use super::*;
 
     /// Tests console color setting with text attributes and buffer filling.
-    /// Validates proper color application across the entire console buffer.
+    /// Validates proper color application across the entire console buffer
+    /// and the post-fill invalidate that works around the conhost
+    /// stale-row/column bug.
     #[test]
     fn test_set_console_color() {
         let mut mock_api = MockWindowsApi::new();
@@ -194,42 +196,6 @@ mod console_color_test {
             .times(25)
             .returning(|_, _, _| return Ok(80));
 
-        // Default to Win11 so the post-fill invalidate is gated off; the
-        // dedicated tests below cover both gate branches.
-        mock_api
-            .expect_get_os_version()
-            .returning(|| return "10.0.22000".to_string());
-
-        set_console_color(&mock_api, test_color);
-    }
-
-    /// Tests that on Windows 10 the post-fill console invalidate is
-    /// issued exactly once, working around the legacy conhost leaving
-    /// the trailing row and column stale after a bulk attribute fill.
-    #[test]
-    fn test_set_console_color_invalidates_on_windows_10() {
-        let mut mock_api = MockWindowsApi::new();
-        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
-
-        let mut buffer_info = CONSOLE_SCREEN_BUFFER_INFO::default();
-        buffer_info.dwSize.X = 80;
-        buffer_info.dwSize.Y = 25;
-
-        mock_api
-            .expect_set_console_text_attribute()
-            .times(1)
-            .returning(|_| return Ok(()));
-        mock_api
-            .expect_get_console_screen_buffer_info()
-            .times(1)
-            .return_const(Ok(buffer_info));
-        mock_api
-            .expect_fill_console_output_attribute()
-            .times(25)
-            .returning(|_, _, _| return Ok(80));
-        mock_api
-            .expect_get_os_version()
-            .returning(|| return "10.0.19045".to_string());
         mock_api
             .expect_invalidate_console_window()
             .times(1)
@@ -238,10 +204,11 @@ mod console_color_test {
         set_console_color(&mock_api, test_color);
     }
 
-    /// Tests that on Windows 11 the post-fill console invalidate is not
-    /// issued - the modern terminal repaints on its own.
+    /// Tests that a failing invalidate is logged and does not propagate -
+    /// a stale visual is recoverable; panicking would kill the SSH
+    /// session for a non-critical visual cue.
     #[test]
-    fn test_set_console_color_skips_invalidate_on_windows_11() {
+    fn test_set_console_color_swallows_invalidate_error() {
         let mut mock_api = MockWindowsApi::new();
         let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
 
@@ -261,41 +228,6 @@ mod console_color_test {
             .expect_fill_console_output_attribute()
             .times(25)
             .returning(|_, _, _| return Ok(80));
-        mock_api
-            .expect_get_os_version()
-            .returning(|| return "10.0.22631".to_string());
-        mock_api.expect_invalidate_console_window().times(0);
-
-        set_console_color(&mock_api, test_color);
-    }
-
-    /// Tests that a failing invalidate on Windows 10 is logged and does
-    /// not propagate - a stale visual is recoverable; panicking would
-    /// kill the SSH session for a non-critical visual cue.
-    #[test]
-    fn test_set_console_color_swallows_invalidate_error_on_windows_10() {
-        let mut mock_api = MockWindowsApi::new();
-        let test_color = CONSOLE_CHARACTER_ATTRIBUTES(0x0F);
-
-        let mut buffer_info = CONSOLE_SCREEN_BUFFER_INFO::default();
-        buffer_info.dwSize.X = 80;
-        buffer_info.dwSize.Y = 25;
-
-        mock_api
-            .expect_set_console_text_attribute()
-            .times(1)
-            .returning(|_| return Ok(()));
-        mock_api
-            .expect_get_console_screen_buffer_info()
-            .times(1)
-            .return_const(Ok(buffer_info));
-        mock_api
-            .expect_fill_console_output_attribute()
-            .times(25)
-            .returning(|_, _, _| return Ok(80));
-        mock_api
-            .expect_get_os_version()
-            .returning(|| return "10.0.19045".to_string());
         mock_api
             .expect_invalidate_console_window()
             .times(1)

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -931,14 +931,14 @@ pub fn set_console_color(api: &dyn WindowsApi, color: CONSOLE_CHARACTER_ATTRIBUT
         )
         .unwrap();
     }
-    // Win10 conhost leaves the bottom row + rightmost column stale after a
-    // bulk attribute fill until something forces a redraw (the user
-    // double-clicking is one such trigger). Win11+ Terminal repaints on
-    // its own.
-    if is_windows_10(api) {
-        if let Err(err) = api.invalidate_console_window() {
-            warn!("Failed to invalidate console window after recolor: {}", err);
-        }
+    // conhost leaves the bottom row + rightmost column stale after a bulk
+    // FillConsoleOutputAttribute until something forces a redraw (the user
+    // double-clicking is one such trigger). Reproduces on the conhost
+    // shipped with both Win10 and Win11, and csshw forces conhost as the
+    // host terminal (see WindowsSettingsDefaultTerminalApplicationGuard),
+    // so we always invalidate.
+    if let Err(err) = api.invalidate_console_window() {
+        warn!("Failed to invalidate console window after recolor: {}", err);
     }
 }
 


### PR DESCRIPTION
The post-fill `InvalidateRect` call in `set_console_color` was gated
on `is_windows_10`, with a comment claiming that `Win11+ Terminal
repaints on its own`. That framing was wrong: csshw forces
`conhost.exe` as the host terminal for the lifetime of the daemon /
client processes (via `WindowsSettingsDefaultTerminalApplicationGuard`),
so the relevant question is how conhost behaves, not Windows Terminal.
The bottom-row + rightmost-column stale-cells bug after a bulk
`FillConsoleOutputAttribute` reproduces on the conhost shipped with
Win11 too, which means the original fix from #189 was silently
skipped for every Win11 user.

Drop the `is_windows_10` gate, always invalidate, and rewrite the
comment to describe the actual conhost bug. The three Win10/Win11-
specific tests around the gate collapse into one happy-path test that
asserts the invalidate is issued, plus a renamed error-swallow test.
Client-side mock helpers that previously mocked Win11 to gate the
invalidate off now expect the invalidate instead.

is_windows_10 itself stays exported - it is still used by
set_console_border_color, where the Win10/Win11 distinction is a
real feature gap (DWM border-color is unavailable on Win10), not a
shared-bug workaround.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
