### PR TITLE
Spawn child consoles via current_exe instead of CARGO_PKG_NAME

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,10 @@ jobs:
           # Create package directory
           mkdir -p package
 
-          # Copy and rename binary
-          cp artifacts/csshw.exe "package/csshw.${VERSION}.exe"
+          # Copy binary. The version is carried by the zip filename below;
+          # the executable inside the archive keeps its plain `csshw.exe`
+          # name so users can drop it straight onto PATH.
+          cp artifacts/csshw.exe package/csshw.exe
 
           # Copy documentation
           cp README.md package/

--- a/news/~spawn-current-exe.bugfix.md
+++ b/news/~spawn-current-exe.bugfix.md
@@ -1,0 +1,6 @@
+Fixed the released 0.19.0 binary panicking with `Failed to create process`
+when launched. The daemon and client child consoles were spawned by the
+hard-coded name `csshw.exe`, but the release workflow packaged the binary
+as `csshw.<version>.exe`, so `CreateProcess` could not find it. Child
+consoles are now spawned via `std::env::current_exe()`, and the release
+workflow keeps the executable inside the archive named `csshw.exe`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,8 +5,8 @@ use crate::daemon::{main as daemon_main, resolve_cluster_tags};
 use crate::utils::config::{ClientConfig, Cluster, Config, ConfigOpt, DaemonConfig};
 use crate::utils::windows::WindowsApi;
 use crate::{
-    get_console_window_handle, init_logger, is_launched_from_gui, spawn_console_process,
-    WindowsSettingsDefaultTerminalApplicationGuard,
+    current_exe_path, get_console_window_handle, init_logger, is_launched_from_gui,
+    spawn_console_process, WindowsSettingsDefaultTerminalApplicationGuard,
 };
 use clap::{ArgAction, CommandFactory, Parser, Subcommand};
 
