### PR TITLE
ci: grant contents:write to Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -40,6 +40,7 @@ on:
     types: [opened, reopened, synchronize, labeled, ready_for_review]
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The `enablePullRequestAutoMerge` GraphQL mutation requires repo
write access, not just pull-request write. With only
`pull-requests: write`, the workflow failed on every Dependabot PR
with `GraphQL: Resource not accessible by integration
(enablePullRequestAutoMerge)`, leaving auto-merge off and surfacing
a red check.

Add `contents: write` to the workflow's permissions block so the
mutation succeeds and auto-merge gets enabled as intended.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
