### PR TITLE
deps: bump windows 0.59 -> 0.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -331,7 +331,7 @@ dependencies = [
  "time",
  "tokio",
  "toml 0.8.23",
- "windows 0.59.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2208,12 +2208,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.59.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.59.0",
- "windows-targets 0.53.5",
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2231,28 +2242,26 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface 0.59.3",
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2260,17 +2269,6 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2312,15 +2310,19 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -2333,20 +2335,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2361,20 +2354,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2401,7 +2385,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2428,7 +2412,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -2436,20 +2420,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2465,12 +2441,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,12 +2451,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2501,22 +2465,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2531,12 +2483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,12 +2493,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2567,12 +2507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,12 +2517,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ features = ["toml_conf"]
 default-features = false
 
 [dependencies.windows]
-version = "0.59.0"
+version = "0.62.2"
 features = [
     "UI_UIAutomation",
     "Win32_Foundation",

--- a/src/protocol/deserialization.rs
+++ b/src/protocol/deserialization.rs
@@ -1,6 +1,6 @@
-use windows::Win32::{
-    Foundation::BOOL,
-    System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0},
+use windows::{
+    core::BOOL,
+    Win32::System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0},
 };
 
 use crate::protocol::{

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -448,7 +448,7 @@ fn test_write_console_input() {
             virtual_key_code: 0x20, // Space key
             unicode_char: b' ' as u16,
             control_key_state: LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED,
-            api_result: Err(windows::core::Error::from_win32()),
+            api_result: Err(windows::core::Error::from_thread()),
         },
     ];
 

--- a/src/tests/daemon/test_mod.rs
+++ b/src/tests/daemon/test_mod.rs
@@ -1528,7 +1528,7 @@ mod daemon_test {
     #[test]
     fn test_esc_in_active_state_is_consumed_and_resets_to_inactive() {
         use crate::utils::windows::MockWindowsApi;
-        use windows::Win32::Foundation::BOOL;
+        use windows::core::BOOL;
         use windows::Win32::System::Console::{CONSOLE_SCREEN_BUFFER_INFO, COORD, INPUT_RECORD_0};
         use windows::Win32::UI::Input::KeyboardAndMouse::VK_ESCAPE;
 

--- a/src/tests/protocol/test_mod.rs
+++ b/src/tests/protocol/test_mod.rs
@@ -1,8 +1,8 @@
 //! Unit tests for the protocol module.
 
-use windows::Win32::{
-    Foundation::BOOL,
-    System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0},
+use windows::{
+    core::BOOL,
+    Win32::System::Console::{INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0},
 };
 
 use crate::protocol::{SERIALIZED_INPUT_RECORD_0_LENGTH, SERIALIZED_PID_LENGTH};

--- a/src/tests/test_lib.rs
+++ b/src/tests/test_lib.rs
@@ -315,7 +315,7 @@ mod create_process_api_test {
         mock_api
             .expect_create_process_raw()
             .times(1)
-            .returning(|_, _, _, _| return Err(windows::core::Error::from_win32()));
+            .returning(|_, _, _, _| return Err(windows::core::Error::from_thread()));
 
         let result = create_process(&mock_api, application, &command_line);
 

--- a/src/tests/utils/test_windows.rs
+++ b/src/tests/utils/test_windows.rs
@@ -231,7 +231,7 @@ mod console_color_test {
         mock_api
             .expect_invalidate_console_window()
             .times(1)
-            .returning(|| return Err(windows::core::Error::from_win32()));
+            .returning(|| return Err(windows::core::Error::from_thread()));
 
         set_console_color(&mock_api, test_color);
     }
@@ -247,7 +247,7 @@ mod console_color_test {
             .expect_set_console_text_attribute()
             .with(mockall::predicate::eq(test_color))
             .times(1)
-            .returning(|_| return Err(windows::core::Error::from_win32()));
+            .returning(|_| return Err(windows::core::Error::from_thread()));
 
         let result = std::panic::catch_unwind(|| {
             set_console_color(&mock_api, test_color);
@@ -303,7 +303,7 @@ mod clear_screen_test {
         mock_api
             .expect_get_console_screen_buffer_info()
             .times(1)
-            .returning(|| return Err(windows::core::Error::from_win32()));
+            .returning(|| return Err(windows::core::Error::from_thread()));
 
         let result = std::panic::catch_unwind(|| {
             clear_screen(&mock_api);
@@ -371,7 +371,7 @@ mod console_border_color_test {
         api.expect_set_console_border_color()
             .with(mockall::predicate::eq(test_color))
             .times(1)
-            .returning(|_| return Err(windows::core::Error::from_win32()));
+            .returning(|_| return Err(windows::core::Error::from_thread()));
 
         let result = std::panic::catch_unwind(|| {
             set_console_border_color(&api, test_color);
@@ -455,7 +455,7 @@ mod console_input_test {
             ..Default::default()
         };
         let mut key_event_record = KEY_EVENT_RECORD {
-            bKeyDown: windows::Win32::Foundation::BOOL(1),
+            bKeyDown: windows::core::BOOL(1),
             wRepeatCount: 1,
             wVirtualKeyCode: 0x41,
             wVirtualScanCode: 0x1E,
@@ -522,7 +522,7 @@ mod console_input_test {
             .expect_read_console_input()
             .with(mockall::predicate::always())
             .times(1)
-            .returning(|_| return Err(windows::core::Error::from_win32()));
+            .returning(|_| return Err(windows::core::Error::from_thread()));
 
         let result = std::panic::catch_unwind(|| {
             read_console_input(&mock_api);

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -15,8 +15,8 @@ use std::ffi::OsString;
 use std::os::windows::ffi::OsStrExt;
 use std::{mem, ptr};
 
-use windows::core::{HSTRING, PCWSTR};
-use windows::Win32::Foundation::{BOOL, COLORREF, FALSE, HANDLE, HWND, LPARAM, TRUE};
+use windows::core::{BOOL, HSTRING, PCWSTR};
+use windows::Win32::Foundation::{COLORREF, FALSE, HANDLE, HWND, LPARAM, TRUE};
 use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_BORDER_COLOR};
 use windows::Win32::Graphics::Gdi::InvalidateRect;
 use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
@@ -646,7 +646,7 @@ impl WindowsApi for DefaultWindowsApi {
         if succeeded.as_bool() {
             return Ok(());
         }
-        return Err(windows::core::Error::from_win32());
+        return Err(windows::core::Error::from_thread());
     }
 
     fn write_console_input(
@@ -768,7 +768,7 @@ impl WindowsApi for DefaultWindowsApi {
         if result.as_bool() {
             return Ok(());
         } else {
-            return Err(windows::core::Error::from_win32());
+            return Err(windows::core::Error::from_thread());
         }
     }
 


### PR DESCRIPTION
`BOOL` moved from `windows::Win32::Foundation` to `windows::core`, and
`windows::core::Error::from_win32()` was renamed to `from_thread()`.
Adjust imports and error construction across the codebase accordingly.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