@@ -313,7 +313,7 @@ impl Entrypoint for MainEntrypoint {
         // reset the configuration before the window was launched
         let _ = get_console_window_handle(
             windows_api,
-            spawn_console_process(windows_api, &format!("{PKG_NAME}.exe"), daemon_args, true)
+            spawn_console_process(windows_api, &current_exe_path(), daemon_args, true)
                 .expect("Failed to create process")
                 .dwProcessId,
         );

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -24,7 +24,7 @@ use crate::utils::config::{Cluster, DaemonConfig, EdgeBehavior};
 use crate::utils::debug::StringRepr;
 use crate::utils::windows::{clear_screen, set_console_color, WindowsApi};
 use crate::{
-    spawn_console_process,
+    current_exe_path, spawn_console_process,
     utils::{
         constants::{PIPE_NAME, PKG_NAME},
         windows::{
@@ -1533,9 +1533,8 @@ fn launch_client_console<W: WindowsApi>(
     client_args.push("client".to_string());
     client_args.extend(vec!["--".to_string(), actual_host.to_string()]);
 
-    let process_info =
-        spawn_console_process(windows_api, &format!("{PKG_NAME}.exe"), client_args, false)
-            .expect("Failed to create process");
+    let process_info = spawn_console_process(windows_api, &current_exe_path(), client_args, false)
+        .expect("Failed to create process");
     let client_window_handle = get_console_window_handle(windows_api, process_info.dwProcessId);
     let process_handle = windows_api
         .open_process(PROCESS_QUERY_INFORMATION.0, false, process_info.dwProcessId)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,30 @@ pub fn spawn_console_process<W: WindowsApi>(
     return api.create_process_with_args(application, args, with_keyboard_focus);
 }
 
+/// Return the path to the currently running executable.
+///
+/// Used when spawning child daemon/client consoles so that they invoke the same
+/// binary that is currently running, regardless of how the user has named the
+/// executable on disk. Hard-coding `csshw.exe` would break any deployment that
+/// renames the binary (e.g. release artifacts that embed the version number).
+///
+/// # Returns
+///
+/// The current executable path as a UTF-8 string. The conversion is lossy if
+/// the path contains non-UTF-8 code units.
+///
+/// # Panics
+///
+/// Panics if `std::env::current_exe()` fails. The standard library only
+/// returns an error in highly unusual circumstances (e.g. the executable has
+/// been deleted while running); the caller cannot meaningfully recover.
+pub fn current_exe_path() -> String {
+    return std::env::current_exe()
+        .expect("Failed to determine current executable path")
+        .to_string_lossy()
+        .into_owned();
+}
+
 /// Initialize the logger.
 ///
 /// Makes sure a `logs` directory exists in the current working directory.

--- a/src/tests/test_cli.rs
+++ b/src/tests/test_cli.rs
@@ -358,7 +358,7 @@ mod cli_main_test {
                     mock_windows_api
                         .expect_create_process_with_args()
                         .with(
-                            mockall::predicate::eq("csshw.exe"),
+                            mockall::predicate::eq(crate::current_exe_path()),
                             mockall::predicate::eq(vec![
                                 "daemon".to_string(),
                                 "host1".to_string(),
@@ -1355,7 +1355,7 @@ mod main_entrypoint_test {
         mock_windows_api
             .expect_create_process_with_args()
             .with(
-                eq("csshw.exe"),
+                eq(crate::current_exe_path()),
                 eq(vec![
                     "daemon".to_string(),
                     "host1".to_string(),
@@ -1421,7 +1421,7 @@ mod main_entrypoint_test {
         mock_windows_api
             .expect_create_process_with_args()
             .with(
-                eq("csshw.exe"),
+                eq(crate::current_exe_path()),
                 eq(vec![
                     "-d".to_string(),
                     "daemon".to_string(),
@@ -1487,7 +1487,7 @@ mod main_entrypoint_test {
         mock_windows_api
             .expect_create_process_with_args()
             .with(
-                eq("csshw.exe"),
+                eq(crate::current_exe_path()),
                 eq(vec![
                     "-u".to_string(),
                     "testuser".to_string(),
@@ -1557,7 +1557,7 @@ mod main_entrypoint_test {
         mock_windows_api
             .expect_create_process_with_args()
             .with(
-                eq("csshw.exe"),
+                eq(crate::current_exe_path()),
                 eq(vec![
                     "-d".to_string(),
                     "-u".to_string(),
@@ -1629,7 +1629,7 @@ mod main_entrypoint_test {
         let mut mock_windows_api = mock_windows_api;
         mock_windows_api
             .expect_create_process_with_args()
-            .with(eq("csshw.exe"), eq(vec!["daemon".to_string()]), eq(true))
+            .with(eq(crate::current_exe_path()), eq(vec!["daemon".to_string()]), eq(true))
             .times(1)
             .returning(|_, _, _| {
                 return Some(PROCESS_INFORMATION {
@@ -1727,7 +1727,7 @@ mod main_entrypoint_test {
         mock_windows_api
             .expect_create_process_with_args()
             .with(
-                eq("csshw.exe"),
+                eq(crate::current_exe_path()),
                 eq(vec!["daemon".to_string(), "host1".to_string()]),
                 eq(true),
             )


### PR DESCRIPTION
## Summary

- Released `csshw 0.19.0` was unusable: `Failed to create process` panic on startup. The daemon/client spawn calls passed the hard-coded name `csshw.exe`, but the release workflow packaged the binary as `csshw.<version>.exe`, so `CreateProcess` could not find it.
- `current_exe_path()` is added to the library; the two spawn sites in `cli.rs` and `daemon/mod.rs` now invoke the running binary by its actual path, so any rename (the version-stamped release artifact, or a user-renamed copy) works.
- `release.yml` also stops renaming the exe inside the zip - the version stays in the archive filename only. With both fixes either change alone would unblock the user; together they are belt-and-braces.
- `PKG_NAME` is kept for brand-string uses (window titles, `csshw-config.toml`, the named-pipe contract, clap's `argv[0]`). Those intentionally do not follow the binary's on-disk name.

## Test plan

- [x] `cargo fmt`
- [x] `cargo lint` (clippy clean)
- [x] `cargo test` - 212 tests pass (existing `MainEntrypoint` tests updated to match `current_exe_path()` instead of `"csshw.exe"`)
- [x] `cargo doc-tests`
- [x] `cargo xtask check-typography`
- [x] Reproduced original failure with `csshw.0.19.0.exe` from the release zip - `Failed to create process` panic
- [x] Built locally, copied to `csshw.0.19.1-test.exe`, `--version` still works (full SSH spawn not exercised locally - merge + patch release will validate end-to-end)
- [ ] Merge to `0.19-maintenance`, cut 0.19.1, confirm renamed and unrenamed binaries both run

Once merged here and a patch release is cut, the fix + release-workflow change will be picked across to `main`.

GitHub: (none - direct PR)

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>