### PR TITLE
deps: bump xtask toml_edit 0.21 -> 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,17 +2091,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -2112,6 +2101,19 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2764,15 +2766,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
@@ -2785,6 +2778,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -2959,7 +2955,7 @@ dependencies = [
  "clap",
  "mockall",
  "semver",
- "toml_edit 0.21.1",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 # Shared: CLI parsing, error handling, TOML editing, semver bumps.
 anyhow    = "1"
 clap      = { version = "4", features = ["derive"] }
-toml_edit = "0.21"
+toml_edit = "0.25"
 semver    = "1.0"
 
 [dev-dependencies]

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -84,7 +84,7 @@ impl ChangelogSystem for RealSystem {
 /// Returns an error if the content cannot be parsed as TOML or the
 /// `[package].version` key is absent.
 pub fn extract_version_from_cargo_toml(cargo_toml_content: &str) -> Result<String> {
-    let doc: toml_edit::Document = cargo_toml_content
+    let doc: toml_edit::DocumentMut = cargo_toml_content
         .parse()
         .context("failed to parse Cargo.toml")?;
     let version = doc
@@ -113,7 +113,7 @@ pub fn extract_version_from_cargo_toml(cargo_toml_content: &str) -> Result<Strin
 ///
 /// Returns an error if `changelogging_content` cannot be parsed as TOML.
 pub fn set_changelogging_version(changelogging_content: &str, version: &str) -> Result<String> {
-    let mut doc: toml_edit::Document = changelogging_content
+    let mut doc: toml_edit::DocumentMut = changelogging_content
         .parse()
         .context("failed to parse changelogging.toml")?;
     doc["context"]["version"] = toml_edit::value(version);

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -438,7 +438,7 @@ pub fn determine_release_type(current: &Version, next: &Version) -> ReleaseType 
 ///
 /// Returns an error if `cargo_toml_content` cannot be parsed as TOML.
 pub fn set_cargo_toml_version(cargo_toml_content: &str, new_version: &str) -> Result<String> {
-    let mut doc: toml_edit::Document = cargo_toml_content
+    let mut doc: toml_edit::DocumentMut = cargo_toml_content
         .parse()
         .context("failed to parse Cargo.toml")?;
     doc["package"]["version"] = toml_edit::value(new_version);

--- a/xtask/src/tests/test_changelog.rs
+++ b/xtask/src/tests/test_changelog.rs
@@ -70,7 +70,7 @@ fn test_set_changelogging_version_updates_version() {
     let result = set_changelogging_version(CHANGELOGGING_TOML, "1.2.3").unwrap();
 
     // Assert
-    let doc: toml_edit::Document = result.parse().unwrap();
+    let doc: toml_edit::DocumentMut = result.parse().unwrap();
     assert_eq!(doc["context"]["version"].as_str().unwrap(), "1.2.3");
 }
 
@@ -80,7 +80,7 @@ fn test_set_changelogging_version_preserves_other_keys() {
     let result = set_changelogging_version(CHANGELOGGING_TOML, "1.2.3").unwrap();
 
     // Assert
-    let doc: toml_edit::Document = result.parse().unwrap();
+    let doc: toml_edit::DocumentMut = result.parse().unwrap();
     assert_eq!(doc["context"]["name"].as_str().unwrap(), "csshw");
     assert_eq!(
         doc["context"]["url"].as_str().unwrap(),
@@ -136,6 +136,6 @@ fn test_generate_changelog_writes_correct_version() {
 
     // Assert
     let content = written.lock().unwrap().clone();
-    let doc: toml_edit::Document = content.parse().unwrap();
+    let doc: toml_edit::DocumentMut = content.parse().unwrap();
     assert_eq!(doc["context"]["version"].as_str().unwrap(), "1.2.3");
 }

--- a/xtask/src/tests/test_release.rs
+++ b/xtask/src/tests/test_release.rs
@@ -118,7 +118,7 @@ fn test_set_cargo_toml_version_updates_version() {
     let result = set_cargo_toml_version(&content, "1.0.0").unwrap();
 
     // Assert
-    let doc: toml_edit::Document = result.parse().unwrap();
+    let doc: toml_edit::DocumentMut = result.parse().unwrap();
     assert_eq!(doc["package"]["version"].as_str().unwrap(), "1.0.0");
 }
 
@@ -131,7 +131,7 @@ fn test_set_cargo_toml_version_preserves_other_fields() {
     let result = set_cargo_toml_version(&content, "1.0.0").unwrap();
 
     // Assert
-    let doc: toml_edit::Document = result.parse().unwrap();
+    let doc: toml_edit::DocumentMut = result.parse().unwrap();
     assert_eq!(doc["package"]["name"].as_str().unwrap(), "csshw");
     assert_eq!(doc["package"]["edition"].as_str().unwrap(), "2021");
 }


### PR DESCRIPTION
toml_edit 0.22 renamed `Document` to `DocumentMut` (with a generic
`Document<S>` retained as the immutable variant). Update the xtask
sources and tests to refer to the new type.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
