### PR TITLE
docs: drop outdated cargo-make and src/serde references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ multiple hosts simultaneously with synchronized keystroke distribution.
 
 - **Binary**: `csshw.exe` - Main executable with CLI interface (`src/main.rs`, `src/cli.rs`)
 - **Library**: `csshw_lib` - Core functionality (`src/lib.rs`)
-- **Modules**: `src/client/`, `src/daemon/`, `src/serde/`, `src/utils/`
+- **Modules**: `src/client/`, `src/daemon/`, `src/protocol/`, `src/utils/`
 - **Tests**: `src/tests/` with component-based organization (`test_*.rs` naming)
 - **xtask**: `xtask/` - Developer automation tasks (README checks, release, changelog, social preview)
 - **Config**: `.config/` - grouped, shared single-line marker files consumed
@@ -81,7 +81,7 @@ characters - do NOT add to the allowlist.
 - **Test functions, closures, trivial trait impls**: no docs.
 - **Module docs** (`//!`): one line for typical modules. Multi-paragraph only
   when the module defines a protocol or wire format (see
-  `src/serde/protocol/mod.rs`). All library modules use
+  `src/protocol/mod.rs`). All library modules use
   `#![doc(html_no_source)]`.
 
 ````rust
@@ -127,9 +127,9 @@ Add a `//` comment only for:
 Never paraphrase the next line, narrate steps (`// Step 1: ...`,
 `// First, ... // Then, ...`), add banner dividers (`// ----- Helpers -----`),
 or commit commented-out code. Canonical examples to study:
-`src/utils/windows.rs:934-942` (conhost stale-cells workaround),
-`src/daemon/mod.rs:706-708` (async ordering invariant),
-`src/client/mod.rs:409-411` (protocol contract).
+`src/utils/windows.rs:933-940` (conhost stale-cells workaround),
+`src/daemon/mod.rs:1640` (async ordering invariant),
+`src/client/mod.rs:541-543` (named-pipe contract).
 
 ```rust
 // GOOD - cites a platform quirk and explains the workaround.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,7 @@ Add a `//` comment only for:
 
 Never paraphrase the next line, narrate steps (`// Step 1: ...`,
 `// First, ... // Then, ...`), add banner dividers (`// ----- Helpers -----`),
-or commit commented-out code. Canonical examples to study:
-`src/utils/windows.rs:933-940` (conhost stale-cells workaround),
-`src/daemon/mod.rs:1640` (async ordering invariant),
-`src/client/mod.rs:541-543` (named-pipe contract).
+or commit commented-out code.
 
 ```rust
 // GOOD - cites a platform quirk and explains the workaround.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,11 +54,6 @@ Unsure where to begin contributing to csshW? Here are some suggestions:
    git config --local core.hooksPath .githooks/
    ```
 
-3. **Install Development Tools**:
-   ```cmd
-   cargo install cargo-make
-   ```
-
 ### AI agent GitHub auth (optional)
 
 If you use [paseo](https://paseo.dev) to spawn AI coding agents on this
@@ -88,7 +83,7 @@ or recreate the worktree.
 
 ### Development Workflow
 
-csshW uses cargo aliases and [cargo make](https://github.com/sagiegurari/cargo-make) for development automation. Key commands:
+csshW uses cargo aliases and the [`xtask`](https://github.com/matklad/cargo-xtask) crate for development automation. Key commands:
 
 - `cargo fmt` - Format code
 - `cargo lint` - Run clippy linting
@@ -219,17 +214,17 @@ For easy manual testing on Windows we recommend the following setup:
 
 ## Development Tools and Automation
 
-### Cargo Make Tasks
+### xtask Subcommands
 
-csshW uses several `cargo make` tasks for automation either as part of the pre-commit githook, in the GitHub Actions CI or locally.
+csshW uses `cargo xtask` subcommands for automation - run as part of the pre-commit githook, in the GitHub Actions CI, or locally. See `cargo xtask --help` for the full list.
 
 ### Release Process
 
 csshW follows a structured release process:
 
-1. **Prepare release** with `cargo make prepare-release`
+1. **Prepare release** with `cargo xtask prepare-release`
 2. **Create pull request** from maintenance branch to main
-3. **Create release tag** with `cargo make release`
+3. **Create release tag** with `cargo xtask create-release-tag`
 4. **Publish release** through GitHub Actions
 
 Contributors don't need to worry about releases - maintainers handle this process.

--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ submenu_edge_behavior = 'clamp'
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `height` | u16 | `200` | Height of the daemon console. |
-| `aspect_ratio_adjustement` | float | `-1.0` | Bias for vertical vs. horizontal layout of client windows. See [Aspect ratio](#aspect-ratio). |
+| `aspect_ratio_adjustment` | float | `-1.0` | Bias for vertical vs. horizontal layout of client windows. See [Aspect ratio](#aspect-ratio). |
 | <a id="console_color"></a>`console_color` | u16 | `207` (`8+4+2+1+64+128`) | Daemon console colors. Default paints white text on red. See [Console color encoding](#console-color-encoding). |
 | `submenu_edge_behavior` | enum | `'clamp'` | What happens when an arrow / `hjkl` keystroke in the submenu would move the highlight past the edge of the client grid. See [Submenu edge behavior](#submenu-edge-behavior). |
 
 ### Aspect ratio
-`aspect_ratio_adjustement` configures whether the available screen space should rather be used horizontally or vertically.
+`aspect_ratio_adjustment` configures whether the available screen space should rather be used horizontally or vertically.
 * `> 0.0` - aims for vertical rectangle shape. The larger the value, the more exaggerated the "verticality". Eventually the windows will all be columns.
 * `= 0.0` - aims for square shape.
 * `< 0.0` - aims for horizontal rectangle shape. The smaller the value, the more exaggerated the "horizontality". Eventually the windows will all be rows. `-1.0` is the sweetspot for mostly preserving a 16:9 ratio.
@@ -166,9 +166,9 @@ Install them via ``git config --local core.hooksPath .githooks/``.
 
 ## Releases
 Step by step guide to create a new release:
-- `cargo make prepare-release` and follow the instructions
+- `cargo xtask prepare-release` and follow the instructions
 - Create a pull request from the new maintenance branch to main OR cherry-pick the new Version change from the existing maintenance branch to main
-- `cargo make release` and follow the instructions
+- `cargo xtask create-release-tag` and follow the instructions
 - Revise the automatically created Release Draft and publish it
 
 [^1]: The searchbar used to launch csshw in the demo clip is [keypirinha](https://keypirinha.com/).


### PR DESCRIPTION
Release automation moved from `cargo make` to `cargo xtask`, and the
`src/serde/` module was renamed to `src/protocol/`. Update the user-
and contributor-facing docs to match, and refresh the inline-comment
canonical-examples table in AGENTS.md whose line ranges had drifted.

- README.md: release steps use `cargo xtask prepare-release` /
  `cargo xtask create-release-tag`; daemon config table and Aspect
  ratio prose use the canonical `aspect_ratio_adjustment` spelling
  (the misspelled form remains a serde alias for backwards compat).
- CONTRIBUTING.md: drop the `cargo install cargo-make` setup step,
  point at `cargo xtask --help` instead of "Cargo Make Tasks", and
  update the Release Process commands.
- AGENTS.md: `src/serde/` -> `src/protocol/` and rewire the three
  canonical-comment line refs to existing comments
  (windows.rs:933-940, daemon/mod.rs:1640, client/mod.rs:541-543).

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
