### PR TITLE
changelog: include `bugfix` entries in generated changelog

### DIFF
--- a/changelogging.toml
+++ b/changelogging.toml
@@ -1,3 +1,5 @@
+order = ["security", "feature", "bugfix", "deprecation", "removal"]
+
 [context]
 name = "csshw"
 version = "0.18.1"

--- a/news/~changelogging-order.bugfix.md
+++ b/news/~changelogging-order.bugfix.md
@@ -1,0 +1,5 @@
+Fixed `changelogging build` silently dropping all `*.bugfix.md` news
+fragments from the generated changelog. The custom `[types]` mapping in
+`changelogging.toml` renamed `fix` to `bugfix`, but the default `order`
+list still referenced `fix`, so bugfix entries were never rendered. An
+explicit top-level `order = [..., "bugfix", ...]` is now configured.


### PR DESCRIPTION
`changelogging build` was silently dropping every `*.bugfix.md` news
fragment from the generated changelog. The custom `[types]` table in
`changelogging.toml` renames the default `fix` key to `bugfix`, but
the default `order` list still references `fix`, so changelogging
never rendered any bugfix entries. The 0.19.0 release notes generated
by this tooling omitted four bugfix fragments (#193, #196, #197,
#210) before the omission was caught in review on #236.

Add an explicit top-level `order = [..., "bugfix", ...]` so the
renamed type is rendered. With this change, `changelogging preview`
emits the expected `### Bug Fixes` section.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
