### PR TITLE
ci: trigger full pre-submit on toolchain and lockfile changes

### DIFF
--- a/.github/workflows/pre-submit.yml
+++ b/.github/workflows/pre-submit.yml
@@ -28,7 +28,9 @@ jobs:
               - 'src/**'
               - 'build.rs'
               - 'Cargo.toml'
+              - 'Cargo.lock'
               - 'clippy.toml'
+              - 'rust-toolchain.toml'
               - 'xtask/**'
               - 'rustfmt.toml'
             workflows:


### PR DESCRIPTION
The `detect-changes` job in `pre-submit.yml` enumerates the files
that should trigger the full CI suite, but it omitted
`rust-toolchain.toml` and `Cargo.lock`. As a result, PR #221
(rust-toolchain 1.91 -> 1.95) saw `ci`, `coverage-report`, and
`diff-cover` skipped entirely - the new toolchain was never
exercised by build, lint, or tests before merge.

Both files are first-class inputs to the build (the shared CI
workflow already keys its caches on `Cargo.toml` and
`rust-toolchain.toml`), so add them to the `src` filter. Future
toolchain bumps and lockfile-only updates (e.g. once Dependabot's
cargo ecosystem starts opening PRs) will now run the full suite.

GitHub: #221
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
