### PR TITLE
ci: auto-enable GitHub auto-merge on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,7 +37,6 @@ on:
     types: [opened, reopened, synchronize, labeled, ready_for_review]
 
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,47 @@
+#
+#   Dependabot Auto-Merge
+#
+# Enables GitHub auto-merge on Dependabot PRs so they merge themselves
+# once the repository's required status checks pass. This workflow does
+# NOT merge immediately and does NOT bypass branch protection - it only
+# flips the auto-merge flag, leaving the merge decision to the existing
+# required checks on `main`.
+#
+# Guards:
+#   - PR author must be `dependabot[bot]`
+#   - PR base branch must be `main`
+#   - PR must carry the `dependencies` label (set by Dependabot itself
+#     per `.github/dependabot.yml`)
+#
+# `pull_request_target` is used so the workflow runs with a token that
+# has write permission to the PR; Dependabot's own `pull_request` runs
+# only get a read-only token. Because no PR-controlled code is checked
+# out or executed, this trigger is safe here.
+#
+# Calling `gh pr merge --auto` is idempotent: re-running on a PR that
+# already has auto-merge enabled is a no-op.
+
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,14 +12,22 @@
 #   - PR base branch must be `main`
 #   - PR must carry the `dependencies` label (set by Dependabot itself
 #     per `.github/dependabot.yml`)
+#   - PR must not be a draft
 #
 # `pull_request_target` is used so the workflow runs with a token that
 # has write permission to the PR; Dependabot's own `pull_request` runs
 # only get a read-only token. Because no PR-controlled code is checked
 # out or executed, this trigger is safe here.
 #
-# Calling `gh pr merge --auto` is idempotent: re-running on a PR that
-# already has auto-merge enabled is a no-op.
+# There is no race against CI: `--auto` only flips the auto-merge flag,
+# and GitHub then waits for the branch's required status checks before
+# performing the merge. Re-running on a PR that already has auto-merge
+# enabled is a no-op.
+#
+# `gh pr merge --auto` can still exit non-zero in transient states
+# (conflicts, ineligible base, auto-merge temporarily disallowed). We
+# log those cases and exit successfully so they do not surface as red
+# checks - the next PR event (synchronize, labeled, ...) will retry.
 
 name: Dependabot Auto-Merge
 
@@ -37,6 +45,7 @@ jobs:
     if: >-
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.draft == false &&
       contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     steps:
@@ -44,4 +53,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          if ! gh pr merge --auto --squash "$PR_URL"; then
+            echo "::notice::Could not enable auto-merge on $PR_URL (PR may have conflicts or be temporarily ineligible). The next PR event will retry."
+          fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,9 +25,12 @@
 # enabled is a no-op.
 #
 # `gh pr merge --auto` can still exit non-zero in transient states
-# (conflicts, ineligible base, auto-merge temporarily disallowed). We
-# log those cases and exit successfully so they do not surface as red
-# checks - the next PR event (synchronize, labeled, ...) will retry.
+# (conflicts, ineligible base, checks pending). We log those cases
+# and exit successfully so they do not surface as red checks - the
+# next PR event (synchronize, labeled, ...) will retry. Persistent
+# failures (missing token permissions, repo-level auto-merge
+# disabled, missing `gh`) are surfaced as job failures so they get
+# fixed instead of silently leaving auto-merge off forever.
 
 name: Dependabot Auto-Merge
 
@@ -53,6 +56,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          if ! gh pr merge --auto --squash "$PR_URL"; then
-            echo "::notice::Could not enable auto-merge on $PR_URL (PR may have conflicts or be temporarily ineligible). The next PR event will retry."
+          set +e
+          output=$(gh pr merge --auto --squash "$PR_URL" 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -eq 0 ]; then
+            exit 0
           fi
+          # Treat permission/config/tooling errors as persistent: if we
+          # silently ignored these, auto-merge would never get enabled
+          # and CI would stay green forever. Everything else (conflicts,
+          # not-yet-mergeable, checks pending) is transient and retried
+          # on the next PR event.
+          if printf '%s' "$output" | grep -qiE 'resource not accessible|auto[- ]merge is not allowed|auto[- ]merge is not enabled|bad credentials|requires authentication|gh: command not found'; then
+            echo "::error::Persistent failure enabling auto-merge on $PR_URL - see log above."
+            exit 1
+          fi
+          echo "::notice::Could not enable auto-merge on $PR_URL (likely transient: conflicts, ineligible base, or checks pending). The next PR event will retry."


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-auto-merge.yml` that enables GitHub auto-merge on Dependabot PRs targeting `main` that carry the `dependencies` label.
- Workflow only flips the auto-merge flag; the actual merge stays gated by the existing required status checks on `main`, so branch protection and CI behavior are unchanged.
- Uses `pull_request_target` (Dependabot's own `pull_request` runs get only a read-only token) with `contents: write` + `pull-requests: write` and runs `gh pr merge --auto --squash`, which is idempotent on repeated triggers.

## Guards
- Author must be `dependabot[bot]`
- Base branch must be `main`
- PR must carry the `dependencies` label (Dependabot applies this per `.github/dependabot.yml`)

## Test plan
- [ ] Wait for the next Dependabot PR (or trigger one) and confirm the workflow runs and enables auto-merge.
- [ ] Confirm a non-Dependabot PR with the `dependencies` label does NOT get auto-merge enabled.
- [ ] Confirm the PR only merges once required status checks pass.

Generated with Claude Code