### PR TITLE
ci: drop unsupported semver-major-days from github-actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,9 +63,10 @@ updates:
     labels:
       - dependencies
       - no-news-fragment-needed
+    # github-actions only supports `default-days`; semver-* keys are
+    # rejected here because actions don't expose semver to Dependabot.
     cooldown:
-      default-days: 3
-      semver-major-days: 7
+      default-days: 7
     groups:
       actions-minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
Dependabot rejected the config added in #218 with:

    The property '#/updates/2/cooldown/semver-major-days' is not
    supported for the package ecosystem 'github-actions'.

The `cooldown.semver-*` knobs are only honored for ecosystems with
semver-aware version parsing; github-actions is not one of them
(actions are typically pinned by tag, not a semver constraint).

Drop the unsupported key and raise `default-days` to 7 so major
action bumps still get a week of shakeout time, matching the
original intent of waiting longer on major upgrades.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
