### PR TITLE
ci: trigger post-submit CI for Dependabot auto-merges

### DIFF
--- a/.github/workflows/_shared-ci.yml
+++ b/.github/workflows/_shared-ci.yml
@@ -9,6 +9,14 @@ name: Shared CI Logic
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: >-
+          Git ref or SHA to check out. Empty string falls back to the
+          triggering event's default ref.
+        type: string
+        required: false
+        default: ''
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,6 +26,8 @@ jobs:
     runs-on: &runner-version windows-latest
     steps:
       - uses: &checkout-action actions/checkout@v5
+        with: &checkout-with
+          ref: ${{ inputs.ref }}
 
       - uses: &rust-cache-action Swatinem/rust-cache@v2
         with: &rust-cache-shared-key
@@ -43,6 +53,7 @@ jobs:
     runs-on: *runner-version
     steps:
       - uses: *checkout-action
+        with: *checkout-with
       - name: Check format
         run: cargo fmt -- --check
 
@@ -51,6 +62,7 @@ jobs:
     needs: build
     steps:
       - uses: *checkout-action
+        with: *checkout-with
       - uses: *rust-cache-action
         with: *rust-cache-shared-key
       - uses: *build-cache
@@ -64,6 +76,7 @@ jobs:
     needs: build
     steps:
       - uses: *checkout-action
+        with: *checkout-with
       - uses: *rust-cache-action
         with: *rust-cache-shared-key
       - uses: *build-cache
@@ -114,6 +127,7 @@ jobs:
     needs: build
     steps:
       - uses: *checkout-action
+        with: *checkout-with
       - uses: *rust-cache-action
         with: *rust-cache-shared-key
       - uses: *build-cache
@@ -126,6 +140,7 @@ jobs:
     needs: build
     steps:
       - uses: *checkout-action
+        with: *checkout-with
       - uses: *rust-cache-action
         with: *rust-cache-shared-key
       - uses: *build-cache
@@ -138,6 +153,7 @@ jobs:
     needs: build
     steps:
       - uses: *checkout-action
+        with: *checkout-with
       - uses: *rust-cache-action
         with: *rust-cache-shared-key
       - uses: *build-cache

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -62,7 +62,14 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
+      # Mirror the `ci` job's checkout ref so the local
+      # `./.github/workflows/_coverage_report` action is loaded from the
+      # merged commit on `main`, not the `pull_request_target` default
+      # `refs/pull/<n>/merge` (which would source the action from
+      # PR-controlled content).
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
       - name: Download Coverage XML Data
         uses: actions/download-artifact@v4

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -6,22 +6,28 @@
 # Uses the shared CI workflow.
 #
 # Trigger model:
-#   `pull_request_target` `closed` with `merged == true` covers every
-#   merge into `main`, including Dependabot auto-merges. A `push`-on-
-#   `main` trigger would miss the Dependabot path: the auto-merge
-#   workflow enables `--auto` using the default `GITHUB_TOKEN`, so when
-#   GitHub later performs the merge, the resulting `push` event is
-#   suppressed from triggering further workflow runs (anti-loop
-#   safeguard for `GITHUB_TOKEN`-attributed actions).
-#   `pull_request_target` is observed on state transition and is not
-#   subject to that safeguard, so a single trigger handles human and
-#   Dependabot merges uniformly without risk of duplicate runs.
+#   - `push` to `main` covers normal human-driven merges. The resulting
+#     workflow run carries `main` as its head_branch, so downstream
+#     `workflow_run` consumers (see `deploy_github_pages.yml`) that
+#     filter on `branches: [main]` keep firing.
+#   - `pull_request_target` `closed` covers Dependabot auto-merges. The
+#     auto-merge workflow enables `--auto` with the default
+#     `GITHUB_TOKEN`; per GitHub's anti-loop safeguard for
+#     `GITHUB_TOKEN`-attributed actions, the resulting `push` event is
+#     suppressed from triggering further workflow runs, so this path
+#     would otherwise never run post-submit CI for Dependabot merges.
+#     `pull_request_target` is observed on state transition and is not
+#     subject to that safeguard. It is gated to merged Dependabot PRs
+#     to avoid duplicate runs on human merges (which take the `push`
+#     path).
 #
 # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
 
 name: Post-Submit CI
 
 on:
+  push:
+    branches: ["main"]
   pull_request_target:
     branches: ["main"]
     types: [closed]
@@ -36,9 +42,21 @@ permissions:
 
 jobs:
   ci:
