### PR TITLE
control mode: speed up submenu-highlight recolor

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -194,8 +194,8 @@ fn start_flash(
 
 /// Paint `target` if it differs from `last`, then update `last`.
 ///
-/// Skipping unchanged repaints keeps the slow per-row
-/// `fill_console_output_attribute` calls off the hot path.
+/// Skipping unchanged repaints avoids an unnecessary LPC roundtrip to
+/// conhost (and, on Win10, the post-fill `InvalidateRect`/WM_PAINT).
 ///
 /// # Arguments
 ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -195,7 +195,7 @@ fn start_flash(
 /// Paint `target` if it differs from `last`, then update `last`.
 ///
 /// Skipping unchanged repaints avoids an unnecessary LPC roundtrip to
-/// conhost (and, on Win10, the post-fill `InvalidateRect`/WM_PAINT).
+/// conhost and the post-fill `InvalidateRect`/WM_PAINT.
 ///
 /// # Arguments
 ///

--- a/src/tests/client/test_mod.rs
+++ b/src/tests/client/test_mod.rs
@@ -860,8 +860,8 @@ fn mock_for_one_set_console_color() -> MockWindowsApi {
         .times(1)
         .return_const(Ok(buffer_info));
     mock.expect_fill_console_output_attribute()
-        .times(25)
-        .returning(|_, _, _| return Ok(80));
+        .times(1)
+        .returning(|_, _, _| return Ok(80 * 25));
     mock.expect_invalidate_console_window()
         .times(1)
         .returning(|| return Ok(()));
@@ -936,7 +936,8 @@ fn mock_for_n_set_console_color_calls(n: usize) -> MockWindowsApi {
         .times(n)
         .returning(move || return Ok(buffer_info));
     mock.expect_fill_console_output_attribute()
-        .returning(|_, _, _| return Ok(80));
+        .times(n)
+        .returning(|_, _, _| return Ok(80 * 25));
     mock.expect_invalidate_console_window()
         .times(n)
         .returning(|| return Ok(()));

--- a/src/tests/utils/test_windows.rs
+++ b/src/tests/utils/test_windows.rs
@@ -191,10 +191,17 @@ mod console_color_test {
             .times(1)
             .return_const(Ok(buffer_info));
 
+        // Single call covering the entire buffer (width * height cells
+        // from (0,0)) - FillConsoleOutputAttribute auto-spans rows.
         mock_api
             .expect_fill_console_output_attribute()
-            .times(25)
-            .returning(|_, _, _| return Ok(80));
+            .with(
+                mockall::predicate::eq(test_color.0),
+                mockall::predicate::eq(80u32 * 25u32),
+                mockall::predicate::eq(COORD { X: 0, Y: 0 }),
+            )
+            .times(1)
+            .returning(|_, _, _| return Ok(80 * 25));
 
         mock_api
             .expect_invalidate_console_window()
@@ -226,8 +233,8 @@ mod console_color_test {
             .return_const(Ok(buffer_info));
         mock_api
             .expect_fill_console_output_attribute()
-            .times(25)
-            .returning(|_, _, _| return Ok(80));
+            .times(1)
+            .returning(|_, _, _| return Ok(80 * 25));
         mock_api
             .expect_invalidate_console_window()
             .times(1)

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -925,9 +925,7 @@ pub fn set_console_color(api: &dyn WindowsApi, color: CONSOLE_CHARACTER_ATTRIBUT
     let buffer_info = api.get_console_screen_buffer_info().unwrap();
     // FillConsoleOutputAttribute continues into successive rows when the
     // length extends past the end of the row, so a single call from (0,0)
-    // recolors the entire buffer in one LPC roundtrip. The screen buffer
-    // can be thousands of rows tall (scrollback), so a per-row loop here
-    // would dominate the cost of rapid submenu navigation.
+    // recolors the entire buffer in one LPC roundtrip.
     let width: u32 = buffer_info.dwSize.X.try_into().unwrap();
     let height: u32 = buffer_info.dwSize.Y.try_into().unwrap();
     api.fill_console_output_attribute(color.0, width * height, COORD { X: 0, Y: 0 })
@@ -939,9 +937,7 @@ pub fn set_console_color(api: &dyn WindowsApi, color: CONSOLE_CHARACTER_ATTRIBUT
     // cell, so the fill above cannot reach them, and conhost does not
     // repaint them on an attribute-only update - they keep the old color
     // until something triggers a WM_PAINT (user double-clicking is one
-    // such trigger). csshw forces conhost as the host terminal (see
-    // WindowsSettingsDefaultTerminalApplicationGuard), so this always
-    // applies.
+    // such trigger).
     if let Err(err) = api.invalidate_console_window() {
         warn!("Failed to invalidate console window after recolor: {}", err);
     }

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -923,20 +923,25 @@ pub fn build_command_line(application: &str, args: &[String]) -> Vec<u16> {
 pub fn set_console_color(api: &dyn WindowsApi, color: CONSOLE_CHARACTER_ATTRIBUTES) {
     api.set_console_text_attribute(color).unwrap();
     let buffer_info = api.get_console_screen_buffer_info().unwrap();
-    for y in 0..buffer_info.dwSize.Y {
-        api.fill_console_output_attribute(
-            color.0,
-            buffer_info.dwSize.X.try_into().unwrap(),
-            COORD { X: 0, Y: y },
-        )
+    // FillConsoleOutputAttribute continues into successive rows when the
+    // length extends past the end of the row, so a single call from (0,0)
+    // recolors the entire buffer in one LPC roundtrip. The screen buffer
+    // can be thousands of rows tall (scrollback), so a per-row loop here
+    // would dominate the cost of rapid submenu navigation.
+    let width: u32 = buffer_info.dwSize.X.try_into().unwrap();
+    let height: u32 = buffer_info.dwSize.Y.try_into().unwrap();
+    api.fill_console_output_attribute(color.0, width * height, COORD { X: 0, Y: 0 })
         .unwrap();
-    }
-    // conhost leaves the bottom row + rightmost column stale after a bulk
-    // FillConsoleOutputAttribute until something forces a redraw (the user
-    // double-clicking is one such trigger). Reproduces on the conhost
-    // shipped with both Win10 and Win11, and csshw forces conhost as the
-    // host terminal (see WindowsSettingsDefaultTerminalApplicationGuard),
-    // so we always invalidate.
+    // The console client area can contain a sub-cell-sized pixel sliver at
+    // the right and/or bottom edge when the OS window pixel dimensions do
+    // not divide evenly into the cell grid (csshw clients are sized in
+    // pixels via MoveWindow). Those slivers are not backed by any buffer
+    // cell, so the fill above cannot reach them, and conhost does not
+    // repaint them on an attribute-only update - they keep the old color
+    // until something triggers a WM_PAINT (user double-clicking is one
+    // such trigger). csshw forces conhost as the host terminal (see
+    // WindowsSettingsDefaultTerminalApplicationGuard), so this always
+    // applies.
     if let Err(err) = api.invalidate_console_window() {
         warn!("Failed to invalidate console window after recolor: {}", err);
     }


### PR DESCRIPTION
`set_console_color` previously issued one `FillConsoleOutputAttribute`
call per buffer row. `dwSize.Y` is the screen-buffer height (the
scrollback, ~9000 rows by default on Windows), not the visible
viewport, so each highlight move did ~9000 LPC roundtrips to conhost
per client - and each arrow-key press recolors two clients (un-paint
the previous highlight + paint the new one). The result was
perceptible lag while scrubbing the enable/disable submenu grid.

Microsoft's documentation guarantees that
`FillConsoleOutputAttribute` continues into successive rows when the
requested length extends past the end of the row, so a single call
from `(0, 0)` with `width * height` cells recolors the whole buffer
in one LPC roundtrip. Net effect: roughly 18,000 -> 2 syscalls per
arrow press.

The `InvalidateRect` workaround introduced in #208 stays as-is - it
is needed for a different reason (sub-cell pixel slivers at the
right/bottom edge of the client area when the OS window dimensions
don't divide evenly into the cell grid, which `MoveWindow` produces
in csshw clients). The comment in `set_console_color` is updated to
reflect that root cause rather than the previous
stale-row/stale-column framing.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
