### PR TITLE
githooks: restore cargo on PATH before invoking it

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,19 @@
 #!/bin/bash
 set -e
+
+# Git launches hooks with a sanitized PATH (MSYS2 default on Windows),
+# stripping the user's ~/.cargo/bin. Restore it.
+CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+if [ -f "$CARGO_HOME/env" ]; then
+    # shellcheck disable=SC1091
+    . "$CARGO_HOME/env"
+elif [ -d "$CARGO_HOME/bin" ]; then
+    case ":$PATH:" in
+        *":$CARGO_HOME/bin:"*) ;;
+        *) PATH="$CARGO_HOME/bin:$PATH" ;;
+    esac
+fi
+
 cargo fmt
 cargo lint
 cargo xtask check-typography


### PR DESCRIPTION
Git for Windows resets PATH to the MSYS2 / `git-core` default before
launching hook scripts, stripping the user's `~/.cargo/bin` even when
the outer shell had it. Every `cargo ...` line in the pre-commit hook
then fails with `cargo: command not found`, regardless of whether the
hook is installed via `git config core.hooksPath .githooks/` or by
the paseo workspace setup.

With this change the hook sources `$CARGO_HOME/env` when present
(the rustup-installed shim) and otherwise prepends `$CARGO_HOME/bin`
to PATH if the directory exists. If neither is found PATH is left
alone so a genuinely missing Rust toolchain still fails loudly
instead of being silently masked.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
