### PR TITLE
docs: list Visual C++ Redistributable as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 ## Pre-requisite
 - Any SSH client (Windows 10 and Windows 11 already include a built-in SSH server and client - [docs](https://learn.microsoft.com/en-us/windows/terminal/tutorials/ssh))
+- Microsoft Visual C++ Redistributable (required if launching `csshw.exe` fails with a `VCRUNTIME140.dll was not found` error) - [download](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
 
 ## Overview
 csshW will launch 1 daemon and N client windows (with N being the number of hosts to SSH onto).<br>

--- a/templates/release_template.md
+++ b/templates/release_template.md
@@ -4,6 +4,7 @@
 
 ## Pre-requisite
 - Any SSH client (Windows 10 and Windows 11 already include a built-in SSH server and client - [docs](https://learn.microsoft.com/en-us/windows/terminal/tutorials/ssh))
+- Microsoft Visual C++ Redistributable (required if launching `csshw.exe` fails with a `VCRUNTIME140.dll was not found` error) - [download](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
 
 ## Download/Installation
 csshW is a portable application and is not installed.


### PR DESCRIPTION
Launching csshw.exe on a Windows host that has never had Microsoft
Visual C++ Redistributable installed fails with
"VCRUNTIME140.dll was not found", because the MSVC build links the
runtime dynamically. Until the binary is changed to link the runtime
statically, document the dependency in both the README and the
release template so users hitting this can resolve it themselves.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