-    # Skip closed-without-merge; only build the merged commit.
-    if: github.event.pull_request.merged == true
+    # `push` runs unconditionally; `pull_request_target` runs only for
+    # merged Dependabot PRs (human merges are already covered by `push`).
+    if: >-
+      github.event_name == 'push' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.user.login == 'dependabot[bot]')
     uses: ./.github/workflows/_shared-ci.yml
+    with:
+      # On `pull_request_target`, default checkout would resolve to
+      # `refs/pull/<n>/merge` (a synthetic merge ref) rather than the
+      # commit that actually landed on `main`. Pass `merge_commit_sha`
+      # so the build runs against the merged commit (matters for
+      # squash/rebase merges). Falls through to `github.sha` on `push`,
+      # which is already the merged commit on `main`.
+      ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
   coverage-report:
     needs: ci

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -1,18 +1,48 @@
 #
 #   csshw Post-Submit CI
 #
-# Runs on the main branch on pushes with full coverage collection.
+# Runs on the main branch after merges with full coverage collection.
 # For pull requests, see pre-submit.yml which includes coverage reporting.
 # Uses the shared CI workflow.
+#
+# Trigger model:
+#   - `push` to `main` covers normal human-driven merges.
+#   - `pull_request_target` `closed` covers Dependabot auto-merges.
+#     The Dependabot auto-merge workflow enables `--auto` using the
+#     default `GITHUB_TOKEN`. When GitHub later performs the merge,
+#     the resulting `push` event is suppressed from triggering further
+#     workflow runs (anti-loop safeguard for `GITHUB_TOKEN`-attributed
+#     actions), so post-submit CI would otherwise never run for those
+#     merges. The `pull_request_target` closed event is observed on
+#     state transition and is gated to merged Dependabot PRs to avoid
+#     duplicate runs on human merges (which keep using the `push` path).
+#
+# See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
 
 name: Post-Submit CI
 
 on:
   push:
     branches: ["main"]
+  pull_request_target:
+    branches: ["main"]
+    types: [closed]
+
+# Constrain `pull_request_target` to read-only on contents. The shared
+# CI workflow only builds, tests, and uploads run-scoped artifacts; it
+# does not need write permissions to the repository.
+permissions:
+  contents: read
 
 jobs:
   ci:
+    # On `pull_request_target`, only run for merged Dependabot PRs.
+    # Non-merged closes and human merges are no-ops (human merges are
+    # already covered by the `push` event).
+    if: >-
+      github.event_name == 'push' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.user.login == 'dependabot[bot]')
     uses: ./.github/workflows/_shared-ci.yml
 
   coverage-report:

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -6,43 +6,38 @@
 # Uses the shared CI workflow.
 #
 # Trigger model:
-#   - `push` to `main` covers normal human-driven merges.
-#   - `pull_request_target` `closed` covers Dependabot auto-merges.
-#     The Dependabot auto-merge workflow enables `--auto` using the
-#     default `GITHUB_TOKEN`. When GitHub later performs the merge,
-#     the resulting `push` event is suppressed from triggering further
-#     workflow runs (anti-loop safeguard for `GITHUB_TOKEN`-attributed
-#     actions), so post-submit CI would otherwise never run for those
-#     merges. The `pull_request_target` closed event is observed on
-#     state transition and is gated to merged Dependabot PRs to avoid
-#     duplicate runs on human merges (which keep using the `push` path).
+#   `pull_request_target` `closed` with `merged == true` covers every
+#   merge into `main`, including Dependabot auto-merges. A `push`-on-
+#   `main` trigger would miss the Dependabot path: the auto-merge
+#   workflow enables `--auto` using the default `GITHUB_TOKEN`, so when
+#   GitHub later performs the merge, the resulting `push` event is
+#   suppressed from triggering further workflow runs (anti-loop
+#   safeguard for `GITHUB_TOKEN`-attributed actions).
+#   `pull_request_target` is observed on state transition and is not
+#   subject to that safeguard, so a single trigger handles human and
+#   Dependabot merges uniformly without risk of duplicate runs.
 #
 # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
 
 name: Post-Submit CI
 
 on:
-  push:
-    branches: ["main"]
   pull_request_target:
     branches: ["main"]
     types: [closed]
 
-# Constrain `pull_request_target` to read-only on contents. The shared
-# CI workflow only builds, tests, and uploads run-scoped artifacts; it
-# does not need write permissions to the repository.
+# Constrain `pull_request_target` to the minimum scopes required.
+# `contents: read` for checkout; `actions: write` for the shared CI
+# workflow's caches (`actions/cache@v4`, `Swatinem/rust-cache@v2`) and
+# artifact upload/download.
 permissions:
   contents: read
+  actions: write
 
 jobs:
   ci:
