### PR TITLE
deps: bump mockall 0.13 -> 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ features = [
 ]
 
 [dev-dependencies]
-mockall = "0.13.1"
+mockall = "0.14.0"
 toml = "0.8"
 
 [build-dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,7 +16,7 @@ toml_edit = "0.21"
 semver    = "1.0"
 
 [dev-dependencies]
-mockall = "0.13"
+mockall = "0.14"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }


### PR DESCRIPTION
Drop-in upgrade; no test or mock-spec changes required.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
