### PR TITLE
ci: fix post-submit CI not firing on Dependabot auto-merges

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,8 +25,8 @@
 # `workflow_dispatch` and `repository_dispatch`), so a merge attributed
 # to it would never fire Post-Submit CI on `main`. The PAT carries a
 # distinct identity, so the merge's `push` event triggers post-submit
-# normally. The PAT needs `contents: write` and `pull-requests: write`
-# on this repository (fine-grained, repo-scoped).
+# normally. The PAT needs `contents: write`, `pull-requests: write`,
+# and `workflows: write` on this repository (fine-grained, repo-scoped).
 #
 # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
 #

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,6 +19,17 @@
 # only get a read-only token. Because no PR-controlled code is checked
 # out or executed, this trigger is safe here.
 #
+# Auto-merge is enabled with a personal access token (`AUTOMERGE_TOKEN`)
+# rather than the default `GITHUB_TOKEN`. GitHub suppresses workflow runs
+# for events triggered by the `GITHUB_TOKEN` (the only exceptions are
+# `workflow_dispatch` and `repository_dispatch`), so a merge attributed
+# to it would never fire Post-Submit CI on `main`. The PAT carries a
+# distinct identity, so the merge's `push` event triggers post-submit
+# normally. The PAT needs `contents: write` and `pull-requests: write`
+# on this repository (fine-grained, repo-scoped).
+#
+# See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+#
 # There is no race against CI: `--auto` only flips the auto-merge flag,
 # and GitHub then waits for the branch's required status checks before
 # performing the merge. Re-running on a PR that already has auto-merge
@@ -54,7 +65,7 @@ jobs:
     steps:
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           set +e

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -5,22 +5,15 @@
 # coverage collection. For pull requests, see pre-submit.yml which
 # includes coverage reporting. Uses the shared CI workflow.
 #
-# Trigger model:
-#   - `push` to `main` or a `*-maintenance` branch covers normal
-#     human-driven merges. The resulting workflow run carries the
-#     pushed branch as its head_branch, so downstream `workflow_run`
-#     consumers (see `deploy_github_pages.yml`) that filter on
-#     `branches: [main]` keep firing for `main` merges.
-#   - `pull_request_target` `closed` covers Dependabot auto-merges. The
-#     auto-merge workflow enables `--auto` with the default
-#     `GITHUB_TOKEN`; per GitHub's anti-loop safeguard for
-#     `GITHUB_TOKEN`-attributed actions, the resulting `push` event is
-#     suppressed from triggering further workflow runs, so this path
-#     would otherwise never run post-submit CI for Dependabot merges.
-#     `pull_request_target` is observed on state transition and is not
-#     subject to that safeguard. It is gated to merged Dependabot PRs
-#     to avoid duplicate runs on human merges (which take the `push`
-#     path).
+# Triggered by the `push` that lands on the target branch. This covers
+# both human merges and Dependabot auto-merges: the auto-merge workflow
+# enables `--auto` with a personal access token (not the default
+# `GITHUB_TOKEN`), so GitHub's anti-loop safeguard - which suppresses
+# workflow runs for `GITHUB_TOKEN`-attributed events - does not apply and
+# the merge's `push` fires normally. The run carries the pushed branch as
+# its head_branch, so downstream `workflow_run` consumers (see
+# `deploy_github_pages.yml`) that filter on `branches: [main]` keep firing
+# for `main` merges.
 #
 # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
 
@@ -31,51 +24,27 @@ on:
     branches:
       - "main"
       - "*-maintenance"
-  pull_request_target:
-    branches:
-      - "main"
-      - "*-maintenance"
-    types: [closed]
 
-# Constrain `pull_request_target` to the minimum scopes required.
-# `contents: read` for checkout; `actions: write` for the shared CI
-# workflow's caches (`actions/cache@v4`, `Swatinem/rust-cache@v2`) and
-# artifact upload/download.
 permissions:
   contents: read
+  # `actions: write` for the shared CI workflow's caches
+  # (`actions/cache@v4`, `Swatinem/rust-cache@v2`) and artifact
+  # upload/download.
   actions: write
 
 jobs:
   ci:
-    # `push` runs unconditionally; `pull_request_target` runs only for
-    # merged Dependabot PRs (human merges are already covered by `push`).
-    if: >-
-      github.event_name == 'push' ||
-      (github.event.pull_request.merged == true &&
-       github.event.pull_request.user.login == 'dependabot[bot]')
     uses: ./.github/workflows/_shared-ci.yml
     with:
-      # On `pull_request_target`, default checkout would resolve to
-      # `refs/pull/<n>/merge` (a synthetic merge ref) rather than the
-      # commit that actually landed on the target branch. Pass
-      # `merge_commit_sha` so the build runs against the merged commit
-      # (matters for squash/rebase merges). Falls through to
-      # `github.sha` on `push`, which is already the merged commit on
-      # the pushed branch.
-      ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      ref: ${{ github.sha }}
 
   coverage-report:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      # Mirror the `ci` job's checkout ref so the local
-      # `./.github/workflows/_coverage_report` action is loaded from the
-      # merged commit on the target branch, not the
-      # `pull_request_target` default `refs/pull/<n>/merge` (which would
-      # source the action from PR-controlled content).
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.sha }}
 
       - name: Download Coverage XML Data
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

Post-submit CI never ran for Dependabot auto-merges. Both triggers relied on an event GitHub refuses to emit:

- The auto-merge workflow enabled `--auto` with the default `GITHUB_TOKEN`, and GitHub's anti-loop safeguard suppresses workflow runs for **every** event attributed to that token (only exceptions: `workflow_dispatch`, `repository_dispatch`) - so neither the `push` to `main` nor the `pull_request_target: closed` fallback ever fired.

## Changes

- **`dependabot-auto-merge.yml`**: enable auto-merge with a personal access token (`AUTOMERGE_TOKEN`) instead of `GITHUB_TOKEN`, so the merge carries a distinct identity and the resulting `push` triggers post-submit.
- **`post-submit.yml`**: drop the dead `pull_request_target: closed` trigger and its checkout/`if` plumbing; simplify back to a plain `push` workflow.

## Prerequisite

Repo secret `AUTOMERGE_TOKEN` (fine-grained PAT, repo-scoped, Contents + Pull requests = write) must exist. Added.

## Test plan

- [ ] Pre-submit passes on this PR.
- [ ] Merging this PR (human merge) fires a `push`-event Post-Submit CI run on `main`.
- [ ] The next Dependabot auto-merge fires a `push`-event Post-Submit CI run on `main` (the PAT path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)