### PR TITLE
ci: preserve *-maintenance branches when merging PRs

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -2,10 +2,11 @@
 #   Delete Merged Branches
 #
 # Deletes the head branch of a merged pull request, except for branches
-# matching `*-maintenance`. This replaces GitHub's repo-wide
+# matching `<major>.<minor>-maintenance` (1-3 digit version components,
+# e.g. `0.19-maintenance`). This replaces GitHub's repo-wide
 # "Automatically delete head branches" setting, which cannot exclude
-# long-lived release branches like `0.19-maintenance` that we cherry-pick
-# fixes onto and keep around.
+# long-lived release branches that we cherry-pick fixes onto and keep
+# around.
 #
 # Repo setting "Automatically delete head branches" must be DISABLED for
 # this workflow to be the single source of truth; otherwise the setting

--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -1,0 +1,62 @@
+#
+#   Delete Merged Branches
+#
+# Deletes the head branch of a merged pull request, except for branches
+# matching `*-maintenance`. This replaces GitHub's repo-wide
+# "Automatically delete head branches" setting, which cannot exclude
+# long-lived release branches like `0.19-maintenance` that we cherry-pick
+# fixes onto and keep around.
+#
+# Repo setting "Automatically delete head branches" must be DISABLED for
+# this workflow to be the single source of truth; otherwise the setting
+# wins for non-maintenance branches and races this workflow.
+#
+# Guards:
+#   - PR must be merged (not just closed)
+#   - head and base repo must be the same (skip cross-repo forks; GitHub
+#     cannot delete fork branches anyway)
+#   - head branch must not match `*-maintenance`
+#
+# The delete call is tolerant: if the branch is already gone (manual
+# delete, or another workflow beat us to it) the job still succeeds.
+
+name: Delete Merged Branches
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-branch:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
+      !endsWith(github.event.pull_request.head.ref, '-maintenance')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set +e
+          output=$(gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -eq 0 ]; then
+            echo "::notice::Deleted head branch $BRANCH."
+            exit 0
+          fi
+          # 422 "Reference does not exist" means the branch is already
+          # gone - treat as success so re-runs and races stay green.
+          if printf '%s' "$output" | grep -qiE 'reference does not exist|not found'; then
+            echo "::notice::Head branch $BRANCH was already deleted."
+            exit 0
+          fi
+          echo "::error::Failed to delete head branch $BRANCH - see log above."
+          exit 1

--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -15,7 +15,9 @@
 #   - PR must be merged (not just closed)
 #   - head and base repo must be the same (skip cross-repo forks; GitHub
 #     cannot delete fork branches anyway)
-#   - head branch must not match `*-maintenance`
+#   - head branch must not match `<major>.<minor>-maintenance` (e.g.
+#     `0.19-maintenance`), the only naming convention we use for
+#     long-lived release branches
 #
 # The delete call is tolerant: if the branch is already gone (manual
 # delete, or another workflow beat us to it) the job still succeeds.
@@ -33,8 +35,7 @@ jobs:
   delete-branch:
     if: >-
       github.event.pull_request.merged == true &&
-      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
-      !endsWith(github.event.pull_request.head.ref, '-maintenance')
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - name: Delete head branch
@@ -43,6 +44,14 @@ jobs:
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
+          # Maintenance branches use `<major>.<minor>-maintenance` with
+          # 1-3 digit version components (e.g. `0.19-maintenance`). GitHub
+          # Actions expressions cannot express this, so the precise check
+          # lives here instead of in the job-level `if:`.
+          if [[ "$BRANCH" =~ ^[0-9]{1,3}\.[0-9]{1,3}-maintenance$ ]]; then
+            echo "::notice::Preserving maintenance branch $BRANCH."
+            exit 0
+          fi
           set +e
           output=$(gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" 2>&1)
           status=$?
@@ -52,9 +61,12 @@ jobs:
             echo "::notice::Deleted head branch $BRANCH."
             exit 0
           fi
-          # 422 "Reference does not exist" means the branch is already
-          # gone - treat as success so re-runs and races stay green.
-          if printf '%s' "$output" | grep -qiE 'reference does not exist|not found'; then
+          # GitHub returns HTTP 422 "Reference does not exist" when the
+          # branch is already gone - treat that exact response as success
+          # so re-runs and races stay green. Other failures (404 from a
+          # wrong repo/permission, 5xx, etc.) must still fail the job.
+          if printf '%s' "$output" | grep -q 'HTTP 422' \
+            && printf '%s' "$output" | grep -qi 'Reference does not exist'; then
             echo "::notice::Head branch $BRANCH was already deleted."
             exit 0
           fi


### PR DESCRIPTION
## Summary

- Replaces GitHub's repo-wide ``Automatically delete head branches`` setting with a workflow that skips ``<major>.<minor>-maintenance`` branches (1-3 digit version components, e.g. ``0.19-maintenance``), so long-lived release branches are not deleted when a cherry-pick PR merges into ``main``.
- Runs on ``pull_request_target: closed``, only when ``merged == true`` and the head and base repo match (forks are skipped since GitHub cannot delete branches in a fork's repo).
- Treats ``422 Reference does not exist`` as success so re-runs and races with manual deletes stay green; persistent failures surface as a red job.

> [!IMPORTANT]
> The repo setting **Settings -> General -> Automatically delete head branches** must be **disabled** for this workflow to be the single source of truth. Otherwise the setting wins for non-maintenance branches and races this workflow.

## Test plan

- [ ] Disable the repo-wide ``Automatically delete head branches`` setting before merging this PR.
- [ ] Merge this PR with a non-maintenance head branch (``ci/preserve-maintenance-branches-on-merge``) and confirm the workflow runs and the branch is deleted afterwards.
- [ ] Land the next ``0.19-maintenance`` -> ``main`` cherry-pick PR and confirm ``0.19-maintenance`` is still present after merge.
- [ ] Confirm that a re-run (or manual delete + workflow re-run) does not fail the job.