### PR TITLE
ci: extend quality gates to *-maintenance branches

### DIFF
--- a/.github/workflows/news-fragment-check.yml
+++ b/.github/workflows/news-fragment-check.yml
@@ -9,7 +9,9 @@ name: News Fragment Check
 on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
-    branches: [main]
+    branches:
+      - main
+      - "*-maintenance"
 
 env:
   OVERRIDE_LABEL: "no-news-fragment-needed"
@@ -30,8 +32,9 @@ jobs:
         run: |
           echo "🔍 Checking for news fragments in PR..."
 
-          # Check if PR adds any news fragments
-          FRAGMENTS=$(git diff --name-only --diff-filter=A origin/main...HEAD | \
+          # Check if PR adds any news fragments. Diff against the PR's
+          # actual base so this works for both `main` and `*-maintenance`.
+          FRAGMENTS=$(git diff --name-only --diff-filter=A "origin/${{ github.base_ref }}...HEAD" | \
             grep -E '${{ env.NEWS_FRAGMENT_PATTERN }}' || true)
 
           if [ -n "$FRAGMENTS" ]; then

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -27,9 +27,13 @@ name: Post-Submit CI
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - "main"
+      - "*-maintenance"
   pull_request_target:
-    branches: ["main"]
+    branches:
+      - "main"
+      - "*-maintenance"
     types: [closed]
 
 # Constrain `pull_request_target` to the minimum scopes required.

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -1,15 +1,16 @@
 #
 #   csshw Post-Submit CI
 #
-# Runs on the main branch after merges with full coverage collection.
-# For pull requests, see pre-submit.yml which includes coverage reporting.
-# Uses the shared CI workflow.
+# Runs on `main` and `*-maintenance` branches after merges with full
+# coverage collection. For pull requests, see pre-submit.yml which
+# includes coverage reporting. Uses the shared CI workflow.
 #
 # Trigger model:
-#   - `push` to `main` covers normal human-driven merges. The resulting
-#     workflow run carries `main` as its head_branch, so downstream
-#     `workflow_run` consumers (see `deploy_github_pages.yml`) that
-#     filter on `branches: [main]` keep firing.
+#   - `push` to `main` or a `*-maintenance` branch covers normal
+#     human-driven merges. The resulting workflow run carries the
+#     pushed branch as its head_branch, so downstream `workflow_run`
+#     consumers (see `deploy_github_pages.yml`) that filter on
+#     `branches: [main]` keep firing for `main` merges.
 #   - `pull_request_target` `closed` covers Dependabot auto-merges. The
 #     auto-merge workflow enables `--auto` with the default
 #     `GITHUB_TOKEN`; per GitHub's anti-loop safeguard for
@@ -56,10 +57,11 @@ jobs:
     with:
       # On `pull_request_target`, default checkout would resolve to
       # `refs/pull/<n>/merge` (a synthetic merge ref) rather than the
-      # commit that actually landed on `main`. Pass `merge_commit_sha`
-      # so the build runs against the merged commit (matters for
-      # squash/rebase merges). Falls through to `github.sha` on `push`,
-      # which is already the merged commit on `main`.
+      # commit that actually landed on the target branch. Pass
+      # `merge_commit_sha` so the build runs against the merged commit
+      # (matters for squash/rebase merges). Falls through to
+      # `github.sha` on `push`, which is already the merged commit on
+      # the pushed branch.
       ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
   coverage-report:
@@ -68,9 +70,9 @@ jobs:
     steps:
       # Mirror the `ci` job's checkout ref so the local
       # `./.github/workflows/_coverage_report` action is loaded from the
-      # merged commit on `main`, not the `pull_request_target` default
-      # `refs/pull/<n>/merge` (which would source the action from
-      # PR-controlled content).
+      # merged commit on the target branch, not the
+      # `pull_request_target` default `refs/pull/<n>/merge` (which would
+      # source the action from PR-controlled content).
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}

--- a/.github/workflows/pre-submit.yml
+++ b/.github/workflows/pre-submit.yml
@@ -8,7 +8,9 @@ name: Pre-Submit CI
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "*-maintenance"
 
 jobs:
   detect-changes:


### PR DESCRIPTION
Releases are cut from `*-maintenance` branches (see
`xtask/src/release.rs`), so PRs landing there need the same CI
gates as PRs into `main`. Previously only pre-submit, post-submit,
and the news-fragment check ran for PRs/pushes targeting `main`,
leaving maintenance branches without gating.

With this change:

- `pre-submit.yml`, `post-submit.yml`, and `news-fragment-check.yml`
  also trigger on `*-maintenance`.
- `news-fragment-check.yml` diffs against `origin/${{ github.base_ref }}`
  instead of a hard-coded `origin/main`, so the fragment detection
  works correctly when the PR base is a maintenance branch.

`deploy_github_pages.yml` and `dependabot-auto-merge.yml` remain
`main`-only on purpose: the published docs/coverage site should
reflect `main`, and Dependabot only targets `main`. Note that
branch protection rules (required status checks) are configured
in the GitHub UI per branch and must be applied to
`*-maintenance` separately for these checks to be enforced.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
