### PR TITLE
docs: document SmartScreen first-launch warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,12 @@ csshW is a portable application and is not installed.<br>
 To download the csshW application refer to the [Releases 📦](https://github.com/whme/csshw/releases) page.
 
 > [!NOTE]
-> The released `csshw.exe` is not code-signed - the code-signing
-> certificate that would suppress SmartScreen costs money and we do
-> not have one. On first launch Windows SmartScreen shows a "Windows
-> protected your PC" warning because the binary was downloaded from
-> the internet and has no recognized publisher. To run it: click
-> `More info` -> `Run anyway`, or right-click `csshw.exe` ->
-> `Properties` -> tick `Unblock` -> `Apply`. Equivalent from
-> PowerShell: `Unblock-File .\csshw.exe`.
+> The released `csshw.exe` is not code-signed. On first launch Windows
+> SmartScreen shows a "Windows protected your PC" warning because the
+> binary was downloaded from the internet and has no recognized
+> publisher. To run it: click `More info` -> `Run anyway`, or
+> right-click `csshw.exe` -> `Properties` -> tick `Unblock` ->
+> `Apply`. Equivalent from PowerShell: `Unblock-File .\csshw.exe`.
 >
 > The release `.zip` itself (0.19.0 and later) is signed with a
 > [GitHub build attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds);

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To download the csshW application refer to the [Releases 📦](https://github.co
 > [GitHub build attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds);
 > see the release notes for verification instructions. Verifying it
 > proves the archive came from this project's release workflow at the
-> tagged commit, but does not change SmartScreen's behaviour for the
+> tagged commit, but does not change SmartScreen's behavior for the
 > unsigned `.exe` inside.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Focussing a client will cause any key-strokes to be sent to this client only.
 csshW is a portable application and is not installed.<br>
 To download the csshW application refer to the [Releases 📦](https://github.com/whme/csshw/releases) page.
 
+> [!NOTE]
+> The released `csshw.exe` is not code-signed. On first launch Windows
+> SmartScreen shows a "Windows protected your PC" warning because the
+> binary was downloaded from the internet and has no recognized publisher.
+> To run it: click `More info` -> `Run anyway`, or right-click
+> `csshw.exe` -> `Properties` -> tick `Unblock` -> `Apply`. Equivalent
+> from PowerShell: `Unblock-File .\csshw.exe`.
+
 ## Usage
 
 <!-- HELP_OUTPUT_START -->

--- a/README.md
+++ b/README.md
@@ -25,12 +25,21 @@ csshW is a portable application and is not installed.<br>
 To download the csshW application refer to the [Releases 📦](https://github.com/whme/csshw/releases) page.
 
 > [!NOTE]
-> The released `csshw.exe` is not code-signed. On first launch Windows
-> SmartScreen shows a "Windows protected your PC" warning because the
-> binary was downloaded from the internet and has no recognized publisher.
-> To run it: click `More info` -> `Run anyway`, or right-click
-> `csshw.exe` -> `Properties` -> tick `Unblock` -> `Apply`. Equivalent
-> from PowerShell: `Unblock-File .\csshw.exe`.
+> The released `csshw.exe` is not code-signed - the code-signing
+> certificate that would suppress SmartScreen costs money and we do
+> not have one. On first launch Windows SmartScreen shows a "Windows
+> protected your PC" warning because the binary was downloaded from
+> the internet and has no recognized publisher. To run it: click
+> `More info` -> `Run anyway`, or right-click `csshw.exe` ->
+> `Properties` -> tick `Unblock` -> `Apply`. Equivalent from
+> PowerShell: `Unblock-File .\csshw.exe`.
+>
+> The release `.zip` itself (0.19.0 and later) is signed with a
+> [GitHub build attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds);
+> see the release notes for verification instructions. Verifying it
+> proves the archive came from this project's release workflow at the
+> tagged commit, but does not change SmartScreen's behaviour for the
+> unsigned `.exe` inside.
 
 ## Usage
 

--- a/templates/release_template.md
+++ b/templates/release_template.md
@@ -9,4 +9,12 @@
 csshW is a portable application and is not installed.
 Just download the `.zip` archive, extract it and run `csshw.exe`
 
+> [!NOTE]
+> `csshw.exe` is not code-signed. On first launch Windows SmartScreen
+> shows a "Windows protected your PC" warning because the binary was
+> downloaded from the internet and has no recognized publisher.
+> To run it: click `More info` -> `Run anyway`, or right-click
+> `csshw.exe` -> `Properties` -> tick `Unblock` -> `Apply`. Equivalent
+> from PowerShell: `Unblock-File .\csshw.exe`.
+
 # <a href="https://github.com/whme/csshw/releases/download/{{VERSION}}/csshw.{{VERSION}}.zip"><img src="https://raw.githubusercontent.com/whme/csshw/refs/heads/main/res/csshw.svg" width="20" alt="csshW Logo"></img> csshw.{{VERSION}}.zip</a> [![Downloads](https://img.shields.io/github/downloads/whme/csshw/{{VERSION}}/total?label=downloads)](https://github.com/whme/csshw/releases/download/{{VERSION}}/csshw.{{VERSION}}.zip)

--- a/templates/release_template.md
+++ b/templates/release_template.md
@@ -10,11 +10,28 @@ csshW is a portable application and is not installed.
 Just download the `.zip` archive, extract it and run `csshw.exe`
 
 > [!NOTE]
-> `csshw.exe` is not code-signed. On first launch Windows SmartScreen
-> shows a "Windows protected your PC" warning because the binary was
-> downloaded from the internet and has no recognized publisher.
-> To run it: click `More info` -> `Run anyway`, or right-click
-> `csshw.exe` -> `Properties` -> tick `Unblock` -> `Apply`. Equivalent
-> from PowerShell: `Unblock-File .\csshw.exe`.
+> `csshw.exe` is not code-signed - the code-signing certificate that
+> would suppress SmartScreen costs money and we do not have one. On
+> first launch Windows SmartScreen shows a "Windows protected your PC"
+> warning because the binary was downloaded from the internet and has
+> no recognized publisher. To run it: click `More info` -> `Run anyway`,
+> or right-click `csshw.exe` -> `Properties` -> tick `Unblock` ->
+> `Apply`. Equivalent from PowerShell: `Unblock-File .\csshw.exe`.
+
+### Verifying the download
+Starting with 0.19.0 the release `.zip` is signed with a [GitHub build
+attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+produced by this repository's release workflow. Verifying the
+attestation cryptographically proves that the archive came from the
+`whme/csshw` release workflow at the tagged commit - i.e. the `.zip`
+you have is byte-for-byte the one GitHub built for this release and
+was not modified or repackaged after upload.
+
+Verify it with the [GitHub CLI](https://cli.github.com/):
+```sh
+gh attestation verify csshw.{{VERSION}}.zip --repo whme/csshw
+```
+Note that this verifies the `.zip` only; the `csshw.exe` inside it is
+still unsigned, so the SmartScreen warning above still applies.
 
 # <a href="https://github.com/whme/csshw/releases/download/{{VERSION}}/csshw.{{VERSION}}.zip"><img src="https://raw.githubusercontent.com/whme/csshw/refs/heads/main/res/csshw.svg" width="20" alt="csshW Logo"></img> csshw.{{VERSION}}.zip</a> [![Downloads](https://img.shields.io/github/downloads/whme/csshw/{{VERSION}}/total?label=downloads)](https://github.com/whme/csshw/releases/download/{{VERSION}}/csshw.{{VERSION}}.zip)

--- a/templates/release_template.md
+++ b/templates/release_template.md
@@ -10,13 +10,14 @@ csshW is a portable application and is not installed.
 Just download the `.zip` archive, extract it and run `csshw.exe`
 
 > [!NOTE]
-> `csshw.exe` is not code-signed - the code-signing certificate that
-> would suppress SmartScreen costs money and we do not have one. On
-> first launch Windows SmartScreen shows a "Windows protected your PC"
-> warning because the binary was downloaded from the internet and has
-> no recognized publisher. To run it: click `More info` -> `Run anyway`,
-> or right-click `csshw.exe` -> `Properties` -> tick `Unblock` ->
-> `Apply`. Equivalent from PowerShell: `Unblock-File .\csshw.exe`.
+> `csshw.exe` is not code-signed. On first launch Windows SmartScreen
+> shows a "Windows protected your PC" warning because the binary was
+> downloaded from the internet and has no recognized publisher. To run
+> it: click `More info` -> `Run anyway`, or right-click `csshw.exe` ->
+> `Properties` -> tick `Unblock` -> `Apply`. Equivalent from
+> PowerShell: `Unblock-File .\csshw.exe`.
+
+# <a href="https://github.com/whme/csshw/releases/download/{{VERSION}}/csshw.{{VERSION}}.zip"><img src="https://raw.githubusercontent.com/whme/csshw/refs/heads/main/res/csshw.svg" width="20" alt="csshW Logo"></img> csshw.{{VERSION}}.zip</a> [![Downloads](https://img.shields.io/github/downloads/whme/csshw/{{VERSION}}/total?label=downloads)](https://github.com/whme/csshw/releases/download/{{VERSION}}/csshw.{{VERSION}}.zip)
 
 ### Verifying the download
 Starting with 0.19.0 the release `.zip` is signed with a [GitHub build
@@ -33,5 +34,3 @@ gh attestation verify csshw.{{VERSION}}.zip --repo whme/csshw
 ```
 Note that this verifies the `.zip` only; the `csshw.exe` inside it is
 still unsigned, so the SmartScreen warning above still applies.
-
-# <a href="https://github.com/whme/csshw/releases/download/{{VERSION}}/csshw.{{VERSION}}.zip"><img src="https://raw.githubusercontent.com/whme/csshw/refs/heads/main/res/csshw.svg" width="20" alt="csshW Logo"></img> csshw.{{VERSION}}.zip</a> [![Downloads](https://img.shields.io/github/downloads/whme/csshw/{{VERSION}}/total?label=downloads)](https://github.com/whme/csshw/releases/download/{{VERSION}}/csshw.{{VERSION}}.zip)


### PR DESCRIPTION
The released `csshw.exe` is not code-signed, so Windows SmartScreen
shows a "Windows protected your PC" warning on first launch. Until
the binary is signed, document the warning and the bypass options
(More info -> Run anyway, Properties -> Unblock, or
`Unblock-File`) so users hitting it know what to do.

Add the note to both the README and the release template so it
appears on the GitHub release page next to the download link, which
is where most users first encounter the issue.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