-    # On `pull_request_target`, only run for merged Dependabot PRs.
-    # Non-merged closes and human merges are no-ops (human merges are
-    # already covered by the `push` event).
-    if: >-
-      github.event_name == 'push' ||
-      (github.event.pull_request.merged == true &&
-       github.event.pull_request.user.login == 'dependabot[bot]')
+    # Skip closed-without-merge; only build the merged commit.
+    if: github.event.pull_request.merged == true
     uses: ./.github/workflows/_shared-ci.yml
 
   coverage-report:


### PR DESCRIPTION
## Summary

- Add a `pull_request_target: closed` trigger (gated to merged Dependabot PRs) to `.github/workflows/post-submit.yml` so post-submit CI runs after Dependabot auto-merges land on `main`.
- Declare an explicit `permissions:` block at workflow scope: `contents: read` for checkout, plus `actions: write` so the shared CI workflow's caches (`actions/cache@v4`, `Swatinem/rust-cache@v2`) and artifact upload/download keep working under the new cache backend. Every unlisted scope is implicitly dropped to `none`, so this is still a tightening relative to the default `pull_request_target` token.

## Root cause

`.github/workflows/dependabot-auto-merge.yml` enables `--auto` on Dependabot PRs using the default `GITHUB_TOKEN`:

```yaml
env:
  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

When required checks pass and GitHub later performs the merge, the resulting commit and `push` event are attributed to that token. GitHub's [automatic token authentication docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) document an anti-loop safeguard: *events triggered by `GITHUB_TOKEN` will not create a new workflow run*.

`post-submit.yml` was triggered exclusively by `push: branches: [main]`, so for auto-merged Dependabot PRs the `push` event was silently dropped and `Post-Submit CI` never ran. Human-driven merges, attributed to a real user, were unaffected - which matches the observation that regular PRs still produced post-submit runs.

## Fix design

Add a second trigger to `post-submit.yml`:

```yaml
on:
  push:
    branches: ["main"]
  pull_request_target:
    branches: ["main"]
    types: [closed]
```

- `push` on `main` keeps covering normal human merges and keeps the resulting workflow run's `head_branch` set to `main`, so downstream `workflow_run` consumers (e.g. `deploy_github_pages.yml`) that filter on `branches: [main]` keep firing.
- `pull_request_target` `closed` fires on the PR's state transition and is observed from the base-branch context (so `actions/checkout@v5` lands on post-merge `main`). It is the only path that runs for Dependabot auto-merges, because the `GITHUB_TOKEN` anti-loop safeguard suppresses the corresponding `push` event.
- The `ci` job is gated so it only runs the `pull_request_target` path for merged Dependabot PRs:

  ```yaml
  if: >-
    github.event_name == 'push' ||
    (github.event.pull_request.merged == true &&
     github.event.pull_request.user.login == 'dependabot[bot]')
  ```

  Human merges keep flowing through the `push` trigger - they are not double-run because the `pull_request_target` close event for them fails the gate. Non-merged closes are also no-ops.
- Both jobs (`ci` and `coverage-report`) pass `ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}` to their checkouts, so the whole workflow consistently operates on the merged commit on `main` rather than the `pull_request_target` default `refs/pull/<n>/merge` (which matters for squash/rebase merges and would otherwise source the local `_coverage_report` action from PR-controlled content).
- Permissions are declared at workflow scope: `contents: read` for checkout and `actions: write` for the shared CI's caches and artifact steps. Everything else (including `pull-requests`, `issues`, etc.) is implicitly `none`, so this is still a tightening relative to the default `pull_request_target` token.

## Why this is safe

- No PR-controlled code is checked out or executed - the workflow always operates on the merged commit on `main` via the explicit `ref` input.
- The gate is on `pull_request.user.login == 'dependabot[bot]'`, which on `pull_request_target` is provided by GitHub (not by the PR author), so it cannot be spoofed by branch or fork content.
- Permissions are tightened, not loosened. The `actions: write` scope is the minimum needed for the shared CI's cache + artifact steps; no new secrets, PATs, or GitHub Apps are introduced.
- No recursion risk: the new trigger reacts to PR closes, not to commits produced by this workflow.

## Test plan

- [ ] Merge this PR via the normal human path and confirm `Post-Submit CI` runs once (push path) and the `pull_request_target` close event is skipped by the `if` gate.
- [ ] Wait for the next Dependabot PR to auto-merge and confirm `Post-Submit CI` runs via the `pull_request_target` close event with the post-merge `main` checked out (both `ci` and `coverage-report` jobs).
- [ ] Confirm pre-submit on this PR still runs unchanged (no edits to `pre-submit.yml` or `dependabot-auto-merge.yml`).
