### PR TITLE
fix: rename `aspect_ratio_adjustement` to `aspect_ratio_adjustment`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "svg_to_ico",
  "time",
  "tokio",
+ "toml 0.8.23",
  "windows 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ features = [
 
 [dev-dependencies]
 mockall = "0.13.1"
+toml = "0.8"
 
 [build-dependencies]
 embed-resource = "3.0.9"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ A collection containing daemon relevant configuration
 ``` toml
 [daemon]
 height = 200
-aspect_ratio_adjustement = -1.0
+aspect_ratio_adjustment = -1.0
 console_color = 207
 submenu_edge_behavior = 'clamp'
 ```

--- a/news/210.bugfix.md
+++ b/news/210.bugfix.md
@@ -1,0 +1,3 @@
+Fixed the typo in the `aspect_ratio_adjustement` daemon config key.
+The correct spelling is now `aspect_ratio_adjustment`; existing TOML
+configs using the old key continue to work via a serde alias.

--- a/src/daemon/grid.rs
+++ b/src/daemon/grid.rs
@@ -63,7 +63,7 @@ pub(super) struct ClientGrid {
 /// * `n`           - Number of client windows.
 /// * `aspect`      - `workspace_width / workspace_height` (including
 ///                   frame padding) of the available area.
-/// * `aspect_adj`  - The `aspect_ratio_adjustement` daemon config.
+/// * `aspect_adj`  - The `aspect_ratio_adjustment` daemon config.
 ///
 /// # Returns
 ///

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -539,7 +539,7 @@ fn next_submenu_selection(
 ///
 /// * `clients`                   - Currently tracked clients in launch order.
 /// * `workspace_area`            - Available workspace minus the daemon console.
-/// * `aspect_ratio_adjustment`   - The `aspect_ratio_adjustement` daemon config.
+/// * `aspect_ratio_adjustment`   - The `aspect_ratio_adjustment` daemon config.
 ///
 /// # Returns
 ///
@@ -624,7 +624,7 @@ impl<'a> Daemon<'a> {
                 self.port,
                 self.debug,
                 &workspace_area,
-                self.config.aspect_ratio_adjustement,
+                self.config.aspect_ratio_adjustment,
                 0,
             )
             .await,
@@ -846,7 +846,7 @@ impl<'a> Daemon<'a> {
                     let grid = build_client_grid(
                         &clients_guard,
                         workspace_area,
-                        self.config.aspect_ratio_adjustement,
+                        self.config.aspect_ratio_adjustment,
                     );
                     let next_pid = grid.top_left_pid();
                     let anchor_col = next_pid
@@ -908,7 +908,7 @@ impl<'a> Daemon<'a> {
                                 self.port,
                                 self.debug,
                                 workspace_area,
-                                self.config.aspect_ratio_adjustement,
+                                self.config.aspect_ratio_adjustment,
                                 number_of_existing_clients,
                             )
                             .await;
@@ -1093,7 +1093,7 @@ impl<'a> Daemon<'a> {
                 workspace_area,
                 index,
                 valid_layout.len(),
-                self.config.aspect_ratio_adjustement,
+                self.config.aspect_ratio_adjustment,
             )
         }
     }
@@ -1165,7 +1165,7 @@ impl<'a> Daemon<'a> {
                 let grid = build_client_grid(
                     &clients_guard,
                     workspace_area,
-                    self.config.aspect_ratio_adjustement,
+                    self.config.aspect_ratio_adjustment,
                 );
                 let (next_pid, next_anchor) = next_submenu_selection(
                     &grid,

--- a/src/tests/utils/test_config.rs
+++ b/src/tests/utils/test_config.rs
@@ -185,8 +185,8 @@ mod daemon_config_test {
 
         assert_eq!(daemon_config.height, default_config.height);
         assert_eq!(
-            daemon_config.aspect_ratio_adjustement,
-            default_config.aspect_ratio_adjustement
+            daemon_config.aspect_ratio_adjustment,
+            default_config.aspect_ratio_adjustment
         );
         assert_eq!(daemon_config.console_color, default_config.console_color);
     }
@@ -195,14 +195,14 @@ mod daemon_config_test {
     fn test_daemon_config_opt_from_daemon_config() {
         let daemon_config = DaemonConfig {
             height: 300,
-            aspect_ratio_adjustement: 0.5,
+            aspect_ratio_adjustment: 0.5,
             console_color: 15, // White on black
             submenu_edge_behavior: EdgeBehavior::Wrap,
         };
 
         let config_opt: DaemonConfigOpt = DaemonConfigOpt {
             height: Some(daemon_config.height),
-            aspect_ratio_adjustement: Some(daemon_config.aspect_ratio_adjustement),
+            aspect_ratio_adjustment: Some(daemon_config.aspect_ratio_adjustment),
             console_color: Some(daemon_config.console_color),
             submenu_edge_behavior: Some(daemon_config.submenu_edge_behavior),
         };
@@ -210,8 +210,8 @@ mod daemon_config_test {
 
         assert_eq!(converted_back.height, daemon_config.height);
         assert_eq!(
-            converted_back.aspect_ratio_adjustement,
-            daemon_config.aspect_ratio_adjustement
+            converted_back.aspect_ratio_adjustment,
+            daemon_config.aspect_ratio_adjustment
         );
         assert_eq!(converted_back.console_color, daemon_config.console_color);
         assert_eq!(
@@ -224,7 +224,7 @@ mod daemon_config_test {
     fn test_daemon_config_opt_partial_values() {
         let config_opt = DaemonConfigOpt {
             height: Some(150),
-            aspect_ratio_adjustement: None,
+            aspect_ratio_adjustment: None,
             console_color: Some(112),
             submenu_edge_behavior: None,
         };
@@ -234,8 +234,8 @@ mod daemon_config_test {
 
         assert_eq!(daemon_config.height, 150);
         assert_eq!(
-            daemon_config.aspect_ratio_adjustement,
-            default_config.aspect_ratio_adjustement
+            daemon_config.aspect_ratio_adjustment,
+            default_config.aspect_ratio_adjustment
         ); // Should use default
         assert_eq!(daemon_config.console_color, 112);
         assert_eq!(
@@ -256,12 +256,21 @@ mod daemon_config_test {
     fn test_daemon_config_opt_wrap_round_trip() {
         let config_opt = DaemonConfigOpt {
             height: None,
-            aspect_ratio_adjustement: None,
+            aspect_ratio_adjustment: None,
             console_color: None,
             submenu_edge_behavior: Some(EdgeBehavior::Wrap),
         };
         let daemon_config: DaemonConfig = config_opt.into();
         assert_eq!(daemon_config.submenu_edge_behavior, EdgeBehavior::Wrap);
+    }
+
+    #[test]
+    fn test_daemon_config_accepts_legacy_aspect_ratio_alias() {
+        // Older configs spelled the field `aspect_ratio_adjustement`. The
+        // serde alias must keep deserializing those files after the typo fix.
+        let toml = "aspect_ratio_adjustement = 0.5\n";
+        let config_opt: DaemonConfigOpt = toml::from_str(toml).unwrap();
+        assert_eq!(config_opt.aspect_ratio_adjustment, Some(0.5));
     }
 }
 
@@ -386,7 +395,7 @@ mod config_test {
             },
             daemon: DaemonConfig {
                 height: 250,
-                aspect_ratio_adjustement: 0.5,
+                aspect_ratio_adjustment: 0.5,
                 console_color: 15,
                 submenu_edge_behavior: EdgeBehavior::Clamp,
             },
@@ -406,7 +415,7 @@ mod config_test {
             }),
             daemon: Some(DaemonConfigOpt {
                 height: Some(original_config.daemon.height),
-                aspect_ratio_adjustement: Some(original_config.daemon.aspect_ratio_adjustement),
+                aspect_ratio_adjustment: Some(original_config.daemon.aspect_ratio_adjustment),
                 console_color: Some(original_config.daemon.console_color),
                 submenu_edge_behavior: Some(original_config.daemon.submenu_edge_behavior),
             }),
@@ -438,7 +447,7 @@ mod config_test {
             client: None, // Should use default
             daemon: Some(DaemonConfigOpt {
                 height: Some(300),
-                aspect_ratio_adjustement: None, // Should use default
+                aspect_ratio_adjustment: None, // Should use default
                 console_color: Some(112),
                 submenu_edge_behavior: None,
             }),
@@ -461,8 +470,8 @@ mod config_test {
         // Daemon should be partially custom, partially default
         assert_eq!(config.daemon.height, 300);
         assert_eq!(
-            config.daemon.aspect_ratio_adjustement,
-            default_daemon.aspect_ratio_adjustement
+            config.daemon.aspect_ratio_adjustment,
+            default_daemon.aspect_ratio_adjustment
         );
         assert_eq!(config.daemon.console_color, 112);
     }
@@ -528,7 +537,7 @@ mod config_integration_test {
             },
             daemon: DaemonConfig {
                 height: 180,
-                aspect_ratio_adjustement: -0.8,
+                aspect_ratio_adjustment: -0.8,
                 console_color: 240,
                 submenu_edge_behavior: EdgeBehavior::Wrap,
             },
@@ -547,7 +556,7 @@ mod config_integration_test {
             }),
             daemon: Some(DaemonConfigOpt {
                 height: Some(original.daemon.height),
-                aspect_ratio_adjustement: Some(original.daemon.aspect_ratio_adjustement),
+                aspect_ratio_adjustment: Some(original.daemon.aspect_ratio_adjustment),
                 console_color: Some(original.daemon.console_color),
                 submenu_edge_behavior: Some(original.daemon.submenu_edge_behavior),
             }),
@@ -582,8 +591,8 @@ mod config_integration_test {
 
         assert_eq!(roundtrip.daemon.height, original.daemon.height);
         assert_eq!(
-            roundtrip.daemon.aspect_ratio_adjustement,
-            original.daemon.aspect_ratio_adjustement
+            roundtrip.daemon.aspect_ratio_adjustment,
+            original.daemon.aspect_ratio_adjustment
         );
         assert_eq!(
             roundtrip.daemon.console_color,

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -293,7 +293,8 @@ pub struct DaemonConfig {
     ///             The smaller the value, the more exaggerated the "horizontality".
     ///             Eventually the windows will all be rows.
     ///             `-1.0` is the sweetspot for mostly preserving a 16:9 ratio.
-    pub aspect_ratio_adjustement: f64,
+    #[serde(alias = "aspect_ratio_adjustement")]
+    pub aspect_ratio_adjustment: f64,
     /// Controls back- and foreground colors of the daemon console window.
     ///
     /// All [standard Windows color combinations][1] are available:
@@ -329,13 +330,13 @@ impl Default for DaemonConfig {
     ///
     /// `DaemonConfig` with the following values:
     /// * `height`                      - `200`
-    /// * `aspect_ratio_adjustement`   - `-1.0`
+    /// * `aspect_ratio_adjustment`    - `-1.0`
     /// * `console_color`               - `207`
     /// * `submenu_edge_behavior`       - `clamp`
     fn default() -> Self {
         return DaemonConfig {
             height: 200,
-            aspect_ratio_adjustement: -1f64,
+            aspect_ratio_adjustment: -1f64,
             console_color: (FOREGROUND_INTENSITY
                 | FOREGROUND_RED
                 | FOREGROUND_GREEN
@@ -355,7 +356,8 @@ pub struct DaemonConfigOpt {
     #[allow(missing_docs)]
     pub height: Option<i32>,
     #[allow(missing_docs)]
-    pub aspect_ratio_adjustement: Option<f64>,
+    #[serde(alias = "aspect_ratio_adjustement")]
+    pub aspect_ratio_adjustment: Option<f64>,
     #[allow(missing_docs)]
     pub console_color: Option<u16>,
     #[allow(missing_docs)]
@@ -374,9 +376,9 @@ impl From<DaemonConfigOpt> for DaemonConfig {
         let default = DaemonConfig::default();
         return DaemonConfig {
             height: val.height.unwrap_or(default.height),
-            aspect_ratio_adjustement: val
-                .aspect_ratio_adjustement
-                .unwrap_or(default.aspect_ratio_adjustement),
+            aspect_ratio_adjustment: val
+                .aspect_ratio_adjustment
+                .unwrap_or(default.aspect_ratio_adjustment),
             console_color: val.console_color.unwrap_or(default.console_color),
             submenu_edge_behavior: val
                 .submenu_edge_behavior
@@ -390,7 +392,7 @@ impl From<DaemonConfig> for DaemonConfigOpt {
     fn from(val: DaemonConfig) -> Self {
         return DaemonConfigOpt {
             height: Some(val.height),
-            aspect_ratio_adjustement: Some(val.aspect_ratio_adjustement),
+            aspect_ratio_adjustment: Some(val.aspect_ratio_adjustment),
             console_color: Some(val.console_color),
             submenu_edge_behavior: Some(val.submenu_edge_behavior),
         };


### PR DESCRIPTION
The daemon config key was originally misspelled as
`aspect_ratio_adjustement`. The previous README change papered over the
typo by documenting the misspelled key; this commit instead corrects
the key in the code and keeps the misspelled form working via a serde
alias so existing TOML configs still load.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
