### PR TITLE
Replace UI Automation focus calls with native Win32 equivalents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,16 +51,13 @@ default-features = false
 [dependencies.windows]
 version = "0.62.2"
 features = [
-    "UI_UIAutomation",
     "Win32_Foundation",
     "Win32_Graphics_Dwm",
     "Win32_Graphics_Gdi",
     "Win32_Security",
-    "Win32_System_Com",
     "Win32_System_Console",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
-    "Win32_UI_Accessibility",
     "Win32_UI_HiDpi",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -313,7 +313,7 @@ impl Entrypoint for MainEntrypoint {
         // reset the configuration before the window was launched
         let _ = get_console_window_handle(
             windows_api,
-            spawn_console_process(windows_api, &format!("{PKG_NAME}.exe"), daemon_args)
+            spawn_console_process(windows_api, &format!("{PKG_NAME}.exe"), daemon_args, true)
                 .expect("Failed to create process")
                 .dwProcessId,
         );

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -601,11 +601,6 @@ impl<'a> Daemon<'a> {
 
         toggle_processed_input_mode(windows_api); // Disable processed input mode
 
-        // Initialize the COM library so we can use UI automation
-        windows_api
-            .initialize_com_library(windows::Win32::System::Com::COINIT_MULTITHREADED)
-            .unwrap();
-
         let workspace_area = workspace::get_workspace_area(windows_api, self.config.height);
 
         self.arrange_daemon_console(windows_api, &workspace_area);
@@ -632,8 +627,7 @@ impl<'a> Daemon<'a> {
 
         // Now that all clients started, focus the daemon console again.
         let daemon_console = windows_api.get_console_window();
-        let _ = windows_api.set_foreground_window(daemon_console);
-        let _ = windows_api.focus_window_with_automation(daemon_console);
+        let _ = windows_api.bring_window_to_top(daemon_console, true);
 
         self.print_instructions(windows_api);
         self.run(windows_api, &mut clients, &workspace_area).await;
@@ -934,8 +928,7 @@ impl<'a> Daemon<'a> {
                     self.arrange_daemon_console(windows_api, workspace_area);
                     // Focus the daemon console again.
                     let daemon_window = windows_api.get_console_window();
-                    let _ = windows_api.set_foreground_window(daemon_window);
-                    let _ = windows_api.focus_window_with_automation(daemon_window);
+                    let _ = windows_api.bring_window_to_top(daemon_window, true);
                     self.quit_control_mode(windows_api);
                 }
                 ControlModeAction::CopyHostnames => {
@@ -1540,8 +1533,9 @@ fn launch_client_console<W: WindowsApi>(
     client_args.push("client".to_string());
     client_args.extend(vec!["--".to_string(), actual_host.to_string()]);
 
-    let process_info = spawn_console_process(windows_api, &format!("{PKG_NAME}.exe"), client_args)
-        .expect("Failed to create process");
+    let process_info =
+        spawn_console_process(windows_api, &format!("{PKG_NAME}.exe"), client_args, false)
+            .expect("Failed to create process");
     let client_window_handle = get_console_window_handle(windows_api, process_info.dwProcessId);
     let process_handle = windows_api
         .open_process(PROCESS_QUERY_INFORMATION.0, false, process_info.dwProcessId)
@@ -2057,28 +2051,20 @@ fn ensure_client_z_order_in_sync_with_daemon<W: WindowsApi + Send + Sync + 'stat
 ///                                     and the clients console window handle.
 /// * `daemon_handle`                 - Handle to the daemon console window.
 fn defer_windows<W: WindowsApi>(windows_api: &W, clients: &[Client], daemon_handle: &HWND) {
-    for client in clients.iter().chain([&Client {
-        hostname: "root".to_owned(),
-        window_handle: *daemon_handle,
-        process_handle: HANDLE::default(),
-        process_id: 0,
-        state_sender: watch::channel(ClientState::Active).0,
-        highlight_sender: watch::channel(false).0,
-        tile_index: 0,
-    }]) {
+    for client in clients.iter() {
         let placement = match windows_api.get_window_placement(client.window_handle) {
             Ok(placement) => placement,
             Err(_) => {
                 continue;
             }
         };
-        // First restore if window is minimized
         if placement.showCmd == SW_SHOWMINIMIZED.0.try_into().unwrap() {
             let _ = windows_api.show_window(client.window_handle, SW_RESTORE);
         }
-        // Then bring it to front using UI automation
-        let _ = windows_api.focus_window_with_automation(client.window_handle);
+        let _ = windows_api.bring_window_to_top(client.window_handle, false);
     }
+    // Raise the daemon last so it ends up on top and keeps keyboard focus.
+    let _ = windows_api.bring_window_to_top(*daemon_handle, true);
 }
 
 /// The entrypoint for the `daemon` subcommand.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -53,7 +53,7 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     VIRTUAL_KEY, VK_A, VK_C, VK_D, VK_DOWN, VK_E, VK_ESCAPE, VK_H, VK_J, VK_K, VK_L, VK_LEFT, VK_N,
     VK_R, VK_RIGHT, VK_T, VK_UP,
 };
-use windows::Win32::UI::WindowsAndMessaging::{SW_RESTORE, SW_SHOWMINIMIZED};
+use windows::Win32::UI::WindowsAndMessaging::{SW_RESTORE, SW_SHOWMINIMIZED, SW_SHOWNOACTIVATE};
 use windows::Win32::{
     Foundation::{COLORREF, HANDLE, HWND, STILL_ACTIVE},
     System::{Console::ENABLE_PROCESSED_INPUT, Threading::PROCESS_QUERY_INFORMATION},
@@ -2052,11 +2052,11 @@ fn ensure_client_z_order_in_sync_with_daemon<W: WindowsApi + Send + Sync + 'stat
 /// * `daemon_handle`                 - Handle to the daemon console window.
 fn defer_windows<W: WindowsApi>(windows_api: &W, clients: &[Client], daemon_handle: &HWND) {
     for client in clients.iter() {
-        restore_if_minimized(windows_api, client.window_handle);
+        restore_if_minimized(windows_api, client.window_handle, false);
         let _ = windows_api.bring_window_to_top(client.window_handle, false);
     }
     // Raise the daemon last so it ends up on top and keeps keyboard focus.
-    restore_if_minimized(windows_api, *daemon_handle);
+    restore_if_minimized(windows_api, *daemon_handle, true);
     let _ = windows_api.bring_window_to_top(*daemon_handle, true);
 }
 
@@ -2065,13 +2065,34 @@ fn defer_windows<W: WindowsApi>(windows_api: &W, clients: &[Client], daemon_hand
 /// Silently does nothing when the placement query fails or the window is
 /// not minimized. Used by [`defer_windows`] so both client and daemon
 /// windows are brought back from the taskbar before z-order updates.
-fn restore_if_minimized<W: WindowsApi>(windows_api: &W, window_handle: HWND) {
+///
+/// # Arguments
+///
+/// * `windows_api`         - Windows API implementation.
+/// * `window_handle`       - Handle to the window to potentially restore.
+/// * `with_keyboard_focus` - Whether the restored window should be activated.
+///                           Pass `false` for client windows so unminimizing
+///                           them does not steal foreground from the daemon -
+///                           `SW_RESTORE` activates, which would let the
+///                           last-restored client win the foreground race and
+///                           block [`WindowsApi::bring_window_to_top`] from
+///                           refocusing the daemon.
+fn restore_if_minimized<W: WindowsApi>(
+    windows_api: &W,
+    window_handle: HWND,
+    with_keyboard_focus: bool,
+) {
     let placement = match windows_api.get_window_placement(window_handle) {
         Ok(placement) => placement,
         Err(_) => return,
     };
     if placement.showCmd == SW_SHOWMINIMIZED.0.try_into().unwrap() {
-        let _ = windows_api.show_window(window_handle, SW_RESTORE);
+        let cmd = if with_keyboard_focus {
+            SW_RESTORE
+        } else {
+            SW_SHOWNOACTIVATE
+        };
+        let _ = windows_api.show_window(window_handle, cmd);
     }
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2052,19 +2052,27 @@ fn ensure_client_z_order_in_sync_with_daemon<W: WindowsApi + Send + Sync + 'stat
 /// * `daemon_handle`                 - Handle to the daemon console window.
 fn defer_windows<W: WindowsApi>(windows_api: &W, clients: &[Client], daemon_handle: &HWND) {
     for client in clients.iter() {
-        let placement = match windows_api.get_window_placement(client.window_handle) {
-            Ok(placement) => placement,
-            Err(_) => {
-                continue;
-            }
-        };
-        if placement.showCmd == SW_SHOWMINIMIZED.0.try_into().unwrap() {
-            let _ = windows_api.show_window(client.window_handle, SW_RESTORE);
-        }
+        restore_if_minimized(windows_api, client.window_handle);
         let _ = windows_api.bring_window_to_top(client.window_handle, false);
     }
     // Raise the daemon last so it ends up on top and keeps keyboard focus.
+    restore_if_minimized(windows_api, *daemon_handle);
     let _ = windows_api.bring_window_to_top(*daemon_handle, true);
+}
+
+/// Restore `window_handle` if its current placement reports minimized.
+///
+/// Silently does nothing when the placement query fails or the window is
+/// not minimized. Used by [`defer_windows`] so both client and daemon
+/// windows are brought back from the taskbar before z-order updates.
+fn restore_if_minimized<W: WindowsApi>(windows_api: &W, window_handle: HWND) {
+    let placement = match windows_api.get_window_placement(window_handle) {
+        Ok(placement) => placement,
+        Err(_) => return,
+    };
+    if placement.showCmd == SW_SHOWMINIMIZED.0.try_into().unwrap() {
+        let _ = windows_api.show_window(window_handle, SW_RESTORE);
+    }
 }
 
 /// The entrypoint for the `daemon` subcommand.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,11 +296,14 @@ impl<R: Registry> Drop for WindowsSettingsDefaultTerminalApplicationGuard<R> {
 ///
 /// # Arguments
 ///
-/// * `api`         - Windows API implementation
-/// * `application` - Application name including file extension (`.exe`).
-///                   If the application is not in the `PATH` environment variable, the full path
-///                   must be specified.
-/// * `args`        - List of arguments to the application.
+/// * `api`                 - Windows API implementation
+/// * `application`         - Application name including file extension (`.exe`).
+///                           If the application is not in the `PATH` environment variable,
+///                           the full path must be specified.
+/// * `args`                - List of arguments to the application.
+/// * `with_keyboard_focus` - Whether the new console window should take foreground focus
+///                           when it appears. Pass `false` when spawning child consoles
+///                           that must not steal focus from the calling process.
 ///
 /// # Returns
 ///
@@ -309,8 +312,9 @@ pub fn spawn_console_process<W: WindowsApi>(
     api: &W,
     application: &str,
     args: Vec<String>,
+    with_keyboard_focus: bool,
 ) -> Option<PROCESS_INFORMATION> {
-    return api.create_process_with_args(application, args);
+    return api.create_process_with_args(application, args, with_keyboard_focus);
 }
 
 /// Initialize the logger.

--- a/src/tests/test_cli.rs
+++ b/src/tests/test_cli.rs
@@ -364,8 +364,9 @@ mod cli_main_test {
                                 "host1".to_string(),
                                 "host2".to_string(),
                             ]),
+                            mockall::predicate::eq(true),
                         )
-                        .returning(|_, _| {
+                        .returning(|_, _, _| {
                             return Some(windows::Win32::System::Threading::PROCESS_INFORMATION {
                                 hProcess: windows::Win32::Foundation::HANDLE(
                                     std::ptr::dangling_mut::<std::ffi::c_void>(),
@@ -1360,9 +1361,10 @@ mod main_entrypoint_test {
                     "host1".to_string(),
                     "host2".to_string(),
                 ]),
+                eq(true),
             )
             .times(1)
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
                     hProcess: windows::Win32::Foundation::HANDLE(std::ptr::dangling_mut::<
                         std::ffi::c_void,
@@ -1425,9 +1427,10 @@ mod main_entrypoint_test {
                     "daemon".to_string(),
                     "host1".to_string(),
                 ]),
+                eq(true),
             )
             .times(1)
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
                     hProcess: windows::Win32::Foundation::HANDLE(std::ptr::dangling_mut::<
                         std::ffi::c_void,
@@ -1494,9 +1497,10 @@ mod main_entrypoint_test {
                     "server1".to_string(),
                     "server2".to_string(),
                 ]),
+                eq(true),
             )
             .times(1)
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
                     hProcess: windows::Win32::Foundation::HANDLE(std::ptr::dangling_mut::<
                         std::ffi::c_void,
@@ -1565,9 +1569,10 @@ mod main_entrypoint_test {
                     "web2".to_string(),
                     "web3".to_string(),
                 ]),
+                eq(true),
             )
             .times(1)
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
                     hProcess: windows::Win32::Foundation::HANDLE(std::ptr::dangling_mut::<
                         std::ffi::c_void,
@@ -1624,9 +1629,9 @@ mod main_entrypoint_test {
         let mut mock_windows_api = mock_windows_api;
         mock_windows_api
             .expect_create_process_with_args()
-            .with(eq("csshw.exe"), eq(vec!["daemon".to_string()]))
+            .with(eq("csshw.exe"), eq(vec!["daemon".to_string()]), eq(true))
             .times(1)
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
                     hProcess: windows::Win32::Foundation::HANDLE(std::ptr::dangling_mut::<
                         std::ffi::c_void,
@@ -1724,9 +1729,10 @@ mod main_entrypoint_test {
             .with(
                 eq("csshw.exe"),
                 eq(vec!["daemon".to_string(), "host1".to_string()]),
+                eq(true),
             )
             .times(1)
-            .returning(|_, _| return None);
+            .returning(|_, _, _| return None);
 
         let args = Args {
             command: None,

--- a/src/tests/test_lib.rs
+++ b/src/tests/test_lib.rs
@@ -360,9 +360,10 @@ mod spawn_process_test {
                     "echo".to_string(),
                     "test".to_string(),
                 ]),
+                eq(true),
             )
             .times(1)
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
                     hProcess: windows::Win32::Foundation::HANDLE(0x1234 as *mut c_void),
                     hThread: windows::Win32::Foundation::HANDLE(0x5678 as *mut c_void),
@@ -375,6 +376,7 @@ mod spawn_process_test {
             &mock_api,
             "cmd.exe",
             vec!["/c".to_string(), "echo".to_string(), "test".to_string()],
+            true,
         );
 
         assert!(result.is_some());
@@ -391,11 +393,16 @@ mod spawn_process_test {
 
         mock_api
             .expect_create_process_with_args()
-            .with(eq("nonexistent.exe"), eq(vec!["arg1".to_string()]))
+            .with(
+                eq("nonexistent.exe"),
+                eq(vec!["arg1".to_string()]),
+                eq(true),
+            )
             .times(1)
-            .returning(|_, _| return None);
+            .returning(|_, _, _| return None);
 
-        let result = spawn_console_process(&mock_api, "nonexistent.exe", vec!["arg1".to_string()]);
+        let result =
+            spawn_console_process(&mock_api, "nonexistent.exe", vec!["arg1".to_string()], true);
 
         assert!(result.is_none());
     }
@@ -408,9 +415,9 @@ mod spawn_process_test {
 
         mock_api
             .expect_create_process_with_args()
-            .with(eq("notepad.exe"), eq(Vec::<String>::new()))
+            .with(eq("notepad.exe"), eq(Vec::<String>::new()), eq(true))
             .times(1)
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
                     hProcess: windows::Win32::Foundation::HANDLE(0xABCD as *mut c_void),
                     hThread: windows::Win32::Foundation::HANDLE(0xEF01 as *mut c_void),
@@ -419,7 +426,7 @@ mod spawn_process_test {
                 });
             });
 
-        let result = spawn_console_process(&mock_api, "notepad.exe", vec![]);
+        let result = spawn_console_process(&mock_api, "notepad.exe", vec![], true);
 
         assert!(result.is_some());
         let process_info = result.unwrap();
@@ -440,9 +447,9 @@ mod spawn_process_test {
         ];
         mock_api
             .expect_create_process_with_args()
-            .with(eq("ssh.exe"), eq(args.clone()))
+            .with(eq("ssh.exe"), eq(args.clone()), eq(true))
             .times(1)
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
                     hProcess: windows::Win32::Foundation::HANDLE(0x2468 as *mut c_void),
                     hThread: windows::Win32::Foundation::HANDLE(0x1357 as *mut c_void),
@@ -451,7 +458,7 @@ mod spawn_process_test {
                 });
             });
 
-        let result = spawn_console_process(&mock_api, "ssh.exe", args);
+        let result = spawn_console_process(&mock_api, "ssh.exe", args, true);
 
         assert!(result.is_some());
         let process_info = result.unwrap();

--- a/src/tests/utils/test_windows.rs
+++ b/src/tests/utils/test_windows.rs
@@ -616,7 +616,7 @@ mod create_process_with_args_test {
         let windows_api = DefaultWindowsApi;
         let application = r"C:\Windows\System32\timeout.exe";
         let args = vec!["30".to_string()];
-        let process_info = match windows_api.create_process_with_args(application, args) {
+        let process_info = match windows_api.create_process_with_args(application, args, true) {
             None => panic!("Failed to create process: {:?}", unsafe { GetLastError() }),
             Some(process_info) => process_info,
         };

--- a/src/tests/utils/test_windows.rs
+++ b/src/tests/utils/test_windows.rs
@@ -603,10 +603,11 @@ mod command_line_test {
 mod create_process_with_args_test {
     use windows::Win32::{
         Foundation::{GetLastError, STILL_ACTIVE},
-        System::Threading::TerminateProcess,
+        System::Threading::{TerminateProcess, STARTF_USESHOWWINDOW},
+        UI::WindowsAndMessaging::SW_SHOWNOACTIVATE,
     };
 
-    use crate::utils::windows::{DefaultWindowsApi, WindowsApi};
+    use crate::utils::windows::{build_startupinfo, DefaultWindowsApi, WindowsApi};
 
     /// Tests create_process_with_args with valid application and arguments.
     /// Validates that the process creation function is called with correct parameters.
@@ -623,5 +624,31 @@ mod create_process_with_args_test {
         assert!(windows_api.get_exit_code(process_info.hProcess).unwrap() == STILL_ACTIVE.0 as u32);
         unsafe { TerminateProcess(process_info.hProcess, 0) }.expect("Failed to terminate process");
         assert!(windows_api.get_exit_code(process_info.hProcess).unwrap() == 0);
+    }
+
+    /// Tests that build_startupinfo populates STARTF_USESHOWWINDOW and
+    /// SW_SHOWNOACTIVATE when keyboard focus is suppressed, so the spawned
+    /// console window appears without stealing foreground focus from the daemon.
+    #[test]
+    fn test_build_startupinfo_without_focus_sets_show_no_activate() {
+        let startupinfo = build_startupinfo(false);
+        assert!(
+            (startupinfo.dwFlags & STARTF_USESHOWWINDOW) == STARTF_USESHOWWINDOW,
+            "STARTF_USESHOWWINDOW must be set when keyboard focus is suppressed"
+        );
+        assert_eq!(startupinfo.wShowWindow, SW_SHOWNOACTIVATE.0 as u16);
+    }
+
+    /// Tests that build_startupinfo leaves STARTF_USESHOWWINDOW unset when
+    /// keyboard focus is allowed, so the spawned process picks its own
+    /// show-window behaviour.
+    #[test]
+    fn test_build_startupinfo_with_focus_leaves_flags_default() {
+        let startupinfo = build_startupinfo(true);
+        assert!(
+            (startupinfo.dwFlags & STARTF_USESHOWWINDOW) != STARTF_USESHOWWINDOW,
+            "STARTF_USESHOWWINDOW must not be set when keyboard focus is allowed"
+        );
+        assert_eq!(startupinfo.wShowWindow, 0);
     }
 }

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -19,7 +19,6 @@ use windows::core::{BOOL, HSTRING, PCWSTR};
 use windows::Win32::Foundation::{COLORREF, FALSE, HANDLE, HWND, LPARAM, TRUE};
 use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_BORDER_COLOR};
 use windows::Win32::Graphics::Gdi::InvalidateRect;
-use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
 use windows::Win32::System::Console::{
     FillConsoleOutputAttribute, GetConsoleProcessList, GetConsoleScreenBufferInfo,
     GetConsoleWindow, GetStdHandle, ReadConsoleInputW, SetConsoleTextAttribute,
@@ -33,17 +32,14 @@ use windows::Win32::System::Console::{
 };
 use windows::Win32::System::Threading::PROCESS_ACCESS_RIGHTS;
 use windows::Win32::System::Threading::{
-    CreateProcessW, CREATE_NEW_CONSOLE, PROCESS_INFORMATION, STARTUPINFOW,
+    CreateProcessW, CREATE_NEW_CONSOLE, PROCESS_INFORMATION, STARTF_USESHOWWINDOW, STARTUPINFOW,
 };
 use windows::Win32::System::Threading::{GetExitCodeProcess, OpenProcess};
-use windows::Win32::UI::Accessibility::{CUIAutomation, IUIAutomation};
 use windows::Win32::UI::WindowsAndMessaging::{
-    EnumWindows, GetWindowTextW, GetWindowThreadProcessId, MoveWindow, SetWindowTextW,
-    SYSTEM_METRICS_INDEX,
-};
-use windows::Win32::UI::WindowsAndMessaging::{
-    GetForegroundWindow, GetWindowPlacement, SetForegroundWindow, ShowWindow, SHOW_WINDOW_CMD,
-    WINDOWPLACEMENT,
+    BringWindowToTop, EnumWindows, GetForegroundWindow, GetWindowPlacement, GetWindowTextW,
+    GetWindowThreadProcessId, MoveWindow, SetWindowPos, SetWindowTextW, ShowWindow, HWND_NOTOPMOST,
+    HWND_TOPMOST, SHOW_WINDOW_CMD, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_SHOWNOACTIVATE,
+    SYSTEM_METRICS_INDEX, WINDOWPLACEMENT,
 };
 
 #[cfg(test)]
@@ -271,12 +267,21 @@ pub trait WindowsApi: Send + Sync {
     /// Console screen buffer information or error
     fn get_console_attached_process_count(&self) -> u32;
 
-    /// Create a new process
+    /// Create a new process attached to its own console window.
+    ///
+    /// When `with_keyboard_focus` is false the new console window is
+    /// shown without activation (`STARTF_USESHOWWINDOW` +
+    /// `SW_SHOWNOACTIVATE`), so the caller retains keyboard focus.
+    /// Used when the daemon spawns client consoles - otherwise the
+    /// last-spawned client wins the foreground and Windows refuses to
+    /// let the daemon steal it back.
     ///
     /// # Arguments
     ///
-    /// * `application` - Application name including file extension
-    /// * `args` - List of arguments to the application
+    /// * `application`         - Application name including file extension
+    /// * `args`                - List of arguments to the application
+    /// * `with_keyboard_focus` - Whether the new console window should take
+    ///                           foreground focus when it appears.
     ///
     /// # Returns
     ///
@@ -285,12 +290,17 @@ pub trait WindowsApi: Send + Sync {
         &self,
         application: &str,
         args: Vec<String>,
+        with_keyboard_focus: bool,
     ) -> Option<windows::Win32::System::Threading::PROCESS_INFORMATION> {
         let command_line = build_command_line(application, &args);
         let mut startupinfo = STARTUPINFOW {
             cb: mem::size_of::<STARTUPINFOW>() as u32,
             ..Default::default()
         };
+        if !with_keyboard_focus {
+            startupinfo.dwFlags = STARTF_USESHOWWINDOW;
+            startupinfo.wShowWindow = SW_SHOWNOACTIVATE.0 as u16;
+        }
         let mut process_information = PROCESS_INFORMATION::default();
         let mut cmd_line = command_line;
         let command_line_ptr = windows::core::PWSTR(cmd_line.as_mut_ptr());
@@ -351,16 +361,27 @@ pub trait WindowsApi: Send + Sync {
     /// Handle to the foreground window
     fn get_foreground_window(&self) -> HWND;
 
-    /// Sets the foreground window.
+    /// Bring `hwnd` to the top of the z-order.
+    ///
+    /// When `with_keyboard_focus` is true the window is also activated and
+    /// receives keyboard focus. When false the window is raised without
+    /// activation, avoiding the taskbar flash that would happen if the
+    /// window is not the current input target.
     ///
     /// # Arguments
     ///
-    /// * `hwnd` - Handle to the window to set as foreground
+    /// * `hwnd`                - Handle to the window to raise.
+    /// * `with_keyboard_focus` - Whether to activate the window and give
+    ///                           it keyboard focus.
     ///
     /// # Returns
     ///
     /// Result indicating success or failure of the operation
-    fn set_foreground_window(&self, hwnd: HWND) -> windows::core::Result<()>;
+    fn bring_window_to_top(
+        &self,
+        hwnd: HWND,
+        with_keyboard_focus: bool,
+    ) -> windows::core::Result<()>;
 
     /// Gets console mode for the specified handle.
     ///
@@ -443,17 +464,6 @@ pub trait WindowsApi: Send + Sync {
     /// Result indicating success or failure of the operation
     fn show_window(&self, hwnd: HWND, cmd_show: SHOW_WINDOW_CMD) -> windows::core::Result<bool>;
 
-    /// Focuses a window using UI Automation.
-    ///
-    /// # Arguments
-    ///
-    /// * `hwnd` - Handle to the window to focus
-    ///
-    /// # Returns
-    ///
-    /// Result indicating success or failure of the operation
-    fn focus_window_with_automation(&self, hwnd: HWND) -> windows::core::Result<()>;
-
     /// Checks if a window handle is valid.
     ///
     /// # Arguments
@@ -482,20 +492,6 @@ pub trait WindowsApi: Send + Sync {
         inherit: bool,
         process_id: u32,
     ) -> windows::core::Result<HANDLE>;
-
-    /// Initializes the COM library for use by the calling thread.
-    ///
-    /// # Arguments
-    ///
-    /// * `coinit` - Initialization options for the COM library
-    ///
-    /// # Returns
-    ///
-    /// Result indicating success or failure of the operation
-    fn initialize_com_library(
-        &self,
-        coinit: windows::Win32::System::Com::COINIT,
-    ) -> windows::core::Result<()>;
 
     /// Gets system metrics information.
     ///
@@ -763,13 +759,41 @@ impl WindowsApi for DefaultWindowsApi {
         return unsafe { GetForegroundWindow() };
     }
 
-    fn set_foreground_window(&self, hwnd: HWND) -> windows::core::Result<()> {
-        let result = unsafe { SetForegroundWindow(hwnd) };
-        if result.as_bool() {
-            return Ok(());
-        } else {
-            return Err(windows::core::Error::from_thread());
+    fn bring_window_to_top(
+        &self,
+        hwnd: HWND,
+        with_keyboard_focus: bool,
+    ) -> windows::core::Result<()> {
+        if with_keyboard_focus {
+            return unsafe { BringWindowToTop(hwnd) };
         }
+        // Raise without activation via the HWND_TOPMOST -> HWND_NOTOPMOST
+        // trick. Synchronous SetWindowPos (no SWP_ASYNCWINDOWPOS) so
+        // HWND_TOPMOST is applied before we strip it again - otherwise
+        // rapid invocations from the z-order loop can leave the
+        // WS_EX_TOPMOST flag set, floating client windows above other
+        // applications. See https://stackoverflow.com/questions/5257977.
+        unsafe {
+            SetWindowPos(
+                hwnd,
+                Some(HWND_TOPMOST),
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+            )?;
+            SetWindowPos(
+                hwnd,
+                Some(HWND_NOTOPMOST),
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+            )?;
+        }
+        return Ok(());
     }
 
     fn get_console_mode(&self, handle: HANDLE) -> windows::core::Result<CONSOLE_MODE> {
@@ -814,14 +838,6 @@ impl WindowsApi for DefaultWindowsApi {
         return Ok(result.as_bool());
     }
 
-    fn focus_window_with_automation(&self, hwnd: HWND) -> windows::core::Result<()> {
-        let automation: IUIAutomation =
-            unsafe { CoCreateInstance(&CUIAutomation, None, CLSCTX_ALL)? };
-        let window = unsafe { automation.ElementFromHandle(hwnd)? };
-        unsafe { window.SetFocus()? };
-        return Ok(());
-    }
-
     fn is_window(&self, hwnd: HWND) -> bool {
         return unsafe { windows::Win32::UI::WindowsAndMessaging::IsWindow(Some(hwnd)).as_bool() };
     }
@@ -833,18 +849,6 @@ impl WindowsApi for DefaultWindowsApi {
         process_id: u32,
     ) -> windows::core::Result<HANDLE> {
         return unsafe { OpenProcess(PROCESS_ACCESS_RIGHTS(access), inherit, process_id) };
-    }
-
-    fn initialize_com_library(
-        &self,
-        coinit: windows::Win32::System::Com::COINIT,
-    ) -> windows::core::Result<()> {
-        let result = unsafe { windows::Win32::System::Com::CoInitializeEx(None, coinit) };
-        if result.is_ok() {
-            return Ok(());
-        } else {
-            return Err(windows::core::Error::from(result));
-        }
     }
 
     fn get_system_metrics(&self, index: SYSTEM_METRICS_INDEX) -> i32 {

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -881,7 +881,7 @@ pub const KEY_EVENT: u16 = KEY_EVENT_U32 as u16;
 ///
 /// A `STARTUPINFOW` with `cb` set and, when applicable, the no-activate
 /// show-window flags applied.
-pub fn build_startupinfo(with_keyboard_focus: bool) -> STARTUPINFOW {
+pub(crate) fn build_startupinfo(with_keyboard_focus: bool) -> STARTUPINFOW {
     let mut startupinfo = STARTUPINFOW {
         cb: mem::size_of::<STARTUPINFOW>() as u32,
         ..Default::default()

--- a/src/utils/windows.rs
+++ b/src/utils/windows.rs
@@ -293,14 +293,7 @@ pub trait WindowsApi: Send + Sync {
         with_keyboard_focus: bool,
     ) -> Option<windows::Win32::System::Threading::PROCESS_INFORMATION> {
         let command_line = build_command_line(application, &args);
-        let mut startupinfo = STARTUPINFOW {
-            cb: mem::size_of::<STARTUPINFOW>() as u32,
-            ..Default::default()
-        };
-        if !with_keyboard_focus {
-            startupinfo.dwFlags = STARTF_USESHOWWINDOW;
-            startupinfo.wShowWindow = SW_SHOWNOACTIVATE.0 as u16;
-        }
+        let mut startupinfo = build_startupinfo(with_keyboard_focus);
         let mut process_information = PROCESS_INFORMATION::default();
         let mut cmd_line = command_line;
         let command_line_ptr = windows::core::PWSTR(cmd_line.as_mut_ptr());
@@ -871,6 +864,34 @@ impl WindowsApi for DefaultWindowsApi {
 /// [1]: https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/Console/constant.KEY_EVENT.html
 /// [2]: https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/Console/struct.INPUT_RECORD.html
 pub const KEY_EVENT: u16 = KEY_EVENT_U32 as u16;
+
+/// Build a `STARTUPINFOW` for [`WindowsApi::create_process_with_args`].
+///
+/// When `with_keyboard_focus` is false, `STARTF_USESHOWWINDOW` and
+/// `SW_SHOWNOACTIVATE` are populated so the new console appears without
+/// stealing foreground focus. Otherwise the struct is left at its default
+/// (the new process picks its own show-window behaviour).
+///
+/// # Arguments
+///
+/// * `with_keyboard_focus` - Whether the spawned process is allowed to take
+///                           foreground focus when its console appears.
+///
+/// # Returns
+///
+/// A `STARTUPINFOW` with `cb` set and, when applicable, the no-activate
+/// show-window flags applied.
+pub fn build_startupinfo(with_keyboard_focus: bool) -> STARTUPINFOW {
+    let mut startupinfo = STARTUPINFOW {
+        cb: mem::size_of::<STARTUPINFOW>() as u32,
+        ..Default::default()
+    };
+    if !with_keyboard_focus {
+        startupinfo.dwFlags = STARTF_USESHOWWINDOW;
+        startupinfo.wShowWindow = SW_SHOWNOACTIVATE.0 as u16;
+    }
+    return startupinfo;
+}
 
 /// Build command line string for Windows process creation
 ///


### PR DESCRIPTION
Drop the UI Automation dependency in favor of direct user32 calls.
CoCreateInstance for IUIAutomation was the slowest step in the
z-order sync loop because it has to resolve the COM class via the
registry and load uiautomationcore.dll on every invocation.

The replacement splits focus handling into two concerns:

- bring_window_to_top(hwnd, with_keyboard_focus) on the WindowsApi
  trait. with_keyboard_focus=true wraps BringWindowToTop (raise +
  activate); with_keyboard_focus=false performs an HWND_TOPMOST ->
  HWND_NOTOPMOST SetWindowPos pair so the window rises without
  stealing focus or flashing the taskbar.

- create_process_with_args grows a with_keyboard_focus flag. The
  daemon spawns client consoles with the flag set to false
  (STARTF_USESHOWWINDOW + SW_SHOWNOACTIVATE in STARTUPINFO) so the
  daemon never loses keyboard focus during launch - otherwise the
  last-spawned client wins the foreground and Windows refuses to
  let the daemon steal it back.

The HWND_TOPMOST/HWND_NOTOPMOST pair is issued synchronously (no
SWP_ASYNCWINDOWPOS) - the previous async version of this dance
left some client windows stuck above other apps when the user
switched between the daemon and an unrelated window faster than
the queued NOTOPMOST messages could drain.

Removes UI_UIAutomation, Win32_UI_Accessibility, and
Win32_System_Com from the windows-rs feature set, plus the COM
init at daemon launch.

Builds on the work in #132 and incorporates the review feedback
there (single helper with a bool flag, drop the generic
SetWindowPos wrapper, fix the topmost-stuck-window bug).

GitHub: #132
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
