### PR TITLE
ci: recolor documentation label to teal to distinguish from dependencies

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -12,7 +12,7 @@
   description: "Something isn't working"
 
 - name: "documentation"
-  color: "0075ca"
+  color: "006b75"
   description: "Improvements or additions to documentation"
 
 - name: "duplicate"


### PR DESCRIPTION
Both `documentation` (0075ca, GitHub's default doc blue) and
`dependencies` (0366d6, Dependabot's blue) were shades of blue and
hard to tell apart on PR lists. Dependabot owns its color, so move
`documentation` to 006b75 (dark teal) - part of GitHub's default
8-pair label palette, conventional "info / docs" color in modern
design systems, and visually distinct from every other label
currently in labels.yml.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
